### PR TITLE
fix: Ensure that client registration provides a logo

### DIFF
--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -45,6 +45,7 @@ export async function registerDynamicClient(): Promise<OAuthClient> {
         response_types: ['code'],
         token_endpoint_auth_method: 'client_secret_basic', // Use Basic auth for token exchange
         application_type: 'native', // CLI is a native application
+        logo_uri: 'https://todoist.b-cdn.net/agentist-icons/service_twist_color_72px.svg',
     }
 
     try {


### PR DESCRIPTION
We use dynamic client registration for Twist in order to provide OAuth, we should provide a url for a logo for this. Currently just using the standard Twist logo. 