### PR TITLE
chore: Simplify release announcement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           {
               echo "should_announce=true"
               echo "message<<EOF"
-              echo "**${package_name} ${new_tag} published**"
+              echo "**Twist CLI ${new_tag} published** 🚀"
               echo
               printf '%s\n' "${changelog}"
               echo


### PR DESCRIPTION
Use a human readable name (Twist CLI) instead of package name (@doist/twist-cli). Makes scanning the release announcements easier. Aligned with todoist-cli (https://github.com/Doist/todoist-cli/pull/174)