### PR TITLE
feat(inbox): add --archive-filter option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "2.3.1",
+                "@doist/twist-sdk": "2.4.0",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -137,9 +137,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.3.1.tgz",
-            "integrity": "sha512-B3VD4S0zkleuo0TgoYkQw/969kFUhdnYr78FB5I26/RUWdJWAwCfeR4vnldLLIbw1WTtCF2NFi7hwqXT62isAw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.4.0.tgz",
+            "integrity": "sha512-FWX0rGMHtCZwTaBvK+km4LSMJRR3caPuiWPYaYThQEvxtcthzrkAv1fqppW/ArVljPZkkvnNh78pv2dWZcT+6g==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "CHANGELOG.md"
     ],
     "dependencies": {
-        "@doist/twist-sdk": "2.3.1",
+        "@doist/twist-sdk": "2.4.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",
@@ -60,14 +60,14 @@
         "yocto-spinner": "1.1.0"
     },
     "devDependencies": {
-        "oxfmt": "0.44.0",
-        "oxlint": "1.59.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
         "@types/node": "25.6.0",
         "conventional-changelog-conventionalcommits": "9.3.1",
         "lefthook": "2.1.5",
+        "oxfmt": "0.44.0",
+        "oxlint": "1.59.0",
         "semantic-release": "25.0.3",
         "typescript": "6.0.2",
         "vitest": "4.1.4"

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -47,6 +47,8 @@ All target command flags pass through (e.g. `--json`, `--raw`, `--full`).
 ```bash
 tw inbox                         # Show inbox threads
 tw inbox --unread                # Only unread threads
+tw inbox --archive-filter all      # Show active + done threads
+tw inbox --archive-filter archived # Show only done threads
 tw inbox --channel <filter>      # Filter by channel name (fuzzy)
 tw inbox --since <date>          # Filter by date (ISO format)
 tw inbox --limit <n>             # Max items (default: 50)

--- a/src/__tests__/inbox.test.ts
+++ b/src/__tests__/inbox.test.ts
@@ -1,9 +1,14 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../lib/api.js', () => ({
+const apiMocks = vi.hoisted(() => ({
     getTwistClient: vi.fn(),
-    getCurrentWorkspaceId: vi.fn().mockResolvedValue(1),
+    getCurrentWorkspaceId: vi.fn(),
+}))
+
+vi.mock('../lib/api.js', () => ({
+    getTwistClient: apiMocks.getTwistClient,
+    getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
 }))
 
 vi.mock('../lib/refs.js', () => ({
@@ -41,5 +46,44 @@ describe('inbox --workspace conflict', () => {
         await expect(
             program.parseAsync(['node', 'tw', 'inbox', 'Doist', '--workspace', 'Other']),
         ).rejects.toThrow('Cannot specify workspace both as argument and --workspace flag')
+    })
+})
+
+describe('inbox --archive-filter', () => {
+    const mockGetInbox = vi.fn()
+    const mockGetUnread = vi.fn()
+    const mockBatch = vi.fn()
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        mockGetInbox.mockReturnValue({ data: [] })
+        mockGetUnread.mockReturnValue({ data: [] })
+        mockBatch.mockResolvedValue([{ data: [] }, { data: [] }])
+        apiMocks.getTwistClient.mockResolvedValue({
+            inbox: { getInbox: mockGetInbox },
+            threads: { getUnread: mockGetUnread },
+            batch: mockBatch,
+        })
+    })
+
+    it('passes archiveFilter to SDK getInbox', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox', '--archive-filter', 'all', '--json'])
+
+        expect(mockGetInbox).toHaveBeenCalledWith(
+            expect.objectContaining({ archiveFilter: 'all' }),
+            { batch: true },
+        )
+    })
+
+    it('defaults archiveFilter to active when not provided', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox', '--json'])
+
+        expect(mockGetInbox).toHaveBeenCalledWith(
+            expect.objectContaining({ archiveFilter: 'active' }),
+            { batch: true },
+        )
     })
 })

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,6 +1,8 @@
+import type { ArchiveFilter } from '@doist/twist-sdk'
 import chalk from 'chalk'
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
+import { withCaseInsensitiveChoices } from '../lib/completion.js'
 import { formatRelativeDate } from '../lib/dates.js'
 import { CliError } from '../lib/errors.js'
 import { includePrivateChannels, isAccessible } from '../lib/global-args.js'
@@ -13,6 +15,7 @@ type InboxOptions = PaginatedViewOptions & {
     workspace?: string
     channel?: string
     unread?: boolean
+    archiveFilter?: ArchiveFilter
 }
 
 async function showInbox(workspaceRef: string | undefined, options: InboxOptions): Promise<void> {
@@ -43,6 +46,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
                 since: options.since ? new Date(options.since) : undefined,
                 until: options.until ? new Date(options.until) : undefined,
                 limit,
+                archiveFilter: options.archiveFilter ?? 'active',
             },
             { batch: true },
         ),
@@ -158,6 +162,15 @@ export function registerInboxCommand(program: Command): void {
         .option('--workspace <ref>', 'Workspace ID or name')
         .option('--channel <filter>', 'Filter by channel name (fuzzy match)')
         .option('--unread', 'Only show unread threads')
+        .addOption(
+            withCaseInsensitiveChoices(
+                new Option(
+                    '--archive-filter <filter>',
+                    'Show active, archived, or all inbox threads (default: active)',
+                ),
+                ['active', 'archived', 'all'],
+            ),
+        )
         .option('--since <date>', 'Filter by date (ISO format)')
         .option('--until <date>', 'Filter by date')
         .option('--limit <n>', 'Max items (default: 50)')
@@ -170,6 +183,8 @@ export function registerInboxCommand(program: Command): void {
 Examples:
   tw inbox
   tw inbox --unread
+  tw inbox --archive-filter all
+  tw inbox --archive-filter archived
   tw inbox --channel engineering --since 2025-01-01
   tw inbox --limit 10 --json`,
         )

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -46,6 +46,8 @@ All target command flags pass through (e.g. \`--json\`, \`--raw\`, \`--full\`).
 \`\`\`bash
 tw inbox                         # Show inbox threads
 tw inbox --unread                # Only unread threads
+tw inbox --archive-filter all      # Show active + done threads
+tw inbox --archive-filter archived # Show only done threads
 tw inbox --channel <filter>      # Filter by channel name (fuzzy)
 tw inbox --since <date>          # Filter by date (ISO format)
 tw inbox --limit <n>             # Max items (default: 50)


### PR DESCRIPTION
## Summary

Surfaces the existing `archive_filter` API parameter in the CLI. Allows fetching active, archived, or all inbox threads.

- Adds `--archive-filter <active|archived|all>` option to `tw inbox`
- Uses `@doist/twist-sdk` v2.4.0 which added `archiveFilter` to `getInbox()`
- Optional parameter, defaults to `active` (current behavior) — fully backward compatible
- Updated skill content and SKILL.md

## Use case

Tools that poll the inbox need visibility into threads marked as done between polling intervals. With `--archive-filter all`, a single call returns both active and archived threads.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint:check` passes
- [x] `npm run check:skill-sync` passes
- [x] `npm test` — 431 tests pass (2 new inbox tests)
- [x] Manual test with live data:
  - `tw inbox --archive-filter all --json --limit 3` → returns both ACTIVE and DONE threads
  - `tw inbox --archive-filter archived --json --limit 3` → returns only DONE threads
  - `tw inbox --archive-filter active --json --limit 3` → returns only ACTIVE threads (default)