### PR TITLE
perf: lazy-load commands and show early spinner for instant feedback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,56 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { program } from 'commander'
-import { registerAuthCommand } from './commands/auth.js'
-import { registerChannelCommand } from './commands/channel.js'
-import { registerInboxCommand } from './commands/inbox.js'
-import { registerMsgCommand } from './commands/msg.js'
-import { registerReactCommand } from './commands/react.js'
-import { registerSearchCommand } from './commands/search.js'
-import { registerSkillCommand } from './commands/skill.js'
-import { registerThreadCommand } from './commands/thread.js'
-import { registerUserCommand } from './commands/user.js'
-import { registerWorkspaceCommand } from './commands/workspace.js'
+import { type Command, program } from 'commander'
+import pkg from '../package.json' with { type: 'json' }
+import { startEarlySpinner, stopEarlySpinner } from './lib/spinner.js'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const { version } = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'))
+const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = {
+    workspace: [
+        'Manage workspace',
+        async () => (await import('./commands/workspace.js')).registerWorkspaceCommand,
+    ],
+    user: [
+        'Show current user info',
+        async () => (await import('./commands/user.js')).registerUserCommand,
+    ],
+    channel: [
+        'List channels in a workspace',
+        async () => (await import('./commands/channel.js')).registerChannelCommand,
+    ],
+    inbox: [
+        'Show inbox threads',
+        async () => (await import('./commands/inbox.js')).registerInboxCommand,
+    ],
+    thread: [
+        'Thread operations',
+        async () => (await import('./commands/thread.js')).registerThreadCommand,
+    ],
+    msg: [
+        'Conversation (DM/group) operations',
+        async () => (await import('./commands/msg.js')).registerMsgCommand,
+    ],
+    search: [
+        'Search content across a workspace',
+        async () => (await import('./commands/search.js')).registerSearchCommand,
+    ],
+    react: [
+        'Add an emoji reaction (target-type: thread, comment, message)',
+        async () => (await import('./commands/react.js')).registerReactCommand,
+    ],
+    auth: [
+        'Manage authentication',
+        async () => (await import('./commands/auth.js')).registerAuthCommand,
+    ],
+    skill: [
+        'Manage agent skill integrations',
+        async () => (await import('./commands/skill.js')).registerSkillCommand,
+    ],
+}
 
 program
     .name('tw')
     .description('Twist CLI')
