### PR TITLE
feat: add comment edit and delete commands

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -82,11 +82,16 @@ Default `--notify` for reply is EVERYONE_IN_THREAD, which may notify more people
 ## Thread Comments
 
 ```bash
-tw comment edit <comment-ref> "new content"    # Edit a thread comment
-tw comment edit <comment-ref> "content" --json  # Edit and return updated comment as JSON
-tw comment edit <comment-ref> "content" --json --full  # Include all comment fields
-tw comment delete <comment-ref>               # Delete a thread comment
-tw comment delete <comment-ref> --json        # Delete and return status as JSON
+tw comment <comment-ref>                       # View a comment (shorthand for view)
+tw comment view <comment-ref>                  # View a single thread comment
+tw comment view <comment-ref> --raw            # Show raw markdown
+tw comment view <comment-ref> --json           # Output as JSON
+tw comment view <comment-ref> --json --full    # Include all fields in JSON output
+tw comment update <comment-ref> "new content"  # Update a thread comment
+tw comment update <comment-ref> "content" --json  # Update and return updated comment as JSON
+tw comment update <comment-ref> "content" --json --full  # Include all comment fields
+tw comment delete <comment-ref>                # Delete a thread comment
+tw comment delete <comment-ref> --json         # Delete and return status as JSON
 ```
 
 ## Conversations (DMs/Groups)
@@ -219,7 +224,7 @@ Commands accept flexible references:
 
 ## Piping Content
 
-Commands that accept content (`thread create`, `thread reply`, `comment edit`, `conversation reply`, `msg update`) auto-detect piped stdin:
+Commands that accept content (`thread create`, `thread reply`, `comment update`, `conversation reply`, `msg update`) auto-detect piped stdin:
 
 ```bash
 cat notes.md | tw thread reply <ref>

--- a/src/__tests__/comment.test.ts
+++ b/src/__tests__/comment.test.ts
@@ -15,24 +15,40 @@ vi.mock('../lib/input.js', () => ({
     openEditor: vi.fn().mockResolvedValue(''),
 }))
 
+vi.mock('../lib/markdown.js', () => ({
+    renderMarkdown: vi.fn((text: string) => text),
+}))
+
 vi.mock('chalk')
 
 import { registerCommentCommand } from '../commands/comment.js'
 import { readStdin } from '../lib/input.js'
 
+function createCommentFixture(id: number) {
+    return {
+        id,
+        content: `Comment ${id}`,
+        creator: 2,
+        threadId: 500,
+        workspaceId: 10,
+        posted: new Date('2026-03-02T00:00:00.000Z'),
+        reactions: [],
+        url: `https://twist.com/a/10/ch/100/t/500/c/${id}`,
+    }
+}
+
 function createClient() {
     return {
         comments: {
+            getComment: vi.fn(async (id: number) => createCommentFixture(id)),
             updateComment: vi.fn(async (args: { id: number; content: string }) => ({
-                id: args.id,
+                ...createCommentFixture(args.id),
                 content: args.content,
-                creator: 2,
-                threadId: 500,
-                posted: new Date('2026-03-02T00:00:00.000Z'),
-                reactions: [],
-                url: `https://twist.com/a/10/ch/100/t/500/c/${args.id}`,
             })),
             deleteComment: vi.fn(async () => undefined),
+        },
+        workspaceUsers: {
+            getUserById: vi.fn(async () => ({ id: 2, name: 'Bob' })),
         },
     }
 }
@@ -44,18 +60,83 @@ function createProgram() {
     return program
 }
 
