### PR TITLE
feat: add `tw thread update` command to edit thread bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ tw thread view <ref>               # view thread with comments
 tw thread view <ref> --comment 123 # view a specific comment
 tw thread reply <ref>              # reply to a thread
 tw thread rename <ref> "New title" # rename a thread
+tw thread update <ref> "New body" # edit a thread's body (first post)
 tw conversation unread             # list unread conversations
 tw conversation view <ref>         # view conversation messages
 tw msg view <ref>                  # view a conversation message

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -90,6 +90,10 @@ tw thread delete <ref> --yes --json # Delete and return status as JSON
 tw thread rename <ref> "New title"  # Rename a thread (change its title)
 tw thread rename <ref> "New title" --json  # Rename and return { id, title } as JSON
 tw thread rename <ref> "New title" --json --full  # Rename and return full thread as JSON
+tw thread update <ref> "New body"   # Update a thread's body (the first post)
+echo "New body" | tw thread update <ref>  # Update body from stdin
+tw thread update <ref> "New body" --dry-run  # Preview without updating
+tw thread update <ref> "New body" --json  # Update and return { id, content } as JSON
 ```
 
 Default `--notify` for reply is EVERYONE_IN_THREAD, which may notify more people than intended. Before posting, confirm with the user whether specific people should be notified instead (via `--notify <user-ids>`). Options: EVERYONE, EVERYONE_IN_THREAD, or comma-separated ID refs.

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -94,6 +94,7 @@ tw thread update <ref> "New body"   # Update a thread's body (the first post)
 echo "New body" | tw thread update <ref>  # Update body from stdin
 tw thread update <ref> "New body" --dry-run  # Preview without updating
 tw thread update <ref> "New body" --json  # Update and return { id, content } as JSON
+tw thread update <ref> "New body" --json --full  # Update and return full thread as JSON
 ```
 
 Default `--notify` for reply is EVERYONE_IN_THREAD, which may notify more people than intended. Before posting, confirm with the user whether specific people should be notified instead (via `--notify <user-ids>`). Options: EVERYONE, EVERYONE_IN_THREAD, or comma-separated ID refs.

--- a/src/__tests__/thread.test.ts
+++ b/src/__tests__/thread.test.ts
@@ -992,7 +992,10 @@ describe('thread update', () => {
         consoleSpy.mockRestore()
     })
 
-    it('shows dry run output', async () => {
+    it('shows dry run output without calling updateThread', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
@@ -1000,6 +1003,7 @@ describe('thread update', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith('Dry run: would update thread 500')
         expect(consoleSpy).toHaveBeenCalledWith('New body')
+        expect(client.threads.updateThread).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
     })

--- a/src/__tests__/thread.test.ts
+++ b/src/__tests__/thread.test.ts
@@ -103,10 +103,13 @@ function createClient({
                 mutedUntil: null,
             })),
             deleteThread: vi.fn(async () => undefined),
-            updateThread: vi.fn(async (_args: { id: number; title?: string | null }) => ({
-                ...thread,
-                title: _args.title ?? thread.title,
-            })),
+            updateThread: vi.fn(
+                async (_args: { id: number; title?: string | null; content?: string | null }) => ({
+                    ...thread,
+                    title: _args.title ?? thread.title,
+                    content: _args.content ?? thread.content,
+                }),
+            ),
         },
         users: {
             getSessionUser: vi.fn((_options?: { batch?: boolean }) => {
@@ -961,6 +964,88 @@ describe('thread rename', () => {
         expect(jsonOutput.title).toBe('New Title')
         // Full output includes more fields
         expect(Object.keys(jsonOutput).length).toBeGreaterThan(2)
+
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('thread update', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('updates a thread body', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'update', '500', 'New body'])
+
+        expect(client.threads.updateThread).toHaveBeenCalledWith({
+            id: 500,
+            content: 'New body',
+        })
+        expect(consoleSpy).toHaveBeenCalledWith('Thread 500 updated.')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('shows dry run output', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'update', '500', 'New body', '--dry-run'])
+
+        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would update thread 500')
+        expect(consoleSpy).toHaveBeenCalledWith('New body')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('reads content from stdin', async () => {
+        vi.mocked(readStdin).mockResolvedValueOnce('Body from stdin')
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'update', '500'])
+
+        expect(client.threads.updateThread).toHaveBeenCalledWith({
+            id: 500,
+            content: 'Body from stdin',
+        })
+
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when no content is provided', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'update', '500']),
+        ).rejects.toHaveProperty('code', 'MISSING_CONTENT')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json including id and content', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'update', '500', 'New body', '--json'])
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput.id).toBe(500)
+        expect(jsonOutput.content).toBe('New body')
+        expect(Object.keys(jsonOutput)).toEqual(['id', 'content'])
 
         consoleSpy.mockRestore()
     })

--- a/src/commands/thread/index.ts
+++ b/src/commands/thread/index.ts
@@ -6,6 +6,7 @@ import { markThreadDone } from './mutate.js'
 import { muteThread, unmuteThread } from './mute.js'
 import { renameThread } from './rename.js'
 import { replyToThread } from './reply.js'
