### PR TITLE
build(deps): replace marked-terminal with marked-terminal-renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
-                "marked": "15.0.12",
-                "marked-terminal": "7.3.0",
+                "marked": "18.0.0",
+                "marked-terminal-renderer": "2.2.0",
                 "open": "11.0.0",
                 "yocto-spinner": "1.1.0"
             },
@@ -114,6 +114,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@borewit/text-codec": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+            "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/@colors/colors": {
@@ -584,11 +594,585 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@jimp/core": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.1.tgz",
+            "integrity": "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/file-ops": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "await-to-js": "^3.0.0",
+                "exif-parser": "^0.1.12",
+                "file-type": "^21.3.3",
+                "mime": "3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/core/node_modules/mime": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@jimp/diff": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.1.tgz",
+            "integrity": "sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/plugin-resize": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "pixelmatch": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/file-ops": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.1.tgz",
+            "integrity": "sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/js-bmp": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.1.tgz",
+            "integrity": "sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "bmp-ts": "^1.0.9"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/js-gif": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.1.tgz",
+            "integrity": "sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "gifwrap": "^0.10.1",
+                "omggif": "^1.0.10"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/js-jpeg": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.1.tgz",
+            "integrity": "sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "jpeg-js": "^0.4.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/js-png": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.1.tgz",
+            "integrity": "sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "pngjs": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/js-tiff": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.1.tgz",
+            "integrity": "sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "utif2": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-blit": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.1.tgz",
+            "integrity": "sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-blit/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-blur": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.1.tgz",
+            "integrity": "sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/utils": "1.6.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-circle": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.1.tgz",
+            "integrity": "sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-circle/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-color": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.1.tgz",
+            "integrity": "sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "tinycolor2": "^1.6.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-color/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-contain": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.1.tgz",
+            "integrity": "sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/plugin-blit": "1.6.1",
+                "@jimp/plugin-resize": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-contain/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-cover": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.1.tgz",
+            "integrity": "sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/plugin-crop": "1.6.1",
+                "@jimp/plugin-resize": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-cover/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-crop": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.1.tgz",
+            "integrity": "sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-crop/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-displace": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.1.tgz",
+            "integrity": "sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-displace/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-dither": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.1.tgz",
+            "integrity": "sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-fisheye": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.1.tgz",
+            "integrity": "sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-fisheye/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-flip": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.1.tgz",
+            "integrity": "sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-flip/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-hash": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.1.tgz",
+            "integrity": "sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/js-bmp": "1.6.1",
+                "@jimp/js-jpeg": "1.6.1",
+                "@jimp/js-png": "1.6.1",
+                "@jimp/js-tiff": "1.6.1",
+                "@jimp/plugin-color": "1.6.1",
+                "@jimp/plugin-resize": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "any-base": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-mask": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.1.tgz",
+            "integrity": "sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-mask/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-print": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.1.tgz",
+            "integrity": "sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/js-jpeg": "1.6.1",
+                "@jimp/js-png": "1.6.1",
+                "@jimp/plugin-blit": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "parse-bmfont-ascii": "^1.0.6",
+                "parse-bmfont-binary": "^1.0.6",
+                "parse-bmfont-xml": "^1.1.6",
+                "simple-xml-to-json": "^1.2.2",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-print/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-quantize": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.1.tgz",
+            "integrity": "sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==",
+            "license": "MIT",
+            "dependencies": {
+                "image-q": "^4.0.0",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-quantize/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-resize": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.1.tgz",
+            "integrity": "sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-resize/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-rotate": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.1.tgz",
+            "integrity": "sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/plugin-crop": "1.6.1",
+                "@jimp/plugin-resize": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-rotate/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/plugin-threshold": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.1.tgz",
+            "integrity": "sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/plugin-color": "1.6.1",
+                "@jimp/plugin-hash": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1",
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/plugin-threshold/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/types": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.1.tgz",
+            "integrity": "sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==",
+            "license": "MIT",
+            "dependencies": {
+                "zod": "^3.23.8"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jimp/types/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/@jimp/utils": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.1.tgz",
+            "integrity": "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/types": "1.6.1",
+                "tinycolor2": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@keyv/serialize": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
             "license": "MIT"
         },
         "node_modules/@napi-rs/keyring": {
@@ -2027,7 +2611,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
             "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@semantic-release/changelog": {
@@ -2730,12 +3313,12 @@
             }
         },
         "node_modules/@sindresorhus/is": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+            "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
             "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -2761,6 +3344,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@tokenizer/inflate": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+            "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "token-types": "^6.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+            "license": "MIT"
+        },
         "node_modules/@types/chai": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2784,6 +3390,12 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -2916,6 +3528,15 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2940,6 +3561,44 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ansi-align": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.1.0"
