### PR TITLE
chore: exclude test files from build output with tsconfig.build.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,16 @@ This file provides guidance to AI coding agents when working with code in this r
 ## Commands
 
 ```bash
-npm run build          # Compile TypeScript to dist/
-npm run dev            # Watch mode compilation
+npm run build          # Compile TypeScript to dist/ (uses tsconfig.build.json, excludes tests)
+npm run dev            # Watch mode compilation (uses tsconfig.build.json, excludes tests)
 npm test               # Run all tests (vitest)
 npm run test:watch     # Run tests in watch mode
-npm run type-check     # Type check without emitting
+npm run type-check     # Type check without emitting (uses tsconfig.json, includes tests)
 npm run format         # Format with Prettier
 npm run format:check   # Check formatting
 ```
+
+The project uses two tsconfig files: `tsconfig.json` includes test files for type-checking, while `tsconfig.build.json` extends it and excludes `src/__tests__/` so that test files are not compiled into `dist/`.
 
 Run a single test file:
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "tw": "dist/index.js"
     },
     "scripts": {
-        "build": "tsc && chmod +x dist/index.js",
-        "dev": "tsc --watch",
+        "build": "tsc -p tsconfig.build.json && chmod +x dist/index.js",
+        "dev": "tsc -p tsconfig.build.json --watch",
         "start": "node dist/index.js",
         "type-check": "tsc --noEmit",
         "lint": "biome check --write .",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["node_modules", "dist", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary
- Add `tsconfig.build.json` that extends the base config but excludes `src/__tests__/`, so test files are not compiled into `dist/`
- Update `build` and `dev` scripts to use `tsconfig.build.json`; `type-check` continues using base `tsconfig.json` (includes tests)
- Document the two-tsconfig setup in `AGENTS.md`

Mirrors the same pattern from [todoist-cli PR #97](https://github.com/Doist/todoist-cli/pull/97).

## Test plan
- [x] `npm run type-check` passes (tests still type-checked)
- [x] `npm run build` succeeds and `dist/__tests__/` does not exist
- [x] `npm test` — all 221 tests pass
- [x] `npm run dev` starts without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)