### PR TITLE
fix: use Node 22 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version: '22'
           cache: npm
           scope: '@doist'
           registry-url: 'https://registry.npmjs.org/'


### PR DESCRIPTION
## Summary
semantic-release 25.x requires Node `^22.14.0 || >= 24.10.0`. The release workflow was using `.nvmrc` (Node 20), causing the release step to fail.

## Changes
- Use `node-version: '22'` instead of `node-version-file: .nvmrc` in the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)