### PR TITLE
feat: upgrade twist-sdk to v2.0.1, use entity.url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.8.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "^1.0.4",
+                "@doist/twist-sdk": "2.0.1",
                 "chalk": "5.6.2",
                 "commander": "14.0.2",
                 "marked": "15.0.12",
@@ -290,9 +290,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-1.0.4.tgz",
-            "integrity": "sha512-IJ6BQGmElZQUDzzveQKmFJ0uWRvKH4SYAjDyb3ZrINduDqtv/p+Y2LvY1qvINGcfRyKYFo6z0i3xJ94r9pmZ8w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.0.1.tgz",
+            "integrity": "sha512-th+iydjV8tMePzaddq/iAaQVBU/5HK2gzo3V1UbMfbZdsWuVO6p9/Na4UdpAI/uFsAcDN2Bv1hYM1mv5MhbD9g==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "dist"
     ],
     "dependencies": {
-        "@doist/twist-sdk": "^1.0.4",
+        "@doist/twist-sdk": "2.0.1",
         "chalk": "5.6.2",
         "commander": "14.0.2",
         "marked": "15.0.12",

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,4 +1,3 @@
-import { getFullTwistURL } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { Command } from 'commander'
 import { getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
@@ -115,7 +114,6 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         const output = sortedChannelGroups.map((t) => ({
             ...t,
             channelName: channelMap.get(t.channelId),
-            url: getFullTwistURL({ workspaceId, channelId: t.channelId, threadId: t.id }),
         }))
         console.log(formatJson(output, 'thread', options.full))
         return
@@ -125,7 +123,6 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         const output = sortedChannelGroups.map((t) => ({
             ...t,
             channelName: channelMap.get(t.channelId),
-            url: getFullTwistURL({ workspaceId, channelId: t.channelId, threadId: t.id }),
         }))
         console.log(formatNdjson(output, 'thread', options.full))
         return
@@ -147,9 +144,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
 
         console.log(`  ${title}${unreadBadge}`)
         console.log(`    ${time}  ${colors.timestamp(`id:${thread.id}`)}`)
-        console.log(
-            `    ${colors.url(getFullTwistURL({ workspaceId, channelId: thread.channelId, threadId: thread.id }))}`,
-        )
+        console.log(`    ${colors.url(thread.url)}`)
         console.log('')
     }
 }

