### PR TITLE
feat: add `tw view <url>` router command

### DIFF
--- a/src/__tests__/lib/refs.test.ts
+++ b/src/__tests__/lib/refs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+    classifyTwistUrl,
     extractId,
     isIdRef,
     parseRef,
@@ -156,5 +157,51 @@ describe('resolveMessageId', () => {
 
     it('resolves message URLs', () => {
         expect(resolveMessageId('https://twist.com/a/12345/msg/333/m/444')).toBe(444)
+    })
+})
+
+describe('classifyTwistUrl', () => {
+    it('classifies thread URL', () => {
+        expect(classifyTwistUrl('https://twist.com/a/20/ch/100/t/200')).toEqual({
+            entityType: 'thread',
+            url: 'https://twist.com/a/20/ch/100/t/200',
+        })
+    })
+
+    it('classifies thread+comment URL as comment', () => {
+        expect(classifyTwistUrl('https://twist.com/a/20/ch/100/t/200/c/300')).toEqual({
+            entityType: 'comment',
+            url: 'https://twist.com/a/20/ch/100/t/200/c/300',
+        })
+    })
+
+    it('classifies conversation URL', () => {
+        expect(classifyTwistUrl('https://twist.com/a/20/msg/400')).toEqual({
+            entityType: 'conversation',
+            url: 'https://twist.com/a/20/msg/400',
+        })
+    })
+
+    it('classifies message URL', () => {
+        expect(classifyTwistUrl('https://twist.com/a/20/msg/400/m/500')).toEqual({
+            entityType: 'message',
+            url: 'https://twist.com/a/20/msg/400/m/500',
+        })
+    })
+
+    it('returns null for workspace-only URL', () => {
+        expect(classifyTwistUrl('https://twist.com/a/20')).toBeNull()
+    })
+
+    it('returns null for channel-only URL', () => {
+        expect(classifyTwistUrl('https://twist.com/a/20/ch/100')).toBeNull()
+    })
+
+    it('returns null for non-Twist URL', () => {
+        expect(classifyTwistUrl('https://google.com/a/20/t/200')).toBeNull()
+    })
+
+    it('returns null for invalid string', () => {
+        expect(classifyTwistUrl('not-a-url')).toBeNull()
     })
 })

--- a/src/__tests__/view.test.ts
+++ b/src/__tests__/view.test.ts
@@ -1,0 +1,91 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../commands/thread.js', () => ({
+    registerThreadCommand: (program: Command) => {
+        const thread = program.command('thread')
+        thread.command('view [ref]').action(() => {
+            throw new Error('ROUTED_TO_THREAD')
+        })
+    },
+}))
+
+vi.mock('../commands/conversation.js', () => ({
+    registerConversationCommand: (program: Command) => {
+        const convo = program.command('conversation')
+        convo.command('view [ref]').action(() => {
+            throw new Error('ROUTED_TO_CONVERSATION')
+        })
+    },
+}))
+
+vi.mock('../commands/msg.js', () => ({
+    registerMsgCommand: (program: Command) => {
+        const msg = program.command('msg')
+        msg.command('view [ref]').action(() => {
+            throw new Error('ROUTED_TO_MSG')
+        })
+    },
+}))
+
+import { registerViewCommand } from '../commands/view.js'
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerViewCommand(program)
+    return program
+}
+
+describe('tw view <url> routing', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('routes thread URL to thread view', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'view', 'https://twist.com/a/1585/ch/100/t/200']),
+        ).rejects.toThrow('ROUTED_TO_THREAD')
+    })
+
+    it('routes comment URL (thread+comment) to thread view', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync([
+                'node',
+                'tw',
+                'view',
+                'https://twist.com/a/1585/ch/100/t/200/c/300',
+            ]),
+        ).rejects.toThrow('ROUTED_TO_THREAD')
+    })
+
+    it('routes conversation URL to conversation view', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'view', 'https://twist.com/a/1585/msg/400']),
+        ).rejects.toThrow('ROUTED_TO_CONVERSATION')
+    })
+
+    it('routes message URL to msg view', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'view', 'https://twist.com/a/1585/msg/400/m/500']),
+        ).rejects.toThrow('ROUTED_TO_MSG')
+    })
+
+    it('throws for unrecognized Twist URL', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'view', 'https://twist.com/a/1585']),
+        ).rejects.toThrow('Not a recognized Twist URL')
+    })
+
+    it('throws for non-Twist URL', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'view', 'https://google.com/something']),
+        ).rejects.toThrow('Not a recognized Twist URL')
+    })
+})