+            }
+        },
+        "node_modules/ansi-align/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -2950,9 +3609,9 @@
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-            "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+            "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
             "license": "MIT",
             "dependencies": {
                 "environment": "^1.0.0"
@@ -2977,25 +3636,43 @@
             }
         },
         "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/any-base": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+            "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+            "license": "MIT"
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
             "license": "MIT"
+        },
+        "node_modules/app-path": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/app-path/-/app-path-4.0.0.tgz",
+            "integrity": "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA==",
+            "license": "MIT",
+            "dependencies": {
+                "execa": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -3028,6 +3705,35 @@
                 "node": ">=12"
             }
         },
+        "node_modules/await-to-js": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+            "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/before-after-hook": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -3035,12 +3741,52 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/bmp-ts": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+            "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+            "license": "MIT"
+        },
         "node_modules/bottleneck": {
             "version": "2.19.5",
             "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
             "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/boxen": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+            "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^3.0.1",
+                "camelcase": "^8.0.0",
+                "chalk": "^5.3.0",
+                "cli-boxes": "^3.0.0",
+                "string-width": "^7.2.0",
+                "type-fest": "^4.21.0",
+                "widest-line": "^5.0.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/braces": {
             "version": "3.0.3",
@@ -3065,6 +3811,85 @@
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/byte-counter": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+            "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cacheable-lookup": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/cacheable-request": {
+            "version": "13.0.18",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.18.tgz",
+            "integrity": "sha512-rFWadDRKJs3s2eYdXlGggnBZKG7MTblkFBB0YllFds+UYnfogDp2wcR6JN97FhRkHTvq59n2vhNoHNZn29dh/Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/http-cache-semantics": "^4.0.4",
+                "get-stream": "^9.0.1",
+                "http-cache-semantics": "^4.2.0",
+                "keyv": "^5.5.5",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.1.1",
+                "responselike": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/cacheable-request/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cacheable-request/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cacheable-request/node_modules/normalize-url": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+            "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3133,6 +3958,33 @@
                 "node": ">=6"
             }
         },
+        "node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/cli-highlight": {
             "version": "2.1.11",
             "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
@@ -3154,6 +4006,21 @@
                 "npm": ">=5.0.0"
             }
         },
+        "node_modules/cli-highlight/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/cli-highlight/node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3168,6 +4035,27 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-highlight/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/cli-table3": {
@@ -3185,6 +4073,35 @@
                 "@colors/colors": "1.5.0"
             }
         },
+        "node_modules/cli-table3/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -3194,6 +4111,67 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
         "node_modules/color-convert": {
@@ -3374,7 +4352,6 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -3429,6 +4406,21 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/decompress-response": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+            "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-response": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/deep-extend": {
@@ -3518,9 +4510,9 @@
             }
         },
         "node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "license": "MIT"
         },
         "node_modules/emojilib": {
@@ -3817,7 +4809,6 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
@@ -3841,7 +4832,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -3849,6 +4839,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/exif-parser": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+            "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
         },
         "node_modules/expect-type": {
             "version": "1.3.0",
@@ -3911,6 +4906,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/file-type": {
+            "version": "21.3.4",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+            "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/inflate": "^0.4.1",
+                "strtok3": "^10.3.4",
+                "token-types": "^6.1.1",
+                "uint8array-extras": "^1.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3952,6 +4965,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/form-data-encoder": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+            "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/from2": {
@@ -4018,10 +5040,9 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-            "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-            "dev": true,
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+            "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -4041,6 +5062,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/gifwrap": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+            "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+            "license": "MIT",
+            "dependencies": {
+                "image-q": "^4.0.0",
+                "omggif": "^1.0.10"
             }
         },
         "node_modules/git-log-parser": {
@@ -4066,6 +5097,44 @@
             "license": "ISC",
             "dependencies": {
                 "through2": "~2.0.0"
+            }
+        },
+        "node_modules/got": {
+            "version": "14.6.6",
+            "resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+            "integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/is": "^7.0.1",
+                "byte-counter": "^0.1.0",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^13.0.12",
+                "decompress-response": "^10.0.0",
+                "form-data-encoder": "^4.0.2",
+                "http2-wrapper": "^2.2.1",
+                "keyv": "^5.5.3",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^4.0.1",
+                "responselike": "^4.0.2",
+                "type-fest": "^4.26.1"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "node_modules/got/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/graceful-fs": {
@@ -4098,12 +5167,15 @@
             }
         },
         "node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+            "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/highlight.js": {
@@ -4141,6 +5213,12 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4153,6 +5231,19 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/http2-wrapper": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -4173,11 +5264,60 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10.17.0"
             }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/image-dimensions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/image-dimensions/-/image-dimensions-2.5.0.tgz",
