### PR TITLE
fix: make thread view --unread filter correctly across all output modes

### DIFF
--- a/src/__tests__/thread.test.ts
+++ b/src/__tests__/thread.test.ts
@@ -163,7 +163,7 @@ describe('thread implicit view', () => {
 
 describe('thread view --unread', () => {
     beforeEach(() => {
-        vi.clearAllMocks()
+        vi.resetAllMocks()
     })
 
     it('shows original post and "No unread comments" when thread has no unread data', async () => {

--- a/src/commands/thread/view.ts
+++ b/src/commands/thread/view.ts
@@ -133,7 +133,11 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
         }
     }
 
-    const userIds = new Set<number>([thread.creator, ...comments.map((c) => c.creator)])
+    const userIds = new Set<number>([
+        thread.creator,
+        ...displayComments.map((c) => c.creator),
+        ...contextComments.map((c) => c.creator),
+    ])
     const userCalls = [...userIds].map((id) =>
         client.workspaceUsers.getUserById(
             { workspaceId: thread.workspaceId, userId: id },


### PR DESCRIPTION
## Summary
- **JSON/NDJSON now respect `--unread`**: Previously the structured output paths returned early before unread filtering was applied, so `--unread --json` returned all comments unfiltered
- **Original post shown when no unread comments**: Previously `--unread` with no unread data just printed "No unread comments in this thread." and exited; now the thread title, channel, and original post are displayed for context before the message
- Added 6 regression tests covering `--unread` across human-readable, JSON, and NDJSON output modes

Closes #75

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` passes (268 tests, 6 new)
- [x] `tw thread view <url> --unread` shows original post + "No unread comments."
- [x] `tw thread view <url> --unread --json` returns thread with empty comments array
- [x] `tw thread view <url> --json` (without --unread) still returns all comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)