### PR TITLE
fix: remove registry-url from setup-node for provenance publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
Fix NPM authentication failure in the release workflow that occurred after enabling provenance publishing.

## Problem
The previous PR enabled provenance publishing but the release workflow was still failing with:
```
npm ERR! code E401
npm ERR! 401 Unauthorized - GET https://registry.npmjs.org/-/whoami
```

## Root Cause
The `registry-url: 'https://registry.npmjs.org'` configuration in `setup-node` was causing it to expect `NPM_TOKEN` authentication, but provenance publishing should use GitHub OIDC tokens instead.

## Solution
- Remove `registry-url` from the `setup-node` configuration in the release job
- Keep `registry-url` in the test job (where it's not needed for publishing)
- Allow `@semantic-release/npm` with `provenance: true` to handle authentication using OIDC

## Test Plan
- [x] All tests pass (128/128 tests)
- [x] Pre-commit and pre-push hooks pass
- [x] Semantic release configuration loads without npm plugin errors locally
- [ ] Release workflow should now succeed with provenance publishing

## References
- Failed workflow run: https://github.com/Doist/twist-cli/actions/runs/21259057772/job/61181653354
- Created issue: https://github.com/Doist/twist-cli/issues/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)