+            "integrity": "sha512-CKZPHjAEtSg9lBV9eER0bhNn/yrY7cFEQEhkwjLhqLY+Na8lcP1pEyWsaGMGc8t2qbKWA/tuqbhFQpOKGN72Yw==",
+            "license": "MIT",
+            "bin": {
+                "image-dimensions": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/image-q": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+            "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "16.9.1"
+            }
+        },
+        "node_modules/image-q/node_modules/@types/node": {
+            "version": "16.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
@@ -4308,12 +5448,18 @@
             }
         },
         "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+            "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
             "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.1"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-in-ssh": {
@@ -4383,7 +5529,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4431,7 +5576,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/issue-parser": {
@@ -4451,6 +5595,22 @@
                 "node": "^18.17 || >=20.6.1"
             }
         },
+        "node_modules/iterm2-version": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/iterm2-version/-/iterm2-version-5.0.0.tgz",
+            "integrity": "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg==",
+            "license": "MIT",
+            "dependencies": {
+                "app-path": "^4.0.0",
+                "plist": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/java-properties": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -4460,6 +5620,50 @@
             "engines": {
                 "node": ">= 0.6.0"
             }
+        },
+        "node_modules/jimp": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
+            "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
+            "license": "MIT",
+            "dependencies": {
+                "@jimp/core": "1.6.1",
+                "@jimp/diff": "1.6.1",
+                "@jimp/js-bmp": "1.6.1",
+                "@jimp/js-gif": "1.6.1",
+                "@jimp/js-jpeg": "1.6.1",
+                "@jimp/js-png": "1.6.1",
+                "@jimp/js-tiff": "1.6.1",
+                "@jimp/plugin-blit": "1.6.1",
+                "@jimp/plugin-blur": "1.6.1",
+                "@jimp/plugin-circle": "1.6.1",
+                "@jimp/plugin-color": "1.6.1",
+                "@jimp/plugin-contain": "1.6.1",
+                "@jimp/plugin-cover": "1.6.1",
+                "@jimp/plugin-crop": "1.6.1",
+                "@jimp/plugin-displace": "1.6.1",
+                "@jimp/plugin-dither": "1.6.1",
+                "@jimp/plugin-fisheye": "1.6.1",
+                "@jimp/plugin-flip": "1.6.1",
+                "@jimp/plugin-hash": "1.6.1",
+                "@jimp/plugin-mask": "1.6.1",
+                "@jimp/plugin-print": "1.6.1",
+                "@jimp/plugin-quantize": "1.6.1",
+                "@jimp/plugin-resize": "1.6.1",
+                "@jimp/plugin-rotate": "1.6.1",
+                "@jimp/plugin-threshold": "1.6.1",
+                "@jimp/types": "1.6.1",
+                "@jimp/utils": "1.6.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jpeg-js": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+            "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -4506,6 +5710,15 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/keyv": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+            "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+            "license": "MIT",
+            "dependencies": {
+                "@keyv/serialize": "^1.1.1"
             }
         },
         "node_modules/lefthook": {
@@ -4757,6 +5970,86 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/log-update": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-8.0.0.tgz",
+            "integrity": "sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.3.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^9.0.0",
+                "string-width": "^8.2.0",
+                "strip-ansi": "^7.2.0",
+                "wrap-ansi": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/string-width": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+            "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/log-update/node_modules/wrap-ansi": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+            "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.3",
+                "string-width": "^8.2.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/lowercase-keys": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "11.2.4",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
@@ -4809,36 +6102,35 @@
             }
         },
         "node_modules/marked": {
-            "version": "15.0.12",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+            "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
             },
             "engines": {
-                "node": ">= 18"
+                "node": ">= 20"
             }
         },
