### PR TITLE
fix: suppress package manager output during update

### DIFF
--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -54,6 +54,9 @@ function mockFetchNetworkError(code: string) {
 function mockSpawnSuccess() {
     mockSpawn.mockImplementation(() => {
         const child = {
+            stderr: {
+                on: vi.fn(),
+            },
             on: vi.fn((event: string, cb: (arg: unknown) => void) => {
                 if (event === 'close') {
                     setTimeout(() => cb(0), 0)
@@ -68,6 +71,9 @@ function mockSpawnSuccess() {
 function mockSpawnFailure(exitCode: number) {
     mockSpawn.mockImplementation(() => {
         const child = {
+            stderr: {
+                on: vi.fn(),
+            },
             on: vi.fn((event: string, cb: (arg: unknown) => void) => {
                 if (event === 'close') {
                     setTimeout(() => cb(exitCode), 0)
@@ -82,6 +88,9 @@ function mockSpawnFailure(exitCode: number) {
 function mockSpawnPermissionError() {
     mockSpawn.mockImplementation(() => {
         const child = {
+            stderr: {
+                on: vi.fn(),
+            },
             on: vi.fn((event: string, cb: (arg: unknown) => void) => {
                 if (event === 'error') {
                     const error = new Error('EACCES') as NodeJS.ErrnoException
@@ -160,7 +169,7 @@ describe('update command', () => {
             expect(mockSpawn).toHaveBeenCalledWith(
                 'npm',
                 ['install', '-g', '@doist/twist-cli@latest'],
-                { stdio: 'inherit' },
+                { stdio: 'pipe' },
             )
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Updated to v99.0.0')
         })
@@ -176,7 +185,7 @@ describe('update command', () => {
             expect(mockSpawn).toHaveBeenCalledWith(
                 'pnpm',
                 ['add', '-g', '@doist/twist-cli@latest'],
-                { stdio: 'inherit' },
+                { stdio: 'pipe' },
             )
         })
     })

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -24,14 +24,20 @@ export function detectPackageManager(): string {
     return 'npm'
 }
 
-export function runInstall(pm: string): Promise<number> {
+export function runInstall(pm: string): Promise<{ exitCode: number; stderr: string }> {
     const command = pm === 'pnpm' ? 'add' : 'install'
     return new Promise((resolve, reject) => {
         const child = spawn(pm, [command, '-g', `${PACKAGE_NAME}@latest`], {
-            stdio: 'inherit',
+            stdio: 'pipe',
         })
+
+        let stderr = ''
+        child.stderr?.on('data', (data: Buffer) => {
+            stderr += data.toString()
+        })
+
         child.on('error', reject)
-        child.on('close', (code) => resolve(code ?? 1))
+        child.on('close', (code) => resolve({ exitCode: code ?? 1, stderr }))
     })
 }
 
@@ -63,17 +69,14 @@ export async function updateAction(options: UpdateOptions): Promise<void> {
         return
     }
 
-    console.log(chalk.blue(`Updating ${PACKAGE_NAME} v${currentVersion} → v${latestVersion}...`))
-
     const pm = detectPackageManager()
 
+    let result: { exitCode: number; stderr: string }
     try {
-        const exitCode = await runInstall(pm)
-        if (exitCode !== 0) {
-            console.error(chalk.red('Update failed:'), `${pm} exited with code ${exitCode}`)
-            process.exitCode = 1
-            return
-        }
+        result = await withSpinner(
+            { text: `Updating to v${latestVersion}...`, color: 'blue' },
+            () => runInstall(pm),
+        )
     } catch (error) {
         if (error instanceof Error && 'code' in error && error.code === 'EACCES') {
             console.error(
@@ -83,6 +86,15 @@ export async function updateAction(options: UpdateOptions): Promise<void> {
         } else {
             const message = error instanceof Error ? error.message : 'Unknown error'
             console.error(chalk.red('Update failed:'), message)
+        }
+        process.exitCode = 1
+        return
+    }
+
+    if (result.exitCode !== 0) {
+        console.error(chalk.red('Update failed:'), `${pm} exited with code ${result.exitCode}`)
+        if (result.stderr) {
+            console.error(chalk.dim(result.stderr.trim()))
         }
         process.exitCode = 1
         return


### PR DESCRIPTION
## Summary
- Suppress npm/pnpm stdout/stderr during `tw update` by switching from `stdio: 'inherit'` to `stdio: 'pipe'`
- Wrap the install step in a spinner ("Updating to vX.Y.Z...") for a clean terminal experience
- Surface captured stderr only on failure, so users still get useful error context

## Test plan
- [x] All existing tests updated and passing (221/221)
- [x] TypeScript type check passes
- [x] Manual: `tw update` when already up-to-date shows clean "Already up to date" message
- [x] Manual: `tw update` when update available shows spinner, no npm output, then "Updated to vX.Y.Z"

🤖 Generated with [Claude Code](https://claude.com/claude-code)