-describe('comment edit', () => {
+describe('comment implicit view', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getTwistClient.mockRejectedValue(new Error('MOCK_API_REACHED'))
+    })
+
+    it('tw comment <ref> routes to view (not unknown command)', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await expect(program.parseAsync(['node', 'tw', 'comment', '300'])).rejects.toThrow(
+            'MOCK_API_REACHED',
+        )
+
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('comment view', () => {
     beforeEach(() => {
         vi.clearAllMocks()
     })
 
-    it('edits a comment with positional content', async () => {
+    it('views a comment', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'comment', 'edit', '300', 'Updated content'])
+        await program.parseAsync(['node', 'tw', 'comment', 'view', '300'])
+
+        expect(client.comments.getComment).toHaveBeenCalledWith(300)
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Comment 300'))
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'comment', 'view', '300', '--json'])
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput.id).toBe(300)
+        expect(jsonOutput.content).toBe('Comment 300')
+        consoleSpy.mockRestore()
+    })
+
+    it('includes creatorName in --json --full output', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'comment', 'view', '300', '--json', '--full'])
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput.id).toBe(300)
+        expect(jsonOutput.creatorName).toBe('Bob')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('comment update', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('updates a comment with positional content', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'comment', 'update', '300', 'Updated content'])
 
         expect(client.comments.updateComment).toHaveBeenCalledWith({
             id: 300,
@@ -73,7 +154,7 @@ describe('comment edit', () => {
             'node',
             'tw',
             'comment',
-            'edit',
+            'update',
             '300',
             'New content',
             '--dry-run',
@@ -90,7 +171,7 @@ describe('comment edit', () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'comment', 'edit', '300', 'Updated', '--json'])
+        await program.parseAsync(['node', 'tw', 'comment', 'update', '300', 'Updated', '--json'])
 
         const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
         expect(jsonOutput.id).toBe(300)
@@ -105,7 +186,7 @@ describe('comment edit', () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'comment', 'edit', '300'])
+        await program.parseAsync(['node', 'tw', 'comment', 'update', '300'])
 
         expect(client.comments.updateComment).toHaveBeenCalledWith({
             id: 300,
@@ -122,9 +203,9 @@ describe('comment edit', () => {
             throw new Error('process.exit')
         })
 
-        await expect(program.parseAsync(['node', 'tw', 'comment', 'edit', '300'])).rejects.toThrow(
-            'process.exit',
-        )
+        await expect(
+            program.parseAsync(['node', 'tw', 'comment', 'update', '300']),
+        ).rejects.toThrow('process.exit')
 
         expect(errorSpy).toHaveBeenCalledWith('No content provided.')
         expect(exitSpy).toHaveBeenCalledWith(1)

--- a/src/commands/comment.ts
+++ b/src/commands/comment.ts
@@ -1,18 +1,44 @@
 import { Command } from 'commander'
 import { getTwistClient } from '../lib/api.js'
+import { formatRelativeDate } from '../lib/dates.js'
 import { openEditor, readStdin } from '../lib/input.js'
-import type { MutationOptions } from '../lib/options.js'
-import { formatJson } from '../lib/output.js'
+import { renderMarkdown } from '../lib/markdown.js'
+import type { MutationOptions, ViewOptions } from '../lib/options.js'
+import { colors, formatJson } from '../lib/output.js'
 import { resolveCommentId } from '../lib/refs.js'
 
-type EditOptions = MutationOptions
+type UpdateOptions = MutationOptions
 
 type DeleteOptions = MutationOptions
 
-async function editComment(
+async function viewComment(ref: string, options: ViewOptions): Promise<void> {
+    const commentId = resolveCommentId(ref)
+    const client = await getTwistClient()
+    const comment = await client.comments.getComment(commentId)
+
+    const userResponse = await client.workspaceUsers.getUserById(
+        { workspaceId: comment.workspaceId, userId: comment.creator },
+        { batch: false },
+    )
+    const creatorName = userResponse.name
+
+    if (options.json) {
+        const output = { ...comment, creatorName }
+        console.log(formatJson(output, options.full ? undefined : 'comment', options.full))
+        return
+    }
+
+    const author = colors.author(creatorName)
+    const time = colors.timestamp(formatRelativeDate(comment.posted))
+    console.log(`${author}  ${time}  ${colors.timestamp(`id:${comment.id}`)}`)
+    console.log(options.raw ? comment.content : renderMarkdown(comment.content))
+    console.log('')
+}
+
+async function updateComment(
     ref: string,
     content: string | undefined,
-    options: EditOptions,
+    options: UpdateOptions,
 ): Promise<void> {
     const commentId = resolveCommentId(ref)
 
@@ -71,15 +97,29 @@ async function deleteComment(ref: string, options: DeleteOptions): Promise<void>
 export function registerCommentCommand(program: Command): void {
     const comment = program
         .command('comment')
-        .description('Thread comment operations (edit, delete)')
+        .description('Thread comment operations (view, update, delete)')
 
     comment
-        .command('edit <comment-ref> [content]')
-        .description('Edit a thread comment')
+        .command('view [comment-ref]', { isDefault: true })
+        .description('View a single thread comment')
+        .option('--raw', 'Show raw markdown instead of rendered')
+        .option('--json', 'Output as JSON')
+        .option('--full', 'Include all fields in JSON output')
+        .action((ref, options) => {
+            if (!ref) {
+                comment.help()
+                return
+            }
+            return viewComment(ref, options)
+        })
+
+    comment
+        .command('update <comment-ref> [content]')
+        .description('Update a thread comment')
         .option('--dry-run', 'Show what would be updated without updating')
         .option('--json', 'Output updated comment as JSON')
         .option('--full', 'Include all fields in JSON output')
-        .action(editComment)
+        .action(updateComment)
 
     comment
         .command('delete <comment-ref>')

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
     thread: ['Thread operations', loadThreadCommand],
     conversation: ['Conversation (DM/group) operations', loadConversationCommand],
     msg: ['Conversation message operations (view, update, delete)', loadMsgCommand],
-    comment: ['Thread comment operations (edit, delete)', loadCommentCommand],
+    comment: ['Thread comment operations (view, update, delete)', loadCommentCommand],
     search: ['Search content across a workspace', loadSearchCommand],
     away: ['Manage away status', loadAwayCommand],
     react: ['Add an emoji reaction (target-type: thread, comment, message)', loadReactCommand],

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -81,11 +81,16 @@ Default \`--notify\` for reply is EVERYONE_IN_THREAD, which may notify more peop
 ## Thread Comments
 
 \`\`\`bash
-tw comment edit <comment-ref> "new content"    # Edit a thread comment
-tw comment edit <comment-ref> "content" --json  # Edit and return updated comment as JSON
-tw comment edit <comment-ref> "content" --json --full  # Include all comment fields
-tw comment delete <comment-ref>               # Delete a thread comment
-tw comment delete <comment-ref> --json        # Delete and return status as JSON
+tw comment <comment-ref>                       # View a comment (shorthand for view)
+tw comment view <comment-ref>                  # View a single thread comment
+tw comment view <comment-ref> --raw            # Show raw markdown
+tw comment view <comment-ref> --json           # Output as JSON
+tw comment view <comment-ref> --json --full    # Include all fields in JSON output
+tw comment update <comment-ref> "new content"  # Update a thread comment
+tw comment update <comment-ref> "content" --json  # Update and return updated comment as JSON
+tw comment update <comment-ref> "content" --json --full  # Include all comment fields
+tw comment delete <comment-ref>                # Delete a thread comment
+tw comment delete <comment-ref> --json         # Delete and return status as JSON
 \`\`\`
 
 ## Conversations (DMs/Groups)
@@ -218,7 +223,7 @@ Commands accept flexible references:
 
 ## Piping Content
 
-Commands that accept content (\`thread create\`, \`thread reply\`, \`comment edit\`, \`conversation reply\`, \`msg update\`) auto-detect piped stdin:
+Commands that accept content (\`thread create\`, \`thread reply\`, \`comment update\`, \`conversation reply\`, \`msg update\`) auto-detect piped stdin:
 
 \`\`\`bash
 cat notes.md | tw thread reply <ref>


### PR DESCRIPTION
## Summary
- Adds a new top-level `tw comment` command with `edit` and `delete` subcommands, following the same pattern as `tw msg` for conversation messages
- Clarifies `tw thread reply` notify default in skill content, with agent guidance to confirm notification recipients before posting

## Test plan
- [x] `npm run type-check` passes
- [x] All 299 tests pass (8 new for comment edit/delete)
- [x] `npm run build` clean
- [x] `tw comment --help` shows edit and delete subcommands
- [x] Skill file in sync (`npm run check:skill-sync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)