+import { updateThread } from './update.js'
 import { viewThread } from './view.js'
 
 export function registerThreadCommand(program: Command): void {
@@ -138,6 +139,22 @@ Examples:
         .option('--json', 'Output result as JSON')
         .option('--full', 'Include all fields in JSON output')
         .action(renameThread)
+
+    thread
+        .command('update <thread-ref> [content]')
+        .description("Update a thread's body (the first post)")
+        .option('--dry-run', 'Show what would be updated without updating')
+        .option('--json', 'Output updated thread as JSON')
+        .option('--full', 'Include all fields in JSON output')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  tw thread update 12345 "Updated body text"
+  echo "New body" | tw thread update 12345
+  tw thread update 12345 "Fixed" --json`,
+        )
+        .action(updateThread)
 
     thread
         .command('unmute <thread-ref>')

--- a/src/commands/thread/update.ts
+++ b/src/commands/thread/update.ts
@@ -1,0 +1,58 @@
+import { getTwistClient } from '../../lib/api.js'
+import { CliError } from '../../lib/errors.js'
+import { openEditor, readStdin } from '../../lib/input.js'
+import type { MutationOptions } from '../../lib/options.js'
+import { formatJson } from '../../lib/output.js'
+import { assertChannelIsPublic } from '../../lib/public-channels.js'
+import { resolveThreadId } from '../../lib/refs.js'
+
+type UpdateOptions = MutationOptions
+
+export async function updateThread(
+    ref: string,
+    content: string | undefined,
+    options: UpdateOptions,
+): Promise<void> {
+    const threadId = resolveThreadId(ref)
+
+    let newContent = await readStdin()
+    if (!newContent && content) {
+        newContent = content
+    }
+    if (!newContent) {
+        newContent = await openEditor()
+    }
+    if (!newContent || newContent.trim() === '') {
+        throw new CliError(
+            'MISSING_CONTENT',
+            'No content provided. Pass content as an argument or pipe via stdin.',
+        )
+    }
+
+    if (options.dryRun) {
+        console.log(`Dry run: would update thread ${threadId}`)
+        console.log('')
+        console.log(newContent)
+        return
+    }
+
+    const client = await getTwistClient()
+    const thread = await client.threads.getThread(threadId)
+    await assertChannelIsPublic(thread.channelId, thread.workspaceId)
+
+    const updated = await client.threads.updateThread({
+        id: threadId,
+        content: newContent,
+    })
+
+    if (options.json) {
+        if (options.full) {
+            console.log(formatJson(updated, 'thread', true))
+        } else {
+            console.log(formatJson({ id: updated.id, content: updated.content }))
+        }
+        return
+    }
+
+    console.log(`Thread ${threadId} updated.`)
+}

--- a/src/commands/thread/update.ts
+++ b/src/commands/thread/update.ts
@@ -29,16 +29,16 @@ export async function updateThread(
         )
     }
 
+    const client = await getTwistClient()
+    const thread = await client.threads.getThread(threadId)
+    await assertChannelIsPublic(thread.channelId, thread.workspaceId)
+
     if (options.dryRun) {
         console.log(`Dry run: would update thread ${threadId}`)
         console.log('')
         console.log(newContent)
         return
     }
-
-    const client = await getTwistClient()
-    const thread = await client.threads.getThread(threadId)
-    await assertChannelIsPublic(thread.channelId, thread.workspaceId)
 
     const updated = await client.threads.updateThread({
         id: threadId,

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -93,6 +93,7 @@ tw thread update <ref> "New body"   # Update a thread's body (the first post)
 echo "New body" | tw thread update <ref>  # Update body from stdin
 tw thread update <ref> "New body" --dry-run  # Preview without updating
 tw thread update <ref> "New body" --json  # Update and return { id, content } as JSON
+tw thread update <ref> "New body" --json --full  # Update and return full thread as JSON
 \`\`\`
 
 Default \`--notify\` for reply is EVERYONE_IN_THREAD, which may notify more people than intended. Before posting, confirm with the user whether specific people should be notified instead (via \`--notify <user-ids>\`). Options: EVERYONE, EVERYONE_IN_THREAD, or comma-separated ID refs.

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -89,6 +89,10 @@ tw thread delete <ref> --yes --json # Delete and return status as JSON
 tw thread rename <ref> "New title"  # Rename a thread (change its title)
 tw thread rename <ref> "New title" --json  # Rename and return { id, title } as JSON
 tw thread rename <ref> "New title" --json --full  # Rename and return full thread as JSON
+tw thread update <ref> "New body"   # Update a thread's body (the first post)
+echo "New body" | tw thread update <ref>  # Update body from stdin
+tw thread update <ref> "New body" --dry-run  # Preview without updating
+tw thread update <ref> "New body" --json  # Update and return { id, content } as JSON
 \`\`\`
 
 Default \`--notify\` for reply is EVERYONE_IN_THREAD, which may notify more people than intended. Before posting, confirm with the user whether specific people should be notified instead (via \`--notify <user-ids>\`). Options: EVERYONE, EVERYONE_IN_THREAD, or comma-separated ID refs.


### PR DESCRIPTION
## Summary

- Adds `tw thread update <thread-ref> [content]` — edits the body (first post) of a thread, mirroring `tw comment update`
- Reuses existing plumbing: `resolveThreadId`, `assertChannelIsPublic`, `readStdin`/`openEditor` input cascade, `MutationOptions`
- Hit this limitation while cross-linking related threads after-the-fact; previously had to fall back to the Twist UI

The Twist SDK already supported `content` on `UpdateThreadArgs`, so no API plumbing was needed — just a new command file and registration.

## Test plan

- [x] `tw thread update <id> "new body"` — positional arg
- [x] `echo "new body" | tw thread update <id>` — stdin
- [x] `tw thread update <id> "..." --dry-run` — preview without calling the API
- [x] `tw thread update <id> "..." --json` — emits `{ id, content }`
- [x] `tw thread update <id> "..." --json --full` — emits full thread object
- [x] Errors with `MISSING_CONTENT` when no content provided (matches `tw comment update`)
- [x] 5 new unit tests in `src/__tests__/thread.test.ts`
- [x] End-to-end verification against a live thread (body edited via stdin, server round-trip confirmed)
- [x] `npm test` (434/434), `npm run type-check`, `npm run lint`, `npm run check:skill-sync` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)