### PR TITLE
fix: suppress credential manager warning on every command

### DIFF
--- a/src/__tests__/lib/auth.test.ts
+++ b/src/__tests__/lib/auth.test.ts
@@ -198,7 +198,7 @@ describe('auth token storage', () => {
         })
     })
 
-    it('reads from plaintext config with a warning when the secure store is unavailable', async () => {
+    it('reads from plaintext config silently when the secure store is unavailable', async () => {
         mocks.secureTokenStore.setSecret.mockRejectedValue(
             new mocks.MockSecureStoreUnavailableError('No keychain access'),
         )
@@ -208,9 +208,7 @@ describe('auth token storage', () => {
         const { getApiToken } = await import('../../lib/auth.js')
 
         await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(errorSpy).toHaveBeenCalledWith(
-            'Warning: system credential manager unavailable; using plaintext token from /home/user/.config/twist-cli/config.json',
-        )
+        expect(errorSpy).not.toHaveBeenCalled()
 
         errorSpy.mockRestore()
     })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -47,9 +47,7 @@ export async function getApiToken(): Promise<string> {
                 warn(cleanupWarning)
             }
         } catch (error) {
-            if (error instanceof SecureStoreUnavailableError) {
-                warnSecureStoreFallback('using plaintext token from')
-            } else {
+            if (!(error instanceof SecureStoreUnavailableError)) {
                 throw error
             }
         }
@@ -242,8 +240,4 @@ function isMissingFileError(error: unknown): boolean {
 
 function warn(message: string): void {
     console.error(`Warning: ${message}`)
-}
-
-function warnSecureStoreFallback(action: string): void {
-    warn(buildFallbackWarning(action))
 }


### PR DESCRIPTION
## Summary
- Removed the "system credential manager unavailable; using plaintext token from ..." warning that was printed to stderr on every command invocation when the secure store isn't available
- Users whose token is working fine via the config file fallback will no longer see alarming warnings on every single command
- The one-time warning at token save time (`login`/`token set`) is preserved so users are still informed when their token falls back to plaintext storage

## Test plan
- [x] Verified all 321 tests pass
- [x] Updated the test that previously asserted the warning was printed to instead assert `errorSpy.not.toHaveBeenCalled()`
- [ ] Manual: run `tw` commands in an environment without a system credential manager and confirm no warning on each invocation
- [ ] Manual: run `tw auth token <token>` in the same environment and confirm the one-time fallback warning still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)