### PR TITLE
chore: remove duplicate groups:read scope entries

### DIFF
--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -29,7 +29,6 @@ export const READ_WRITE_SCOPES = [
     'groups:read', // Read group information
     'search:read', // Search functionality
     'notifications:read', // Read notifications
-    'groups:read', // Read groups (needed for --notify with group IDs)
 ].join(' ')
 
 // OAuth scopes for read-only CLI operations (no :write scopes)
@@ -44,7 +43,6 @@ export const READ_ONLY_SCOPES = [
     'groups:read',
     'search:read',
     'notifications:read',
-    'groups:read',
 ].join(' ')
 
 /**


### PR DESCRIPTION
## Summary

Removes duplicate `groups:read` entries in both `READ_WRITE_SCOPES` and `READ_ONLY_SCOPES` that were introduced when the squash merge of #172 combined with a separate commit that also added the scope.

## Test plan

- [x] `npm test` — 441/441 pass
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)