-        "node_modules/marked-terminal": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
-            "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+        "node_modules/marked-terminal-renderer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal-renderer/-/marked-terminal-renderer-2.2.0.tgz",
+            "integrity": "sha512-cUDuyNl4CyI3atFoDtxKL+zDsJAnLo/+1ETfJd8UvFVYRAltCbcPPa1UVEuS//N/85ZoGZFfqWyeRqyjXR37Wg==",
             "license": "MIT",
             "dependencies": {
-                "ansi-escapes": "^7.0.0",
-                "ansi-regex": "^6.1.0",
-                "chalk": "^5.4.1",
+                "ansi-regex": "^6.2.2",
+                "boxen": "^8.0.1",
+                "chalk": "^5.6.2",
                 "cli-highlight": "^2.1.11",
                 "cli-table3": "^0.6.5",
+                "got": "^14.6.5",
                 "node-emoji": "^2.2.0",
-                "supports-hyperlinks": "^3.1.0"
+                "terminal-image": "^4.1.0",
+                "terminal-link": "^5.0.0"
             },
-            "engines": {
-                "node": ">=16.0.0"
-            },
-            "peerDependencies": {
-                "marked": ">=1 <16"
+            "bin": {
+                "catmd": "catmd.mjs"
             }
         },
         "node_modules/meow": {
@@ -4858,7 +6150,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/micromatch": {
@@ -4908,10 +6199,33 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mimic-response": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimist": {
@@ -4986,6 +6300,18 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/node-emoji/node_modules/@sindresorhus/is": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
         },
         "node_modules/normalize-package-data": {
@@ -5175,7 +6501,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
             "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.0.0"
@@ -6965,11 +8290,16 @@
             ],
             "license": "MIT"
         },
+        "node_modules/omggif": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+            "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+            "license": "MIT"
+        },
         "node_modules/onetime": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mimic-fn": "^2.1.0"
@@ -7086,6 +8416,15 @@
                 }
             }
         },
+        "node_modules/p-cancelable": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+            "integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
         "node_modules/p-each-series": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -7177,6 +8516,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7188,6 +8533,28 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/parse-bmfont-ascii": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+            "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+            "license": "MIT"
+        },
+        "node_modules/parse-bmfont-binary": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+            "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+            "license": "MIT"
+        },
+        "node_modules/parse-bmfont-xml": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+            "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+            "license": "MIT",
+            "dependencies": {
+                "xml-parse-from-string": "^1.0.0",
+                "xml2js": "^0.5.0"
             }
         },
         "node_modules/parse-json": {
@@ -7247,7 +8614,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -7298,6 +8664,27 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pixelmatch": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+            "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+            "license": "ISC",
+            "dependencies": {
+                "pngjs": "^6.0.0"
+            },
+            "bin": {
+                "pixelmatch": "bin/pixelmatch"
+            }
+        },
+        "node_modules/pixelmatch/node_modules/pngjs": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+            "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.13.0"
             }
         },
         "node_modules/pkg-conf": {
@@ -7387,6 +8774,29 @@
                 "node": ">=4"
             }
         },
+        "node_modules/plist": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+            "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.8.8",
+                "base64-js": "^1.5.1",
+                "xmlbuilder": "^15.1.1"
+            },
+            "engines": {
+                "node": ">=10.4.0"
+            }
+        },
+        "node_modules/pngjs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+            "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.19.0"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -7457,6 +8867,18 @@
             "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/rc": {
             "version": "1.2.8",
@@ -7581,6 +9003,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "license": "MIT"
+        },
         "node_modules/resolve-from": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7589,6 +9017,64 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/responselike": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+            "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
+            "license": "MIT",
+            "dependencies": {
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor/node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/restore-cursor/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/rollup": {
@@ -7654,6 +9140,15 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/semantic-release": {
             "version": "25.0.3",
@@ -7725,19 +9220,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/semantic-release/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/semantic-release/node_modules/clean-stack": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
@@ -7768,13 +9250,6 @@
             "engines": {
                 "node": ">=20"
             }
-        },
-        "node_modules/semantic-release/node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/semantic-release/node_modules/execa": {
             "version": "9.6.1",
@@ -7833,6 +9308,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/semantic-release/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/semantic-release/node_modules/human-signals": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -7867,6 +9352,41 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/marked": {
+            "version": "15.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+            "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/semantic-release/node_modules/marked-terminal": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+            "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "ansi-regex": "^6.1.0",
+                "chalk": "^5.4.1",
+                "cli-highlight": "^2.1.11",
+                "cli-table3": "^0.6.5",
+                "node-emoji": "^2.2.0",
+                "supports-hyperlinks": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "marked": ">=1 <16"
             }
         },
         "node_modules/semantic-release/node_modules/npm-run-path": {
@@ -7925,24 +9445,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/semantic-release/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/semantic-release/node_modules/strip-ansi": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
@@ -7972,22 +9474,34 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/semantic-release/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+        "node_modules/semantic-release/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
+                "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=8"
+            }
+        },
+        "node_modules/semantic-release/node_modules/supports-hyperlinks": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
             },
             "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
             }
         },
         "node_modules/semantic-release/node_modules/yargs": {
@@ -8048,7 +9562,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -8061,7 +9574,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -8078,7 +9590,6 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/signale": {
@@ -8187,6 +9698,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/simple-xml-to-json": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+            "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.12.2"
+            }
+        },
         "node_modules/skin-tone": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -8197,6 +9717,22 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/slice-ansi": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+            "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.3",
