### PR TITLE
ci: Correct lint/test workflow triggers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,7 @@
 name: Lint
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 name: Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
Since semantic release does its own lint/test checks, we don't need them running separately on main.

Also, we don't want them to only run on PRs that have `main` as the base branch, we want them to run on all PRs. 