### PR TITLE
feat(user): add --json and --full support to tw user

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -177,6 +177,8 @@ tw search "query" --cursor <cur> # Pagination cursor
 
 ```bash
 tw user                          # Show current user info
+tw user --json                   # JSON output
+tw user --json --full            # Include all fields in JSON output
 tw users                         # List workspace users
 tw users --search <text>         # Filter by name/email
 tw channels                      # List active joined workspace channels

--- a/src/__tests__/user.test.ts
+++ b/src/__tests__/user.test.ts
@@ -1,10 +1,16 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../lib/api.js', () => ({
+const apiMocks = vi.hoisted(() => ({
     getCurrentWorkspaceId: vi.fn().mockResolvedValue(1),
     getSessionUser: vi.fn(),
     getWorkspaceUsers: vi.fn(),
+}))
+
+vi.mock('../lib/api.js', () => ({
+    getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
+    getSessionUser: apiMocks.getSessionUser,
+    getWorkspaceUsers: apiMocks.getWorkspaceUsers,
 }))
 
 vi.mock('../lib/refs.js', () => ({
@@ -33,5 +39,57 @@ describe('users --workspace conflict', () => {
         await expect(
             program.parseAsync(['node', 'tw', 'users', 'Doist', '--workspace', 'Other']),
         ).rejects.toThrow('Cannot specify workspace both as argument and --workspace flag')
+    })
+})
+
+describe('user --json', () => {
+    const sampleUser = {
+        id: 42,
+        name: 'Jane Smith',
+        email: 'jane@example.com',
+        timezone: 'America/New_York',
+        userType: 'regular',
+        awayMode: null,
+        defaultWorkspace: 1,
+        lang: 'en',
+        shortName: 'Jane',
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getSessionUser.mockResolvedValue(sampleUser)
+    })
+
+    it('outputs essential user fields as JSON', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'user', '--json'])
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1)
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput.id).toBe(42)
+        expect(jsonOutput.name).toBe('Jane Smith')
+        expect(jsonOutput.email).toBe('jane@example.com')
+        expect(jsonOutput.timezone).toBe('America/New_York')
+        expect(jsonOutput).not.toHaveProperty('lang')
+        expect(jsonOutput).not.toHaveProperty('shortName')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs full user fields with --full', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'user', '--json', '--full'])
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1)
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput).toHaveProperty('lang', 'en')
+        expect(jsonOutput).toHaveProperty('shortName', 'Jane')
+        expect(jsonOutput).toHaveProperty('defaultWorkspace', 1)
+
+        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -8,8 +8,13 @@ import { resolveWorkspaceRef } from '../lib/refs.js'
 
 type UsersOptions = ViewOptions & { workspace?: string; search?: string }
 
-async function showCurrentUser(): Promise<void> {
+async function showCurrentUser(options: ViewOptions): Promise<void> {
     const user = await getSessionUser()
+
+    if (options.json) {
+        console.log(formatJson(user, 'user', options.full))
+        return
+    }
 
     console.log(chalk.bold(user.name))
     console.log('')
@@ -77,11 +82,14 @@ export function registerUserCommand(program: Command): void {
     program
         .command('user')
         .description('Show current user info')
+        .option('--json', 'Output as JSON')
+        .option('--full', 'Include all fields in JSON output')
         .addHelpText(
             'after',
             `
 Examples:
-  tw user`,
+  tw user
+  tw user --json`,
         )
         .action(showCurrentUser)
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -176,6 +176,8 @@ tw search "query" --cursor <cur> # Pagination cursor
 
 \`\`\`bash
 tw user                          # Show current user info
+tw user --json                   # JSON output
+tw user --json --full            # Include all fields in JSON output
 tw users                         # List workspace users
 tw users --search <text>         # Filter by name/email
 tw channels                      # List active joined workspace channels


### PR DESCRIPTION
## Summary
- Adds `--json` and `--full` flags to `tw user` so the current session user can be emitted as machine-readable JSON, matching the pattern already in `tw users` and `tw away status`.
- Updates `SKILL_CONTENT` (and regenerates `skills/twist-cli/SKILL.md`) to document the new flags.
- Adds tests covering both essential-fields and `--full` output.

## Test plan
- [x] `npm test -- user` passes (3 tests)
- [x] Full suite passes via pre-push hook (443 tests)
- [x] `npm run build` clean
- [x] `npm run sync:skill` clean
- [ ] Manual: `tw user --json | jq .id` returns the current user id

🤖 Generated with [Claude Code](https://claude.com/claude-code)