-    .version(version)
+    .version(pkg.version)
     .option('--no-spinner', 'Disable loading animations')
     .option('--progress-jsonl [path]', 'Output progress events as JSONL to stderr or file')
     .option(
@@ -36,15 +65,33 @@ Note for AI/LLM agents:
   Default JSON shows essential fields; use --full for all fields.`,
     )
 
-registerWorkspaceCommand(program)
-registerUserCommand(program)
-registerChannelCommand(program)
-registerInboxCommand(program)
-registerThreadCommand(program)
-registerMsgCommand(program)
-registerSearchCommand(program)
-registerReactCommand(program)
-registerAuthCommand(program)
-registerSkillCommand(program)
+// Register lightweight placeholders so --help lists all commands
+for (const [name, [description]] of Object.entries(commands)) {
+    program.command(name).description(description)
+}
 
-program.parse()
+// Detect which command is being invoked
+const commandName = process.argv.slice(2).find((a) => !a.startsWith('-') && a in commands)
+
+if (commandName && commands[commandName]) {
+    // Remove the placeholder so the real registration can take its place
+    const idx = program.commands.findIndex((c) => c.name() === commandName)
+    if (idx !== -1) (program.commands as Command[]).splice(idx, 1)
+
+    const loader = commands[commandName][1]
+
+    startEarlySpinner()
+    try {
+        const register = await loader()
+        register(program)
+    } catch (err) {
+        stopEarlySpinner()
+        throw err
+    }
+}
+
+try {
+    await program.parseAsync()
+} finally {
+    stopEarlySpinner()
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,13 +1,17 @@
-import { marked } from 'marked'
+import { type MarkedExtension, marked } from 'marked'
 import { markedTerminal } from 'marked-terminal'
 
-marked.use(markedTerminal())
+let initialized = false
 
 function preprocessMentions(content: string): string {
     return content.replace(/\[([^\]]+)\]\((twist-mention:\/\/\d+)\)/g, '[@$1]($2)')
 }
 
 export function renderMarkdown(content: string): string {
+    if (!initialized) {
+        marked.use(markedTerminal() as unknown as MarkedExtension)
+        initialized = true
+    }
     const processed = preprocessMentions(content)
     const rendered = marked.parse(processed, { async: false }) as string
     return rendered.trimEnd()

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -7,19 +7,91 @@ interface SpinnerOptions {
     noSpinner?: boolean // Allow overriding spinner display
 }
 
+function shouldDisableSpinner(): boolean {
+    // Check for environment variables that should disable spinners
+    if (process.env.TW_SPINNER === 'false') {
+        return true
+    }
+
+    // Check if we're in CI environment
+    if (process.env.CI) {
+        return true
+    }
+
+    // Check process arguments for flags that should disable spinner
+    const args = process.argv
+    const spinnerDisablingFlags = ['--json', '--ndjson', '--no-spinner', '--progress-jsonl']
+
+    // Check for both exact matches and prefix matches (to handle --flag=value variants)
+    return spinnerDisablingFlags.some(
+        (flag) =>
+            args.includes(flag) || // exact match
+            args.some((arg) => arg.startsWith(`${flag}=`)), // prefix match with equals
+    )
+}
+
+// ── Early spinner (shown before command module is loaded) ──────────────
+
+let earlySpinnerInstance: ReturnType<typeof yoctoSpinner> | null = null
+let originalStdoutWrite: typeof process.stdout.write | null = null
+
+export function startEarlySpinner(): void {
+    if (!process.stdout.isTTY || shouldDisableSpinner()) {
+        return
+    }
+
+    earlySpinnerInstance = yoctoSpinner({ text: chalk.blue('Loading...') })
+    earlySpinnerInstance.start()
+
+    // Intercept stdout.write so the spinner auto-stops before any command output
+    originalStdoutWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((...args: Parameters<typeof process.stdout.write>) => {
+        stopEarlySpinner()
+        return process.stdout.write(...args)
+    }) as typeof process.stdout.write
+}
+
+export function stopEarlySpinner(): void {
+    if (originalStdoutWrite) {
+        process.stdout.write = originalStdoutWrite
+        originalStdoutWrite = null
+    }
+    if (earlySpinnerInstance) {
+        earlySpinnerInstance.stop()
+        earlySpinnerInstance = null
+    }
+}
+
+/** For tests only — reset singleton state without stopping */
+export function resetEarlySpinner(): void {
+    earlySpinnerInstance = null
+    originalStdoutWrite = null
+}
+
+// ── LoadingSpinner (used by API calls) ─────────────────────────────────
+
 class LoadingSpinner {
     private spinnerInstance: ReturnType<typeof yoctoSpinner> | null = null
+    private adopted = false
 
     start(options: SpinnerOptions) {
         // Don't show spinner in non-interactive environments, when disabled via options, or when JSON output is expected
-        if (!process.stdout.isTTY || options.noSpinner || this.shouldDisableSpinner()) {
+        if (!process.stdout.isTTY || options.noSpinner || shouldDisableSpinner()) {
+            return this
+        }
+
+        // If an early spinner is running, adopt it instead of creating a new one
+        if (earlySpinnerInstance) {
+            this.spinnerInstance = earlySpinnerInstance
+            this.spinnerInstance.text = chalk[options.color || 'blue'](options.text)
+            earlySpinnerInstance = null
+            this.adopted = true
             return this
         }
 
         const colorFn = chalk[options.color || 'blue']
         this.spinnerInstance = yoctoSpinner({
             text: colorFn(options.text),
-            // yocto-spinner uses dots spinner by default which matches NPM's braille pattern
         })
         this.spinnerInstance.start()
         return this
@@ -27,6 +99,13 @@ class LoadingSpinner {
 
     succeed(text?: string) {
         if (this.spinnerInstance) {
+            if (this.adopted) {
+                // Release back so subsequent API calls can re-adopt
+                earlySpinnerInstance = this.spinnerInstance
+                this.spinnerInstance = null
+                this.adopted = false
+                return
+            }
             this.spinnerInstance.success(text ? chalk.green(`✓ ${text}`) : undefined)
             this.spinnerInstance = null
         }
@@ -34,39 +113,25 @@ class LoadingSpinner {
 
     fail(text?: string) {
         if (this.spinnerInstance) {
+            // Errors always stop the spinner for real
             this.spinnerInstance.error(text ? chalk.red(`✗ ${text}`) : undefined)
             this.spinnerInstance = null
+            this.adopted = false
         }
     }
 
     stop() {
         if (this.spinnerInstance) {
+            if (this.adopted) {
+                // Release back so subsequent API calls can re-adopt
+                earlySpinnerInstance = this.spinnerInstance
+                this.spinnerInstance = null
+                this.adopted = false
+                return
+            }
             this.spinnerInstance.stop()
             this.spinnerInstance = null
         }
-    }
-
-    private shouldDisableSpinner(): boolean {
-        // Check for environment variables that should disable spinners
-        if (process.env.TW_SPINNER === 'false') {
-            return true
-        }
-
-        // Check if we're in CI environment
-        if (process.env.CI) {
-            return true
-        }
-
-        // Check process arguments for flags that should disable spinner
-        const args = process.argv
-        const spinnerDisablingFlags = ['--json', '--ndjson', '--no-spinner', '--progress-jsonl']
-
-        // Check for both exact matches and prefix matches (to handle --flag=value variants)
-        return spinnerDisablingFlags.some(
-            (flag) =>
-                args.includes(flag) || // exact match
-                args.some((arg) => arg.startsWith(`${flag}=`)), // prefix match with equals
-        )
     }
 }
 


### PR DESCRIPTION
## Summary

- **Lazy-load command modules**: Instead of importing all 10 command modules at startup, `src/index.ts` now registers lightweight placeholders and only `import()`s the module for the invoked command. Eliminates `fs`/`path`/`url` imports by using JSON import for `package.json`.
- **Early spinner for instant feedback**: A "Loading..." spinner starts immediately before the dynamic import, so there's zero visual silence. It seamlessly hands off to each API call's spinner (text updates in-place without flicker), stays running through all API calls via a release-back mechanism, and auto-clears the moment stdout is written to.
- **Defer markedTerminal init**: `marked.use(markedTerminal())` is now called on first `renderMarkdown()` invocation instead of at module load time.

Port of [todoist-cli#65](https://github.com/Doist/todoist-cli/pull/65).

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — all 158 tests pass (11 new early spinner tests)
- [x] `npm run type-check` — no errors
- [x] `npm run lint:check` — clean
- [x] `npm run format:check` — clean
- [ ] `tw --version` — fast, no spinner
- [ ] `tw --help` — lists all commands
- [ ] `tw inbox <workspace>` — spinner shows immediately, stays through API calls, clears before output
- [ ] `tw inbox <workspace> --json` — no spinner shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)