### PR TITLE
fix: add groups:read scope and handle 403 errors globally

### DIFF
--- a/src/__tests__/away.test.ts
+++ b/src/__tests__/away.test.ts
@@ -128,18 +128,17 @@ describe('away', () => {
             logSpy.mockRestore()
         })
 
-        it('shows friendly error on insufficient scope (403)', async () => {
-            apiMocks.updateUser.mockRejectedValue(
-                new TwistRequestError('Request failed with status 403', 403, {
-                    error_code: 109,
-                    error_string: 'Insufficient scope provided: user:write',
-                }),
-            )
+        it('propagates insufficient scope errors (handled globally by API proxy)', async () => {
+            const scopeError = new TwistRequestError('Request failed with status 403', 403, {
+                error_code: 109,
+                error_string: 'Insufficient scope provided: user:write',
+            })
+            apiMocks.updateUser.mockRejectedValue(scopeError)
             const program = createProgram()
 
             await expect(
                 program.parseAsync(['node', 'tw', 'away', 'set', 'vacation', '2026-03-20']),
-            ).rejects.toHaveProperty('code', 'INSUFFICIENT_SCOPE')
+            ).rejects.toThrow(scopeError)
         })
 
         it('rejects invalid away type', async () => {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,40 @@
+import { TwistRequestError } from '@doist/twist-sdk'
+import { describe, expect, it } from 'vitest'
+
+import { isInsufficientScope } from '../lib/errors.js'
+
+describe('isInsufficientScope', () => {
+    it('returns true for a 403 with "Insufficient scope" error_string', () => {
+        const error = new TwistRequestError('Request failed with status 403', 403, {
+            error_code: 109,
+            error_string: 'Insufficient scope provided: user:write',
+        })
+        expect(isInsufficientScope(error)).toBe(true)
+    })
+
+    it('returns false for a 403 without "Insufficient scope"', () => {
+        const error = new TwistRequestError('Request failed with status 403', 403, {
+            error_code: 100,
+            error_string: 'Access denied',
+        })
+        expect(isInsufficientScope(error)).toBe(false)
+    })
+
+    it('returns false for non-403 errors', () => {
+        const error = new TwistRequestError('Request failed with status 401', 401, {
+            error_code: 100,
+            error_string: 'Insufficient scope provided: user:write',
+        })
+        expect(isInsufficientScope(error)).toBe(false)
+    })
+
+    it('returns false for plain errors', () => {
+        expect(isInsufficientScope(new Error('something'))).toBe(false)
+    })
+
+    it('returns false for non-error values', () => {
+        expect(isInsufficientScope(null)).toBe(false)
+        expect(isInsufficientScope(undefined)).toBe(false)
+        expect(isInsufficientScope('string')).toBe(false)
+    })
+})

--- a/src/commands/away/clear.ts
+++ b/src/commands/away/clear.ts
@@ -1,8 +1,6 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions, ViewOptions } from '../../lib/options.js'
 import { formatJson } from '../../lib/output.js'
-import { handleAwayError } from './helpers.js'
-
 export async function clearAway(options: MutationOptions & ViewOptions): Promise<void> {
     if (options.dryRun) {
         console.log('Dry run: would clear away status')
@@ -10,16 +8,12 @@ export async function clearAway(options: MutationOptions & ViewOptions): Promise
     }
 
     const client = await getTwistClient()
-    try {
-        const user = await client.users.update({ awayMode: '' as never })
+    const user = await client.users.update({ awayMode: '' as never })
 
-        if (options.json) {
-            console.log(formatJson(user, 'user', options.full))
-            return
-        }
-
-        console.log('Away status cleared.')
-    } catch (error) {
-        handleAwayError(error)
+    if (options.json) {
+        console.log(formatJson(user, 'user', options.full))
+        return
     }
+
+    console.log('Away status cleared.')
 }

--- a/src/commands/away/helpers.ts
+++ b/src/commands/away/helpers.ts
@@ -1,6 +1,3 @@
-import { TwistRequestError } from '@doist/twist-sdk'
-import { CliError } from '../../lib/errors.js'
-
 export function formatLocalDate(d: Date): string {
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
@@ -23,23 +20,4 @@ export function formatAwayType(type: string): string {
         other: 'Away',
     }
     return labels[type] ?? type
-}
-
-export function isInsufficientScope(error: unknown): boolean {
-    if (!(error instanceof TwistRequestError)) return false
-    const data = error.responseData as { error_string?: string } | undefined
-    return (
-        error.httpStatusCode === 403 && data?.error_string?.includes('Insufficient scope') === true
-    )
-}
-
-export function handleAwayError(error: unknown): never {
-    if (isInsufficientScope(error)) {
-        throw new CliError(
-            'INSUFFICIENT_SCOPE',
-            'The away status feature requires additional permissions.',
-            ['Run `tw auth login` to re-authenticate with the required scopes'],
-        )
-    }
-    throw error
 }

--- a/src/commands/away/set.ts
+++ b/src/commands/away/set.ts
@@ -3,7 +3,7 @@ import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { MutationOptions, ViewOptions } from '../../lib/options.js'
 import { formatJson } from '../../lib/output.js'
-import { formatAwayType, handleAwayError, todayStr, tomorrowStr } from './helpers.js'
+import { formatAwayType, todayStr, tomorrowStr } from './helpers.js'
 
 type SetAwayOptions = ViewOptions & MutationOptions & { from?: string }
 
@@ -30,18 +30,14 @@ export async function setAway(
     }
 
     const client = await getTwistClient()
-    try {
-        const user = await client.users.update({
-            awayMode: { type: type as AwayModeType, dateFrom, dateTo },
-        })
+    const user = await client.users.update({
+        awayMode: { type: type as AwayModeType, dateFrom, dateTo },
+    })
 
-        if (options.json) {
-            console.log(formatJson(user, 'user', options.full))
-            return
-        }
-
-        console.log(`Set away: ${formatAwayType(type)} from ${dateFrom} until ${dateTo}`)
-    } catch (error) {
-        handleAwayError(error)
+    if (options.json) {
+        console.log(formatJson(user, 'user', options.full))
+        return
     }
+
+    console.log(`Set away: ${formatAwayType(type)} from ${dateFrom} until ${dateTo}`)
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,7 +7,7 @@ import {
 } from '@doist/twist-sdk'
 import { getApiToken } from './auth.js'
 import { getConfig, updateConfig } from './config.js'
-import { CliError } from './errors.js'
+import { CliError, isInsufficientScope } from './errors.js'
 import { ensureWriteAllowed, isMutatingMethod } from './permissions.js'
 import { getProgressTracker } from './progress.js'
 import { withSpinner } from './spinner.js'
@@ -174,6 +174,13 @@ function wrapResult(
         .catch((error: Error) => {
             if (progressTracker.isEnabled()) {
                 progressTracker.emitError(error.name || 'API_ERROR', error.message)
+            }
+            if (isInsufficientScope(error)) {
+                throw new CliError(
+                    'INSUFFICIENT_SCOPE',
+                    'This action requires permissions your current token does not have.',
+                    ['Run `tw auth login` to re-authenticate with the required scopes'],
+                )
             }
             throw error
         })

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -62,7 +62,8 @@ export function isInsufficientScope(error: unknown): boolean {
     }
     return (
         httpStatusCode === 403 &&
-        responseData?.error_string?.includes('Insufficient scope') === true
+        typeof responseData?.error_string === 'string' &&
+        responseData.error_string.includes('Insufficient scope')
     )
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -43,6 +43,29 @@ export type ErrorCode =
 
 export type ErrorType = 'error' | 'info'
 
+/**
+ * Check whether an error is a Twist API 403 "Insufficient scope" response.
+ * Works with any error shaped like TwistRequestError (httpStatusCode + responseData).
+ */
+export function isInsufficientScope(error: unknown): boolean {
+    if (
+        typeof error !== 'object' ||
+        error === null ||
+        !('httpStatusCode' in error) ||
+        !('responseData' in error)
+    ) {
+        return false
+    }
+    const { httpStatusCode, responseData } = error as {
+        httpStatusCode: number
+        responseData: { error_string?: string } | undefined
+    }
+    return (
+        httpStatusCode === 403 &&
+        responseData?.error_string?.includes('Insufficient scope') === true
+    )
+}
+
 export class CliError extends Error {
     constructor(
         public readonly code: ErrorCode,

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -26,6 +26,7 @@ export const READ_WRITE_SCOPES = [
     'messages:write', // Send messages
     'reactions:read', // Read reactions
     'reactions:write', // Add reactions
+    'groups:read', // Read group information
     'search:read', // Search functionality
     'notifications:read', // Read notifications
 ].join(' ')
@@ -39,6 +40,7 @@ export const READ_ONLY_SCOPES = [
     'comments:read',
     'messages:read',
     'reactions:read',
+    'groups:read',
     'search:read',
     'notifications:read',
 ].join(' ')

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -26,6 +26,7 @@ const KNOWN_SAFE_API_METHODS = new Set([
     'conversationMessages.getMessage',
     'conversationMessages.getMessages',
     'inbox.getInbox',
+    'groups.getGroups',
     'batch',
 ])
 


### PR DESCRIPTION
## Summary

Fixes #171 — the CLI was missing the `groups:read` OAuth scope, causing 403 errors on any command that calls `getWorkspaceGroups()` (`tw groups`, `tw thread reply --notify <groupId>`, etc.).

- Add `groups:read` to both `READ_WRITE_SCOPES` and `READ_ONLY_SCOPES` in `src/lib/oauth.ts`
- Add `groups.getGroups` to `KNOWN_SAFE_API_METHODS` in `src/lib/permissions.ts`
- Move `isInsufficientScope` from `src/commands/away/helpers.ts` to `src/lib/errors.ts` and intercept 403 "Insufficient scope" errors globally in the API proxy (`wrapResult`), so every command gets a friendly message instead of a raw stack trace
- Remove per-command error handling from the away set/clear commands (now redundant)

## Test plan

- [x] `npm test` — 441/441 tests pass (0 failures)
- [x] `npm run build` — compiles cleanly (type-check passes)
- [x] Pre-commit hooks pass (oxfmt, oxlint, type-check)
- [x] Manual: `tw auth login` picks up new `groups:read` scope
- [x] Manual: `tw groups` works after re-auth
- [x] Manual: `tw thread reply --notify <groupId>` works after re-auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)