### PR TITLE
fix: use Node 22 for release job to satisfy semantic-release v25 requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: '.nvmrc'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Fix Node version requirement error in release workflow for semantic-release v25.

## Problem
Semantic-release v25 requires Node.js ^22.14.0 || >= 24.10.0 but the release workflow was using Node 20, causing this error:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.6.
```

## Solution
- **Release job**: Updated to use Node 22 to satisfy semantic-release v25 requirements
- **Test job**: Still uses Node 20 (via .nvmrc) to ensure compatibility
- **package.json engines**: Remains `"node": ">=20"` so users can still use Node 20

This follows the pattern where CI tools can use newer Node versions than what we require from users.

## Test Plan
- [x] All tests pass on Node 20 (128/128 tests)  
- [x] Pre-commit and pre-push hooks pass
- [ ] Release workflow should now succeed with Node 22

## Fixes
- Resolves Node version error: https://github.com/Doist/twist-cli/actions/runs/21261074822/job/61188484190

🤖 Generated with [Claude Code](https://claude.com/claude-code)