### PR TITLE
chore: add spinner messages for closeThread/reopenThread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ This is a TypeScript CLI (`tw`) for Twist messaging, built with Commander.js.
 - **Implicit view subcommand**: `tw thread <ref>` defaults to `tw thread view <ref>` via Commander's `{ isDefault: true }`. Same for `conversation` and `msg`. Edge case: if a ref matches a subcommand name (e.g., "reply"), the subcommand wins — user must use `tw thread view reply`
 - **Named flag aliases**: Where commands accept positional `[workspace-ref]`, the `--workspace` flag is also accepted. Error if both positional and flag are provided
 - **JSON output on mutating commands**: Mutating commands (create, update, delete, archive) should support `--json` output where it provides scripting value. Commands that return an object from the API (create/update) should also support `--full`. Commands where the API returns void should output a minimal status object (e.g. `{ id, deleted: true }` or `{ id, isArchived: true }`). Extend `MutationOptions` in `src/lib/options.ts` (which already includes `json` and `full`) rather than adding these fields ad hoc. Use `formatJson()` from `src/lib/output.ts` for the output. See `src/commands/away.ts` as the reference implementation.
+- **Spinner messages**: When adding new SDK method calls, add a corresponding entry in the `API_SPINNER_MESSAGES` map in `src/lib/api.ts`. Every user-facing API call should have a spinner message so the CLI shows progress feedback.
 
 ## Pre-commit Hooks
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,6 +22,8 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         'threads.getThread': { text: 'Loading thread...', color: 'blue' },
         'threads.getUnread': { text: 'Loading unread threads...', color: 'blue' },
         'threads.createThread': { text: 'Creating thread...', color: 'green' },
+        'threads.closeThread': { text: 'Closing thread...', color: 'yellow' },
+        'threads.reopenThread': { text: 'Reopening thread...', color: 'yellow' },
         'threads.muteThread': { text: 'Muting thread...', color: 'yellow' },
         'threads.unmuteThread': { text: 'Unmuting thread...', color: 'yellow' },
 


### PR DESCRIPTION
## Summary

- Add missing spinner messages for `threads.closeThread` and `threads.reopenThread` in `API_SPINNER_MESSAGES`
- Document the spinner message pattern in AGENTS.md so future API method additions don't miss this step

## Test plan

- [x] All 321 tests pass
- [x] Type-check passes
- [ ] Manual: verify spinner shows when closing/reopening a thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)