### PR TITLE
feat: add --json output to auth status command

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -264,6 +264,40 @@ describe('auth command', () => {
             expect(consoleSpy).toHaveBeenCalledWith('  Mode:  read-write')
         })
 
+        it('outputs JSON when --json flag is used', async () => {
+            const program = createProgram()
+
+            const mockUser: User = {
+                id: 1,
+                name: 'Test User',
+                shortName: 'test',
+                bot: false,
+                timezone: 'UTC',
+                removed: false,
+                email: 'test@example.com',
+                lang: 'en',
+            }
+
+            mockGetSessionUser.mockResolvedValue(mockUser)
+
+            await program.parseAsync(['node', 'tw', 'auth', 'status', '--json'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                JSON.stringify({ id: 1, email: 'test@example.com', name: 'Test User' }, null, 2),
+            )
+        })
+
+        it('outputs JSON error when --json flag is used and not authenticated', async () => {
+            const program = createProgram()
+            mockGetSessionUser.mockRejectedValue(new Error('No API token found'))
+
+            await program.parseAsync(['node', 'tw', 'auth', 'status', '--json'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                JSON.stringify({ error: 'Not authenticated' }, null, 2),
+            )
+        })
+
         it('shows not authenticated when no token', async () => {
             const program = createProgram()
             mockGetSessionUser.mockRejectedValue(new Error('No API token found'))

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -117,10 +117,16 @@ async function loginWithToken(token?: string): Promise<void> {
     logTokenStorageResult(saveResult, 'Token stored securely in the system credential manager')
 }
 
-async function showStatus(): Promise<void> {
+async function showStatus(options: { json?: boolean }): Promise<void> {
     try {
         // Try to get session user to verify the token works
         const user = await getSessionUser()
+        if (options.json) {
+            console.log(
+                JSON.stringify({ id: user.id, email: user.email, name: user.name }, null, 2),
+            )
+            return
+        }
         const metadata = await getAuthMetadata()
         const modeLabel =
             metadata.authMode === 'read-only'
@@ -134,6 +140,11 @@ async function showStatus(): Promise<void> {
         console.log(`  Name:  ${user.name}`)
         console.log(`  Mode:  ${modeLabel}`)
     } catch {
+        if (options.json) {
+            console.log(JSON.stringify({ error: 'Not authenticated' }, null, 2))
+            process.exitCode = 1
+            return
+        }
         console.log(chalk.yellow('Not authenticated'))
         console.log(
             chalk.dim(
@@ -173,7 +184,10 @@ export function registerAuthCommand(program: Command): void {
         .description('Save API token for CLI authentication')
         .action(loginWithToken)
 
-    auth.command('status').description('Show current authentication status').action(showStatus)
+    auth.command('status')
+        .description('Show current authentication status')
+        .option('--json', 'Output as JSON')
+        .action(showStatus)
 
     auth.command('logout').description('Remove saved authentication token').action(logout)
 }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -13,6 +13,7 @@ tw auth login                    # OAuth login (opens browser, read-write)
 tw auth login --read-only        # OAuth login with read-only scope
 tw auth token <your-api-token>   # Save API token manually (scope unknown; assumed write-capable)
 tw auth status                   # Verify authentication + show mode
+tw auth status --json            # JSON output: { id, email, name }
 tw auth logout                   # Remove saved token and auth metadata
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace


### PR DESCRIPTION
## Summary
- Add `--json` flag to `tw auth status` that outputs `{ id, email, name }` as structured JSON
- When not authenticated with `--json`, outputs `{ error: "Not authenticated" }` with exit code 1
- Update agent skill content to document the new flag

This mirrors [todoist-cli#121](https://github.com/Doist/todoist-cli/pull/121) — useful for Doist OS so agents can resolve "me/my" context to a user identity.

## Test plan
- [x] `tw auth status` — existing human-readable output unchanged
- [x] `tw auth status --json` — outputs JSON with id, email, name
- [x] `tw auth status --json` when not authenticated — outputs JSON error with exit code 1
- [x] All 272 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)