+                "is-fullwidth-code-point": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/source-map": {
@@ -8298,17 +9834,35 @@
             }
         },
         "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/strip-ansi": {
@@ -8346,7 +9900,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -8360,6 +9913,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/strtok3": {
+            "version": "10.3.5",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+            "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+            "license": "MIT",
+            "dependencies": {
+                "@tokenizer/token": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/super-regex": {
@@ -8381,31 +9950,43 @@
             }
         },
         "node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
             "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/supports-hyperlinks": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+            "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
             "license": "MIT",
             "dependencies": {
-                "has-flag": "^4.0.0",
-                "supports-color": "^7.0.0"
+                "has-flag": "^5.0.1",
+                "supports-color": "^10.2.2"
             },
             "engines": {
-                "node": ">=14.18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+            }
+        },
+        "node_modules/supports-terminal-graphics": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/supports-terminal-graphics/-/supports-terminal-graphics-0.1.0.tgz",
+            "integrity": "sha512-+KdfozhS0Fw8y5Sghw8kkZNGT8nWYzJ1EzcoIvVjxhl+26TJTs26y02yfBgvc1jh5AS/c8jcI3xtahhR95KRyQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tagged-tag": {
@@ -8475,6 +10056,59 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/term-img": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/term-img/-/term-img-7.1.0.tgz",
+            "integrity": "sha512-au++khgSDly2KXNhC6BOU3mLi2v+Dk5mChYKDcpB5xYwhlwqYQtj0z59dIqFEmr+w7ndZaNqurHapkGc6/hprQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.1.1",
+                "iterm2-version": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-image": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/terminal-image/-/terminal-image-4.3.0.tgz",
+            "integrity": "sha512-P4bCi7Ich17LgN/P2zM9sYbeleYNgu1Skk3q/uc15Ol9zWSiCldrCcIJ1Pd6dpgRGDmWhGVTgWHjV+ZMk1m/5g==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.6.2",
+                "image-dimensions": "^2.5.0",
+                "jimp": "^1.6.1",
+                "log-update": "^8.0.0",
+                "omggif": "^1.0.10",
+                "supports-terminal-graphics": "^0.1.0",
+                "term-img": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terminal-link": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-5.0.0.tgz",
+            "integrity": "sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "supports-hyperlinks": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/thenify": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -8528,6 +10162,12 @@
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
             "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinycolor2": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+            "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
             "license": "MIT"
         },
         "node_modules/tinyexec": {
@@ -8588,6 +10228,24 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/token-types": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+            "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@borewit/text-codec": "^0.2.1",
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/traverse": {
@@ -8663,6 +10321,18 @@
             },
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/uint8array-extras": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+            "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/undici": {
@@ -8753,6 +10423,15 @@
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
+        },
+        "node_modules/utif2": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+            "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.11"
             }
         },
         "node_modules/util-deprecate": {
@@ -8962,7 +10641,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -8991,6 +10669,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/widest-line": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+            "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -8999,20 +10692,35 @@
             "license": "MIT"
         },
         "node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/wsl-utils": {
@@ -9029,6 +10737,43 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/xml-parse-from-string": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+            "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+            "license": "MIT"
+        },
+        "node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xml2js/node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/xtend": {
@@ -9075,6 +10820,35 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "license": "MIT"
+        },
+        "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yocto-spinner": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",
-        "marked": "15.0.12",
-        "marked-terminal": "7.3.0",
+        "marked": "18.0.0",
+        "marked-terminal-renderer": "2.2.0",
         "open": "11.0.0",
         "yocto-spinner": "1.1.0"
     },

--- a/src/__tests__/comment.test.ts
+++ b/src/__tests__/comment.test.ts
@@ -16,7 +16,7 @@ vi.mock('../lib/input.js', () => ({
 }))
 
 vi.mock('../lib/markdown.js', () => ({
-    renderMarkdown: vi.fn((text: string) => text),
+    renderMarkdown: vi.fn((text: string) => Promise.resolve(text)),
 }))
 
 vi.mock('chalk')

