### PR TITLE
docs: update Twist API token setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,10 @@ This makes the `tw` command available globally.
 
 ## Setup
 
-Save your Twist API token:
+Set up your Twist API token:
 
 ```bash
-tw login token "your-token"
-```
-
-Alternatively, set via environment variable:
-
-```bash
-export TWIST_API_TOKEN="your-token"
+tw auth login
 ```
 
 ## Usage


### PR DESCRIPTION
- previous API setup instructions were not current