### PR TITLE
fix: upgrade Twist SDK for proxy env var support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "2.1.2",
+                "@doist/twist-sdk": "2.1.4",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -292,9 +292,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.1.2.tgz",
-            "integrity": "sha512-Z9TmNgn94pJ39C1bJMqn3uNjR+1okr7oB8MLSVkNCD3/pAhJhy5tNOvC16UmzlyY2BSEGXWPxgnC4DVnYkBNuw==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.1.4.tgz",
+            "integrity": "sha512-UlPcUhBiaL5c4r/lTBlBCLT9B2gn0vQKaKtrEM+P6+BRuTFY6muaZEz81Jkk50K8vSnKrN7dNgWaJn3S/8sa1w==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "CHANGELOG.md"
     ],
     "dependencies": {
-        "@doist/twist-sdk": "2.1.2",
+        "@doist/twist-sdk": "2.1.4",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",


### PR DESCRIPTION
## Summary
- bump `@doist/twist-sdk` from `2.1.2` to `2.1.4`
- refresh `package-lock.json`

## Validation
- `npm run format:check`
- `npm run lint:check`
- `npm test`
- `npm run type-check`