### PR TITLE
fix: remove inline token placeholder from skill auth example

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -12,7 +12,7 @@ Access Twist messaging via the `tw` CLI. Use when the user asks about their Twis
 ```bash
 tw auth login                    # OAuth login (opens browser, read-write)
 tw auth login --read-only        # OAuth login with read-only scope
-tw auth token <your-api-token>   # Save API token manually (scope unknown; assumed write-capable)
+tw auth token                    # Save API token manually (prompts securely; scope unknown, assumed write-capable)
 tw auth status                   # Verify authentication + show mode
 tw auth status --json            # JSON output: { id, email, name }
 tw auth logout                   # Remove saved token and auth metadata

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -11,7 +11,7 @@ Access Twist messaging via the \`tw\` CLI. Use when the user asks about their Tw
 \`\`\`bash
 tw auth login                    # OAuth login (opens browser, read-write)
 tw auth login --read-only        # OAuth login with read-only scope
-tw auth token <your-api-token>   # Save API token manually (scope unknown; assumed write-capable)
+tw auth token                    # Save API token manually (prompts securely; scope unknown, assumed write-capable)
 tw auth status                   # Verify authentication + show mode
 tw auth status --json            # JSON output: { id, email, name }
 tw auth logout                   # Remove saved token and auth metadata


### PR DESCRIPTION
## Summary
- Remove inline `<your-api-token>` placeholder from `tw auth token` skill example to address Snyk W007 (insecure credential handling) on skills.sh

Mirrors Doist/todoist-cli#183.

## Test plan
- [x] `npm test` — 291 tests passing
- [x] `npm run check:skill-sync` — SKILL.md in sync
- [ ] Verify audit re-runs after merge and scores improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)