--- a/src/__tests__/conversation.test.ts
+++ b/src/__tests__/conversation.test.ts
@@ -19,7 +19,7 @@ vi.mock('../lib/api.js', () => apiMocks)
 vi.mock('../lib/refs.js', () => refsMocks)
 
 vi.mock('../lib/markdown.js', () => ({
-    renderMarkdown: vi.fn((text: string) => text),
+    renderMarkdown: vi.fn((text: string) => Promise.resolve(text)),
 }))
 
 vi.mock('chalk')

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { renderMarkdown } from '../lib/markdown.js'
+
+describe('markdown', () => {
+    it('renders markdown via marked-terminal-renderer', async () => {
+        const result = await renderMarkdown('# Heading\n\n**bold** and *italic*')
+        // Pretty-printed output should differ from the raw input — proves the
+        // marked-terminal-renderer extension is wired up and parsing.
+        expect(result).not.toBe('# Heading\n\n**bold** and *italic*')
+        expect(result).toContain('Heading')
+        expect(result).toContain('bold')
+        expect(result).toContain('italic')
+        // Markdown syntax characters should be consumed by the renderer.
+        expect(result).not.toContain('#')
+        expect(result).not.toContain('**')
+    })
+
+    it('renders unordered lists with bullets', async () => {
+        const result = await renderMarkdown('- one\n- two\n- three')
+        expect(result).toContain('one')
+        expect(result).toContain('two')
+        expect(result).toContain('three')
+        // marked-terminal-renderer's default dark-theme list character.
+        expect(result).toContain('•')
+    })
+
+    it('preprocesses twist-mention links into @mentions', async () => {
+        const result = await renderMarkdown('hello [Alice](twist-mention://12345)')
+        // The preprocessor turns [Name](twist-mention://N) into
+        // [@Name](twist-mention://N), and the renderer keeps the @ in the
+        // visible link text.
+        expect(result).toContain('@Alice')
+    })
+
+    it('is idempotent across multiple calls', async () => {
+        const a = await renderMarkdown('**hello**')
+        const b = await renderMarkdown('**hello**')
+        expect(a).toBe(b)
+    })
+})

--- a/src/__tests__/msg.test.ts
+++ b/src/__tests__/msg.test.ts
@@ -10,7 +10,7 @@ vi.mock('../lib/refs.js', () => ({
 }))
 
 vi.mock('../lib/markdown.js', () => ({
-    renderMarkdown: vi.fn((text: string) => text),
+    renderMarkdown: vi.fn((text: string) => Promise.resolve(text)),
 }))
 
 vi.mock('chalk')

--- a/src/__tests__/thread.test.ts
+++ b/src/__tests__/thread.test.ts
@@ -22,7 +22,7 @@ vi.mock('../lib/api.js', async (importOriginal) => ({
 }))
 
 vi.mock('../lib/markdown.js', () => ({
-    renderMarkdown: vi.fn((text: string) => text),
+    renderMarkdown: vi.fn((text: string) => Promise.resolve(text)),
 }))
 
 vi.mock('../lib/input.js', () => ({

--- a/src/commands/comment/view.ts
+++ b/src/commands/comment/view.ts
@@ -25,6 +25,6 @@ export async function viewComment(ref: string, options: ViewOptions): Promise<vo
     const author = colors.author(creatorName)
     const time = colors.timestamp(formatRelativeDate(comment.posted))
     console.log(`${author}  ${time}  ${colors.timestamp(`id:${comment.id}`)}`)
-    console.log(options.raw ? comment.content : renderMarkdown(comment.content))
+    console.log(options.raw ? comment.content : await renderMarkdown(comment.content))
     console.log('')
 }

--- a/src/commands/conversation/helpers.ts
+++ b/src/commands/conversation/helpers.ts
@@ -204,7 +204,7 @@ export async function listConversationsWithUser(
             `  ${colors.timestamp(`id:${conversation.id}`)}  ${colors.author(participants)}`,
         )
         if (options.snippet && conversation.snippet) {
-            console.log(renderMarkdown(conversation.snippet))
+            console.log(await renderMarkdown(conversation.snippet))
         }
         console.log(`  ${colors.timestamp(formatRelativeDate(conversation.lastActive))}`)
         console.log(`  ${colors.url(conversation.url)}`)

--- a/src/commands/conversation/view.ts
+++ b/src/commands/conversation/view.ts
@@ -84,7 +84,7 @@ export async function viewConversation(
         const author = colors.author(userMap.get(message.creator) || `user:${message.creator}`)
         const time = colors.timestamp(formatRelativeDate(message.posted))
         console.log(`${author}  ${time}  ${colors.timestamp(`id:${message.id}`)}`)
-        console.log(options.raw ? message.content : renderMarkdown(message.content))
+        console.log(options.raw ? message.content : await renderMarkdown(message.content))
         console.log('')
     }
 }

--- a/src/commands/msg/view.ts
+++ b/src/commands/msg/view.ts
@@ -31,6 +31,6 @@ export async function viewMessage(ref: string, options: ViewOptions): Promise<vo
     const author = colors.author(creatorName)
     const time = colors.timestamp(formatRelativeDate(message.posted))
     console.log(`${author}  ${time}  ${colors.timestamp(`id:${message.id}`)}`)
-    console.log(options.raw ? message.content : renderMarkdown(message.content))
+    console.log(options.raw ? message.content : await renderMarkdown(message.content))
     console.log('')
 }