--- a/src/commands/view.ts
+++ b/src/commands/view.ts
@@ -1,0 +1,90 @@
+import { Command } from 'commander'
+import { classifyTwistUrl } from '../lib/refs.js'
+
+function looksLikeTwistAppUrl(token: string): boolean {
+    return /^https?:\/\/twist\.com\/a\/\S+/.test(token)
+}
+
+function extractViewInvocation(parsedUrl: string): {
+    url: string
+    passthroughArgs: string[]
+} {
+    const rawArgs = process.argv
+    const viewIdx = rawArgs.indexOf('view')
+    const afterView = viewIdx >= 0 ? rawArgs.slice(viewIdx + 1) : []
+    const passthroughArgs = afterView.filter((arg: string) => arg !== parsedUrl)
+    return { url: parsedUrl, passthroughArgs }
+}
+
+async function runRoutedCommand(
+    loadRegister: () => Promise<(p: Command) => void>,
+    argv: string[],
+): Promise<void> {
+    const proxy = new Command()
+    proxy.exitOverride()
+    const register = await loadRegister()
+    register(proxy)
+    await proxy.parseAsync(['node', 'tw', ...argv])
+}
+
+export function registerViewCommand(program: Command): void {
+    program
+        .command('view <url> [args...]')
+        .description('View any Twist entity by URL')
+        .allowUnknownOption(true)
+        .addHelpText(
+            'after',
+            `
+Route mapping:
+  Message URL      → tw msg view <url>
+  Conversation URL → tw conversation view <url>
+  Comment URL      → tw thread view <url>  (comment ID extracted from URL)
+  Thread URL       → tw thread view <url>
+
+Examples:
+  tw view https://twist.com/a/1585/ch/100/t/200
+  tw view https://twist.com/a/1585/ch/100/t/200/c/300
+  tw view https://twist.com/a/1585/msg/400
+  tw view https://twist.com/a/1585/msg/400/m/500
+  tw view https://twist.com/a/1585/msg/400/m/500 --json`,
+        )
+        .action(async (url: string) => {
+            if (!looksLikeTwistAppUrl(url)) {
+                throw new Error(`Not a recognized Twist URL: ${url}`)
+            }
+
+            const { url: resolvedUrl, passthroughArgs } = extractViewInvocation(url)
+
+            const route = classifyTwistUrl(resolvedUrl)
+            if (!route) {
+                throw new Error(`Not a recognized Twist URL: ${resolvedUrl}`)
+            }
+
+            switch (route.entityType) {
+                case 'thread':
+                    await runRoutedCommand(
+                        async () => (await import('./thread.js')).registerThreadCommand,
+                        ['thread', 'view', resolvedUrl, ...passthroughArgs],
+                    )
+                    break
+                case 'comment':
+                    await runRoutedCommand(
+                        async () => (await import('./thread.js')).registerThreadCommand,
+                        ['thread', 'view', resolvedUrl, ...passthroughArgs],
+                    )
+                    break
+                case 'conversation':
+                    await runRoutedCommand(
+                        async () => (await import('./conversation.js')).registerConversationCommand,
+                        ['conversation', 'view', resolvedUrl, ...passthroughArgs],
+                    )
+                    break
+                case 'message':
+                    await runRoutedCommand(
+                        async () => (await import('./msg.js')).registerMsgCommand,
+                        ['msg', 'view', resolvedUrl, ...passthroughArgs],
+                    )
+                    break
+            }
+        })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         'Manage agent skill integrations',
         async () => (await import('./commands/skill.js')).registerSkillCommand,
     ],
+    view: [
+        'View a Twist entity by URL',
+        async () => (await import('./commands/view.js')).registerViewCommand,
+    ],
 }
 
 const commandAliases: Record<string, string> = {

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -191,6 +191,23 @@ export function resolveMessageId(ref: string): number {
     throw new Error(`Invalid message reference: ${ref}. Use message ID or Twist URL.`)
 }
 
+export type TwistUrlRoute = {
+    entityType: 'message' | 'conversation' | 'comment' | 'thread'
+    url: string
+}
+
+export function classifyTwistUrl(url: string): TwistUrlRoute | null {
+    const parsed = parseTwistUrl(url)
+    if (!parsed) return null
+
+    if (parsed.messageId) return { entityType: 'message', url }
+    if (parsed.conversationId && !parsed.messageId) return { entityType: 'conversation', url }
+    if (parsed.commentId) return { entityType: 'comment', url }
+    if (parsed.threadId && !parsed.commentId) return { entityType: 'thread', url }
+
+    return null
+}
+
 export async function resolveUserRefs(refs: string, workspaceId: number): Promise<number[]> {
     const { getWorkspaceUsers } = await import('./api.js')
     const users = await getWorkspaceUsers(workspaceId)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -17,6 +17,20 @@ tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 \`\`\`
 
+## View by URL
+
+\`\`\`bash
+tw view <url>                    # View any Twist entity by URL
+\`\`\`
+
+Routes automatically based on URL structure:
+- Message URL → \`tw msg view\`
+- Conversation URL → \`tw conversation view\`
+- Thread+comment URL → \`tw thread view\` (comment ID extracted from URL)
+- Thread URL → \`tw thread view\`
+
+All target command flags pass through (e.g. \`--json\`, \`--raw\`, \`--full\`).
+
 ## Inbox
 
 \`\`\`bash
@@ -132,6 +146,14 @@ Commands accept flexible references:
 - **Fuzzy names**: For workspaces/users - \`"My Workspace"\` or partial matches
 
 ## Common Workflows
+
+**View by URL (auto-routes to the right command):**
+\`\`\`bash
+tw view https://twist.com/a/1585/ch/100/t/200          # View thread
+tw view https://twist.com/a/1585/ch/100/t/200/c/300     # View comment
+tw view https://twist.com/a/1585/msg/400                 # View conversation
+tw view https://twist.com/a/1585/msg/400/m/500 --json    # View message as JSON
+\`\`\`
 
 **Check inbox and respond:**
 \`\`\`bash


### PR DESCRIPTION
## Summary
- Adds `tw view <url>` top-level command that classifies a Twist URL and routes to the appropriate subcommand (`thread view`, `conversation view`, or `msg view`)
- Adds `classifyTwistUrl()` helper to `src/lib/refs.ts` with priority: message > conversation > comment > thread
- All target command flags (e.g. `--json`, `--raw`, `--full`) pass through transparently

## Test plan
- [x] `classifyTwistUrl` unit tests (8 cases: thread, comment, conversation, message, workspace-only, channel-only, non-Twist, invalid)
- [x] View routing tests (6 cases: thread, comment→thread, conversation, message, unrecognized Twist URL, non-Twist URL)
- [x] Build passes (`npm run build`)
- [x] All 181 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [ ] Manual: `tw view https://twist.com/a/1585/msg/1292001/m/107734984`
- [ ] Manual: `tw view <url> --json` and `tw view --json <url>` both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)