### PR TITLE
feat: add --accessible flag for screen-reader-friendly output

### DIFF
--- a/src/__tests__/lib/output.test.ts
+++ b/src/__tests__/lib/output.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { isAccessible } from '../../lib/output.js'
+
+describe('isAccessible', () => {
+    afterEach(() => {
+        delete process.env.TW_ACCESSIBLE
+        // Remove --accessible from argv if added
+        const idx = process.argv.indexOf('--accessible')
+        if (idx !== -1) process.argv.splice(idx, 1)
+    })
+
+    it('returns false by default', () => {
+        expect(isAccessible()).toBe(false)
+    })
+
+    it('returns true when TW_ACCESSIBLE=1', () => {
+        process.env.TW_ACCESSIBLE = '1'
+        expect(isAccessible()).toBe(true)
+    })
+
+    it('returns false when TW_ACCESSIBLE is set to other values', () => {
+        process.env.TW_ACCESSIBLE = '0'
+        expect(isAccessible()).toBe(false)
+        process.env.TW_ACCESSIBLE = 'true'
+        expect(isAccessible()).toBe(false)
+    })
+
+    it('returns true when --accessible is in argv', () => {
+        process.argv.push('--accessible')
+        expect(isAccessible()).toBe(true)
+    })
+})

--- a/src/commands/conversation.ts
+++ b/src/commands/conversation.ts
@@ -5,7 +5,7 @@ import { formatRelativeDate } from '../lib/dates.js'
 import { openEditor, readStdin } from '../lib/input.js'
 import { renderMarkdown } from '../lib/markdown.js'
 import type { MutationOptions, PaginatedViewOptions, ViewOptions } from '../lib/options.js'
-import { colors, formatJson, formatNdjson } from '../lib/output.js'
+import { colors, formatJson, formatNdjson, isAccessible } from '../lib/output.js'
 import { resolveConversationId, resolveWorkspaceRef } from '../lib/refs.js'
 
 type UnreadOptions = ViewOptions & { workspace?: string }
@@ -79,9 +79,10 @@ async function showUnread(workspaceRef: string | undefined, options: UnreadOptio
     for (const conv of conversations) {
         const participants = conv.userIds.map((id) => userMap.get(id) || `user:${id}`).join(', ')
         const title = conv.title || `Conversation with ${participants}`
-        const _unreadInfo = unreadConversations.find((uc) => uc.conversationId === conv.id)
+        const unreadInfo = unreadConversations.find((uc) => uc.conversationId === conv.id)
+        const unreadBadge = unreadInfo ? chalk.blue(isAccessible() ? ' (unread)' : ' *') : ''
 
-        console.log(chalk.bold(title))
+        console.log(`${chalk.bold(title)}${unreadBadge}`)
         console.log(`  ${colors.timestamp(`id:${conv.id}`)}  ${colors.author(participants)}`)
         console.log(`  ${colors.url(conv.url)}`)
         console.log('')

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander'
 import { getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
 import { formatRelativeDate } from '../lib/dates.js'
 import type { PaginatedViewOptions } from '../lib/options.js'
-import { colors, formatJson, formatNdjson } from '../lib/output.js'
+import { colors, formatJson, formatNdjson, isAccessible } from '../lib/output.js'
 import { getPublicChannelIds, includePrivateChannels } from '../lib/public-channels.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
 
@@ -137,7 +137,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
 
         const title = thread.isUnread ? chalk.bold(thread.title) : thread.title
         const time = colors.timestamp(formatRelativeDate(thread.posted))
-        const unreadBadge = thread.isUnread ? chalk.blue(' *') : ''
+        const unreadBadge = thread.isUnread ? chalk.blue(isAccessible() ? ' (unread)' : ' *') : ''
 
         console.log(`  ${title}${unreadBadge}`)
         console.log(`    ${time}  ${colors.timestamp(`id:${thread.id}`)}`)

--- a/src/commands/thread.ts
+++ b/src/commands/thread.ts
@@ -7,7 +7,7 @@ import { formatRelativeDate } from '../lib/dates.js'
 import { openEditor, readStdin } from '../lib/input.js'
 import { renderMarkdown } from '../lib/markdown.js'
 import type { MutationOptions, PaginatedViewOptions } from '../lib/options.js'
-import { colors, formatJson } from '../lib/output.js'
+import { colors, formatJson, isAccessible } from '../lib/output.js'
 import { assertChannelIsPublic } from '../lib/public-channels.js'
 import { extractId, parseRef, resolveThreadId } from '../lib/refs.js'
 
@@ -23,7 +23,10 @@ function printSeparator(label: string): void {
     const remainingWidth = totalWidth - labelWithPadding.length
     const leftWidth = Math.floor(remainingWidth / 2)
     const rightWidth = remainingWidth - leftWidth
-    const line = chalk.dim('─'.repeat(leftWidth) + labelWithPadding + '─'.repeat(rightWidth))
+    const dashChar = isAccessible() ? '-' : '─'
+    const line = chalk.dim(
+        dashChar.repeat(leftWidth) + labelWithPadding + dashChar.repeat(rightWidth),
+    )
     console.log('')
     console.log(line)
     console.log('')

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ program
         '--include-private-channels',
         'Include private channels in output (env: TWIST_INCLUDE_PRIVATE_CHANNELS)',
     )
+    .option('--accessible', 'Add text labels to color-coded output (also: TW_ACCESSIBLE=1)')
     .addHelpText(
         'after',
         `

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -154,3 +154,7 @@ export function printJson<T extends object>(data: T | T[], type?: EntityType, fu
 export function printNdjson<T extends object>(items: T[], type?: EntityType, full = false): void {
     console.log(formatNdjson(items, type, full))
 }
+
+export function isAccessible(): boolean {
+    return process.env.TW_ACCESSIBLE === '1' || process.argv.includes('--accessible')
+}

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -145,6 +145,7 @@ tw update --check                # Check for updates without installing
 \`\`\`bash
 --no-spinner       # Disable loading animations
 --progress-jsonl   # Machine-readable progress events (JSONL to stderr)
+--accessible       # Add text labels to color-coded output (also: TW_ACCESSIBLE=1)
 \`\`\`
 
 ## Output Formats


### PR DESCRIPTION
## Summary

- Add `--accessible` global flag (and `TW_ACCESSIBLE=1` env var) that annotates color-only indicators with text labels for screen readers: unread badges in inbox and conversation lists show `(unread)` instead of `*`, and thread separators use ASCII `-` instead of box-drawing `─`
- Fix bug where conversation unread status was fetched but never displayed (`_unreadInfo` discarded)
- Replace box-drawing `─` separators with ASCII `-` in accessible mode for better screen reader compatibility


## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 217 tests pass
- [x] `npm run format:check` — clean
- [ ] `tw inbox --accessible` — verify `(unread)` text labels appear
- [ ] `tw conversation unread --accessible` — verify unread indicator shows
- [ ] `TW_ACCESSIBLE=1 tw inbox` — verify env var mode works

Inspired by [Doist/todoist-cli#95](https://github.com/Doist/todoist-cli/pull/95).

🤖 Generated with [Claude Code](https://claude.com/claude-code)