### PR TITLE
feat: add Gemini CLI skill

### DIFF
--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -37,6 +37,12 @@ describe('skill registry', () => {
         expect(installer?.name).toBe('cursor')
     })
 
+    it('returns gemini installer', () => {
+        const installer = getInstaller('gemini')
+        expect(installer).not.toBeNull()
+        expect(installer?.name).toBe('gemini')
+    })
+
     it('returns null for unknown agent', () => {
         const installer = getInstaller('unknown-agent')
         expect(installer).toBeNull()
@@ -47,6 +53,7 @@ describe('skill registry', () => {
         expect(names).toContain('claude-code')
         expect(names).toContain('codex')
         expect(names).toContain('cursor')
+        expect(names).toContain('gemini')
     })
 })
 
@@ -55,6 +62,7 @@ describe('installer paths', () => {
         { agent: 'claude-code', dir: '.claude', desc: 'Claude Code skill for Twist CLI' },
         { agent: 'codex', dir: '.codex', desc: 'Codex skill for Twist CLI' },
         { agent: 'cursor', dir: '.cursor', desc: 'Cursor skill for Twist CLI' },
+        { agent: 'gemini', dir: '.gemini', desc: 'Gemini CLI skill for Twist CLI' },
     ] as const
 
     for (const { agent, dir, desc } of cases) {
@@ -176,9 +184,9 @@ describe('listAgents', () => {
 
     it('returns agent info with installed status', async () => {
         const agents = await listAgents(true)
-        expect(agents.length).toBe(3)
+        expect(agents.length).toBe(4)
 
-        for (const name of ['claude-code', 'codex', 'cursor']) {
+        for (const name of ['claude-code', 'codex', 'cursor', 'gemini']) {
             const agent = agents.find((a) => a.name === name)
             expect(agent).toBeDefined()
             expect(agent?.installed).toBe(false)

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -17,6 +17,11 @@ export const skillInstallers: Record<string, SkillInstaller> = {
         description: 'Cursor skill for Twist CLI',
         dirName: '.cursor',
     }),
+    gemini: createInstaller({
+        name: 'gemini',
+        description: 'Gemini CLI skill for Twist CLI',
+        dirName: '.gemini',
+    }),
 }
 
 export function getInstaller(name: string): SkillInstaller | null {


### PR DESCRIPTION
## Summary
- Adds Gemini CLI as a supported skill installer, matching the existing factory pattern
- Installs to `~/.gemini/skills/twist-cli/SKILL.md` (global) or `.gemini/skills/twist-cli/SKILL.md` (local)
- Adds corresponding test coverage for the new agent

## Test plan
- [x] All 217 existing + new tests pass (`npm test`)
- [x] Build compiles cleanly (type-check via pre-commit hook)
- [x] Manual: `tw skill list` shows `gemini` in output
- [x] Manual: `tw skill install gemini` installs to correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)