### PR TITLE
chore(deps): upgrade TypeScript 5.9 to 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "lefthook": "2.1.4",
                 "prettier": "3.8.1",
                 "semantic-release": "25.0.3",
-                "typescript": "5.9.3",
+                "typescript": "6.0.2",
                 "vitest": "4.1.0"
             },
             "engines": {
@@ -8124,9 +8124,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "lefthook": "2.1.4",
         "prettier": "3.8.1",
         "semantic-release": "25.0.3",
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
         "vitest": "4.1.0"
     },
     "optionalDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
     "compilerOptions": {
-        "target": "ES2022",
+        "target": "ES2024",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "outDir": "dist",
         "rootDir": "src",
         "strict": true,
-        "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "declaration": true,
         "declarationMap": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "types": ["node"]
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from 5.9.3 to 6.0.2 (bridge release toward native TS 7.0)
- Add explicit `"types": ["node"]` to tsconfig (TS6 defaults `types` to `[]`)
- Remove redundant `"esModuleInterop": true` (always enabled in TS6)
- Bump target from ES2022 to ES2024

## Context
TypeScript 6.0 changes several compiler option defaults. This project was already well-configured with explicit settings, so the migration is minimal. The main required change is adding the `types` array since TS6 no longer auto-includes all `@types/*` packages.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] `npm test` — all 284 tests pass
- [x] `npm run lint:check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)