### PR TITLE
fix: add missing groups:read OAuth scope for --notify group IDs

### DIFF
--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -28,6 +28,7 @@ export const READ_WRITE_SCOPES = [
     'reactions:write', // Add reactions
     'search:read', // Search functionality
     'notifications:read', // Read notifications
+    'groups:read', // Read groups (needed for --notify with group IDs)
 ].join(' ')
 
 // OAuth scopes for read-only CLI operations (no :write scopes)

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -42,6 +42,7 @@ export const READ_ONLY_SCOPES = [
     'reactions:read',
     'search:read',
     'notifications:read',
+    'groups:read',
 ].join(' ')
 
 /**

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -26,6 +26,7 @@ const KNOWN_SAFE_API_METHODS = new Set([
     'conversationMessages.getMessage',
     'conversationMessages.getMessages',
     'inbox.getInbox',
+    'groups.getGroups',
     'batch',
 ])
 


### PR DESCRIPTION
## Summary

- Adds `groups:read` to the OAuth scopes requested during `tw auth login`, fixing 403 errors when using `tw groups` or `--notify` with group IDs
- Adds `groups.getGroups` to `KNOWN_SAFE_API_METHODS` so group listing works in read-only mode

Closes #171

## Notes

Users will need to re-authenticate (`tw auth login`) after upgrading to pick up the new scope.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 436 tests pass
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)