--- a/src/commands/thread/helpers.ts
+++ b/src/commands/thread/helpers.ts
@@ -28,15 +28,15 @@ export interface CommentLike {
     content: string
 }
 
-export function printComment(
+export async function printComment(
     comment: CommentLike,
     userMap: Map<number, string>,
     raw: boolean,
-): void {
+): Promise<void> {
     const author = colors.author(userMap.get(comment.creator) || `user:${comment.creator}`)
     const time = colors.timestamp(formatRelativeDate(comment.posted))
     console.log(`${author}  ${time}  ${colors.timestamp(`id:${comment.id}`)}`)
-    console.log(raw ? comment.content : renderMarkdown(comment.content))
+    console.log(raw ? comment.content : await renderMarkdown(comment.content))
     console.log('')
 }
 

--- a/src/commands/thread/view.ts
+++ b/src/commands/thread/view.ts
@@ -71,7 +71,7 @@ async function viewSingleComment(
     console.log(chalk.bold(thread.title))
     console.log(colors.channel(`[${channel.name}]`))
     console.log('')
-    printComment(comment, userMap, options.raw ?? false)
+    await printComment(comment, userMap, options.raw ?? false)
 }
 
 export async function viewThread(ref: string, options: ViewOptions): Promise<void> {
@@ -198,7 +198,7 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
             `${colors.author(creatorName)}  ${colors.timestamp(formatRelativeDate(thread.posted))}  ${chalk.dim('(original post)')}`,
         )
         console.log('')
-        console.log(options.raw ? thread.content : renderMarkdown(thread.content))
+        console.log(options.raw ? thread.content : await renderMarkdown(thread.content))
 
         if (!hasUnread) {
             console.log('')
@@ -215,7 +215,7 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
                 console.log('')
             }
             for (const comment of contextComments) {
-                printComment(comment, userMap, options.raw ?? false)
+                await printComment(comment, userMap, options.raw ?? false)
             }
         } else if (lastReadObjIndex > 0) {
             printSeparator(`${lastReadObjIndex} ${pluralize(lastReadObjIndex, 'comment')} skipped`)
@@ -224,7 +224,7 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
         printSeparator(`UNREAD (${displayComments.length} new)`)
 
         for (const comment of displayComments) {
-            printComment(comment, userMap, options.raw ?? false)
+            await printComment(comment, userMap, options.raw ?? false)
         }
     } else {
         const creatorName = userMap.get(thread.creator) || `user:${thread.creator}`
@@ -232,7 +232,7 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
             `${colors.author(creatorName)}  ${colors.timestamp(formatRelativeDate(thread.posted))}`,
         )
         console.log('')
-        console.log(options.raw ? thread.content : renderMarkdown(thread.content))
+        console.log(options.raw ? thread.content : await renderMarkdown(thread.content))
         console.log('')
 
         if (comments.length > 0) {
@@ -242,7 +242,7 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
             console.log('')
 
             for (const comment of comments) {
-                printComment(comment, userMap, options.raw ?? false)
+                await printComment(comment, userMap, options.raw ?? false)
             }
         }
     }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,18 +1,23 @@
-import { type MarkedExtension, marked } from 'marked'
-import { markedTerminal } from 'marked-terminal'
+import { Marked } from 'marked'
+import { createTerminalRenderer, darkTheme } from 'marked-terminal-renderer'
 