--- a/src/commands/msg.ts
+++ b/src/commands/msg.ts
@@ -1,4 +1,3 @@
-import { getFullTwistURL } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { Command } from 'commander'
 import { getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
@@ -77,7 +76,6 @@ async function showUnread(workspaceRef: string | undefined, options: UnreadOptio
         const output = conversations.map((c) => ({
             ...c,
             participantNames: c.userIds.map((id) => userMap.get(id)),
-            url: getFullTwistURL({ workspaceId, conversationId: c.id }),
         }))
         console.log(formatJson(output, 'conversation', options.full))
         return
@@ -87,7 +85,6 @@ async function showUnread(workspaceRef: string | undefined, options: UnreadOptio
         const output = conversations.map((c) => ({
             ...c,
             participantNames: c.userIds.map((id) => userMap.get(id)),
-            url: getFullTwistURL({ workspaceId, conversationId: c.id }),
         }))
         console.log(formatNdjson(output, 'conversation', options.full))
         return
@@ -100,7 +97,7 @@ async function showUnread(workspaceRef: string | undefined, options: UnreadOptio
 
         console.log(chalk.bold(title))
         console.log(`  ${colors.timestamp(`id:${conv.id}`)}  ${colors.author(participants)}`)
-        console.log(`  ${colors.url(getFullTwistURL({ workspaceId, conversationId: conv.id }))}`)
+        console.log(`  ${colors.url(conv.url)}`)
         console.log('')
     }
 }
@@ -139,19 +136,10 @@ async function viewConversation(ref: string, options: ViewOptions): Promise<void
             conversation: {
                 ...conversation,
                 participantNames: conversation.userIds.map((id) => userMap.get(id)),
-                url: getFullTwistURL({
-                    workspaceId: conversation.workspaceId,
-                    conversationId: conversation.id,
-                }),
             },
             messages: messages.map((m) => ({
                 ...m,
                 creatorName: userMap.get(m.creator),
-                url: getFullTwistURL({
-                    workspaceId: conversation.workspaceId,
-                    conversationId: conversation.id,
-                    messageId: m.id,
-                }),
             })),
         }
         console.log(formatJson(output, undefined, options.full))
@@ -224,19 +212,12 @@ async function replyToConversation(
     }
 
     const client = await getTwistClient()
-    const conversation = await client.conversations.getConversation(conversationId)
     const message = await client.conversationMessages.createMessage({
         conversationId,
         content: replyContent,
     })
 
-    const url = getFullTwistURL({
-        workspaceId: conversation.workspaceId,
-        conversationId,
-        messageId: message.id,
-    })
-
-    console.log(`Message sent: ${url}`)
+    console.log(`Message sent: ${message.url}`)
 }
 
 async function markConversationDone(ref: string, options: DoneOptions): Promise<void> {

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -1,4 +1,4 @@
-import { getFullTwistURL, TwistApi } from '@doist/twist-sdk'
+import type { TwistApi } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { Command } from 'commander'
 import { getTwistClient } from '../lib/api.js'
@@ -91,20 +91,12 @@ async function viewSingleComment(
     const channel = channelResponse.data
     const userMap = new Map(userResponses.map((r) => [r.data.id, r.data.name]))
 
-    const url = getFullTwistURL({
-        workspaceId: thread.workspaceId,
-        channelId: thread.channelId,
-        threadId: thread.id,
-        commentId: comment.id,
-    })
-
     if (options.json) {
         const output = {
             ...comment,
             creatorName: userMap.get(comment.creator),
             channelName: channel.name,
             threadTitle: thread.title,
-            url,
         }
         console.log(formatJson(output, undefined, options.full))
         return
@@ -116,7 +108,6 @@ async function viewSingleComment(
                 type: 'comment',
                 ...comment,
                 creatorName: userMap.get(comment.creator),
-                url,
             }),
         )
         return
@@ -195,21 +186,10 @@ async function viewThread(ref: string, options: ViewOptions): Promise<void> {
                 ...thread,
                 channelName: channel.name,
                 creatorName: userMap.get(thread.creator),
-                url: getFullTwistURL({
-                    workspaceId: thread.workspaceId,
-                    channelId: thread.channelId,
-                    threadId: thread.id,
-                }),
             },
             comments: comments.map((c) => ({
                 ...c,
                 creatorName: userMap.get(c.creator),
-                url: getFullTwistURL({
-                    workspaceId: thread.workspaceId,
-                    channelId: thread.channelId,
-                    threadId: thread.id,
-                    commentId: c.id,
-                }),
             })),
         }
         console.log(formatJson(output, undefined, options.full))
@@ -350,14 +330,7 @@ async function replyToThread(
         recipients,
     } as Parameters<typeof client.comments.createComment>[0])
 
-    const url = getFullTwistURL({
-        workspaceId: thread.workspaceId,
-        channelId: thread.channelId,
-        threadId,
-        commentId: comment.id,
-    })
-
-    console.log(`Comment posted: ${url}`)
+    console.log(`Comment posted: ${comment.url}`)
 }
 
 async function markThreadDone(ref: string, options: DoneOptions): Promise<void> {


### PR DESCRIPTION
## Summary

- Upgrades `@doist/twist-sdk` from 1.0.4 to 2.0.1, which adds computed `url` properties to entity schemas via Zod transforms
- Replaces manual `getFullTwistURL()` calls with `entity.url` in `inbox.ts`, `thread.ts`, and `msg.ts` (-51 lines)
- Eliminates a redundant `conversations.getConversation()` API call in `msg reply` that only existed to get `workspaceId` for URL construction
- `search.ts` still uses `getFullTwistURL()` since search results come from a raw API, not SDK-parsed entities

Inspired by [Doist/twist-ai#99](https://github.com/Doist/twist-ai/pull/99).

## Test plan

- [x] `npm run type-check` — no errors
- [x] `npm test` — all 139 tests pass
- [x] `npm run build` — clean
- [x] `tw inbox --limit 3` — URLs render correctly
- [x] `tw inbox --limit 1 --json --full` — `url` field present and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)