-let initialized = false
+let markedInstance: Marked | null = null
+
+function getMarkedInstance(): Marked {
+    if (!markedInstance) {
+        const instance = new Marked()
+        instance.use(createTerminalRenderer(darkTheme()))
+        markedInstance = instance
+    }
+    return markedInstance
+}
 
 function preprocessMentions(content: string): string {
     return content.replace(/\[([^\]]+)\]\((twist-mention:\/\/\d+)\)/g, '[@$1]($2)')
 }
 
-export function renderMarkdown(content: string): string {
-    if (!initialized) {
-        marked.use(markedTerminal() as unknown as MarkedExtension)
-        initialized = true
-    }
+export async function renderMarkdown(content: string): Promise<string> {
     const processed = preprocessMentions(content)
-    const rendered = marked.parse(processed, { async: false }) as string
-    return rendered.trimEnd()
+    const rendered = await getMarkedInstance().parse(processed)
+    return typeof rendered === 'string' ? rendered.trimEnd() : processed
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -19,5 +19,5 @@ function preprocessMentions(content: string): string {
 export async function renderMarkdown(content: string): Promise<string> {
     const processed = preprocessMentions(content)
     const rendered = await getMarkedInstance().parse(processed)
-    return typeof rendered === 'string' ? rendered.trimEnd() : processed
+    return rendered.trimEnd()
 }

--- a/src/types/marked-terminal-renderer.d.ts
+++ b/src/types/marked-terminal-renderer.d.ts
@@ -1,0 +1,16 @@
+// The marked-terminal-renderer package ships type declarations in
+// renderer.d.mts but doesn't expose them via its `exports` map, so TS's
+// NodeNext resolution can't find them. This ambient declaration restates
+// just the surface we use in src/lib/markdown.ts so the integration is
+// type-checked rather than cast through `unknown`.
+declare module 'marked-terminal-renderer' {
+    import type { MarkedExtension } from 'marked'
+
+    export interface TerminalRendererOptions {
+        [key: string]: unknown
+    }
+
+    export function darkTheme(options?: Partial<TerminalRendererOptions>): TerminalRendererOptions
+
+    export function createTerminalRenderer(opts: TerminalRendererOptions): MarkedExtension
+}

--- a/src/types/marked-terminal.d.ts
+++ b/src/types/marked-terminal.d.ts
@@ -1,4 +1,0 @@
-declare module 'marked-terminal' {
-    import type { MarkedExtension } from 'marked'
-    export function markedTerminal(options?: object): MarkedExtension
-}


### PR DESCRIPTION
## Summary

Mirrors Doist/todoist-cli#261. Replaces the unmaintained \`marked-terminal\` (last release Jan 2025, pins \`marked\` peer at \`<16\`) with [\`marked-terminal-renderer\`](https://www.npmjs.com/package/marked-terminal-renderer), which declares no \`marked\` peer dep and is actively maintained. Unblocks the \`marked\` v18 upgrade in #164 (which can be closed as superseded).

The new renderer is async, so \`renderMarkdown\` becomes \`Promise<string>\` and every caller awaits it. \`printComment\` in \`thread/helpers.ts\` also becomes async, with its 4 call sites in \`thread/view.ts\` updated.

## Changes

- \`marked\` 15.0.12 → 18.0.0; \`marked-terminal\` removed; \`marked-terminal-renderer\` added.
- \`src/lib/markdown.ts\` rewritten to use \`createTerminalRenderer + darkTheme\`. Async API. Keeps the existing \`twist-mention://\` → \`@name\` preprocessor.
- All 6 production callers + \`printComment\` await the result.
- 4 test mocks updated to return \`Promise.resolve(text)\`.
- \`src/types/marked-terminal.d.ts\` replaced with \`src/types/marked-terminal-renderer.d.ts\` (the package ships \`renderer.d.mts\` but doesn't expose it via its \`exports\` map, so NodeNext can't resolve them).
- New \`src/__tests__/markdown.test.ts\` exercises the real renderer end-to-end (headings/bold/lists, twist-mention preprocessor, idempotence). Catches a broken renderer import or rejected async parse that the per-command mocks would otherwise miss.

## Test plan

- [x] \`npm install\` resolves cleanly (no peer-dep errors)
- [x] \`npm run type-check\` passes
- [x] \`npm run lint:check\` passes
- [x] \`npm test\` — 429 tests pass (425 + 4 new)
- [x] \`npm ls marked\` shows top-level \`marked@18.0.0\` with no peer warnings
- [x] Runtime smoke: rendered headings, lists, and \`twist-mention://\` preprocessing all output cleanly
- [ ] Manual: \`tw msg view <id>\` / \`tw thread view <id>\` / \`tw comment view <id>\` against content with markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)