### PR TITLE
feat: consistency pass for --json across tw react/unreact, comment view, conversation with

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -110,6 +110,7 @@ tw comment <comment-ref>                       # View a comment (shorthand for v
 tw comment view <comment-ref>                  # View a single thread comment
 tw comment view <comment-ref> --raw            # Show raw markdown
 tw comment view <comment-ref> --json           # Output as JSON
+tw comment view <comment-ref> --ndjson         # Output as newline-delimited JSON
 tw comment view <comment-ref> --json --full    # Include all fields in JSON output
 tw comment update <comment-ref> "new content"  # Update a thread comment
 tw comment update <comment-ref> "content" --json  # Update and return updated comment as JSON
@@ -209,7 +210,9 @@ tw away clear                    # Clear away status
 tw react thread <ref> 👍         # Add reaction to thread
 tw react comment <ref> +1        # Add reaction (shortcode)
 tw react message <ref> heart     # Add reaction to DM message
+tw react thread <ref> 👍 --json  # Output result as JSON
 tw unreact thread <ref> 👍       # Remove reaction
+tw unreact thread <ref> 👍 --json # Output result as JSON
 ```
 
 Supported shortcodes: +1, -1, heart, tada, smile, laughing, thinking, fire, check, x, eyes, pray, clap, rocket, wave

--- a/src/__tests__/comment.test.ts
+++ b/src/__tests__/comment.test.ts
@@ -110,6 +110,22 @@ describe('comment view', () => {
         consoleSpy.mockRestore()
     })
 
+    it('outputs NDJSON with --ndjson', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'comment', 'view', '300', '--ndjson'])
+
+        const line = consoleSpy.mock.calls[0][0]
+        expect(line).not.toContain('\n')
+        const parsed = JSON.parse(line)
+        expect(parsed.id).toBe(300)
+        expect(parsed.content).toBe('Comment 300')
+        consoleSpy.mockRestore()
+    })
+
     it('includes creatorName in --json --full output', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)

--- a/src/__tests__/conversation.test.ts
+++ b/src/__tests__/conversation.test.ts
@@ -403,6 +403,28 @@ describe('conversation with', () => {
         consoleSpy.mockRestore()
     })
 
+    it('emits empty JSON array when no 1:1 conversation is found with --json', async () => {
+        const client = createClient({
+            activeConversations: [],
+            users: {
+                1: { id: 1, name: 'Me' },
+                2: { id: 2, name: 'Alice Example' },
+            },
+        })
+
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'conversation', 'with', 'Alice', '--json'])
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1)
+        expect(JSON.parse(consoleSpy.mock.calls[0][0])).toEqual([])
+
+        consoleSpy.mockRestore()
+    })
+
     it('prints a clean error and exits non-zero for ambiguous user refs', async () => {
         refsMocks.resolveUserRefs.mockRejectedValue(
             new CliError(

--- a/src/__tests__/react.test.ts
+++ b/src/__tests__/react.test.ts
@@ -66,4 +66,65 @@ describe('react refs', () => {
         expect(apiMocks.removeReaction).toHaveBeenCalledWith({ messageId: 44, reaction: '❤️' })
         logSpy.mockRestore()
     })
+
+    it('outputs JSON for react --json', async () => {
+        const program = createProgram()
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'react', 'thread', '99', '+1', '--json'])
+
+        expect(apiMocks.addReaction).toHaveBeenCalledWith({ threadId: 99, reaction: '👍' })
+        const output = JSON.parse(logSpy.mock.calls[0][0])
+        expect(output).toEqual({
+            targetType: 'thread',
+            targetId: 99,
+            emoji: '👍',
+            action: 'added',
+        })
+        logSpy.mockRestore()
+    })
+
+    it('outputs JSON for unreact --json', async () => {
+        const program = createProgram()
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'unreact', 'comment', '42', 'heart', '--json'])
+
+        expect(apiMocks.removeReaction).toHaveBeenCalledWith({ commentId: 42, reaction: '❤️' })
+        const output = JSON.parse(logSpy.mock.calls[0][0])
+        expect(output).toEqual({
+            targetType: 'comment',
+            targetId: 42,
+            emoji: '❤️',
+            action: 'removed',
+        })
+        logSpy.mockRestore()
+    })
+
+    it('outputs JSON for react --json --dry-run without calling API', async () => {
+        const program = createProgram()
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'react',
+            'message',
+            '77',
+            'tada',
+            '--json',
+            '--dry-run',
+        ])
+
+        expect(apiMocks.addReaction).not.toHaveBeenCalled()
+        const output = JSON.parse(logSpy.mock.calls[0][0])
+        expect(output).toEqual({
+            targetType: 'message',
+            targetId: 77,
+            emoji: '🎉',
+            action: 'added',
+            dryRun: true,
+        })
+        logSpy.mockRestore()
+    })
 })

--- a/src/commands/comment/index.ts
+++ b/src/commands/comment/index.ts
@@ -13,6 +13,7 @@ export function registerCommentCommand(program: Command): void {
         .description('View a single thread comment')
         .option('--raw', 'Show raw markdown instead of rendered')
         .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
         .option('--full', 'Include all fields in JSON output')
         .addHelpText(
             'after',

--- a/src/commands/comment/view.ts
+++ b/src/commands/comment/view.ts
@@ -2,7 +2,7 @@ import { getTwistClient } from '../../lib/api.js'
 import { formatRelativeDate } from '../../lib/dates.js'
 import { renderMarkdown } from '../../lib/markdown.js'
 import type { ViewOptions } from '../../lib/options.js'
-import { colors, formatJson } from '../../lib/output.js'
+import { colors, formatJson, formatNdjson } from '../../lib/output.js'
 import { resolveCommentId } from '../../lib/refs.js'
 
 export async function viewComment(ref: string, options: ViewOptions): Promise<void> {
@@ -19,6 +19,12 @@ export async function viewComment(ref: string, options: ViewOptions): Promise<vo
     if (options.json) {
         const output = { ...comment, creatorName }
         console.log(formatJson(output, options.full ? undefined : 'comment', options.full))
+        return
+    }
+
+    if (options.ndjson) {
+        const output = { ...comment, creatorName }
+        console.log(formatNdjson([output], options.full ? undefined : 'comment', options.full))
         return
     }
 

--- a/src/commands/conversation/helpers.ts
+++ b/src/commands/conversation/helpers.ts
@@ -157,6 +157,13 @@ export async function listConversationsWithUser(
     options: ConversationWithOptions,
 ): Promise<void> {
     if (conversations.length === 0) {
+        if (options.json) {
+            console.log(formatJson([], 'conversation', options.full))
+            return
+        }
+        if (options.ndjson) {
+            return
+        }
         console.log('No matching conversations found.')
         return
     }

--- a/src/commands/conversation/with.ts
+++ b/src/commands/conversation/with.ts
@@ -59,6 +59,11 @@ export async function findConversationWithUser(
     )
 
     if (!directConversation) {
+        if (options.json || options.ndjson) {
+            await listConversationsWithUser([], workspaceId, options)
+            return
+        }
+
         const suggestion =
             groupConversationCount > 0
                 ? ` Found ${groupConversationCount} group conversation${groupConversationCount === 1 ? '' : 's'} with ${targetUser.name}. Use --include-groups to list them.`

--- a/src/commands/react.ts
+++ b/src/commands/react.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { getTwistClient } from '../lib/api.js'
 import { CliError } from '../lib/errors.js'
 import type { MutationOptions } from '../lib/options.js'
+import { formatJson } from '../lib/output.js'
 import { resolveCommentId, resolveMessageId, resolveThreadId } from '../lib/refs.js'
 
 type TargetType = 'thread' | 'comment' | 'message'
@@ -50,6 +51,18 @@ async function addReaction(
     const normalizedEmoji = normalizeEmoji(emoji)
 
     if (options.dryRun) {
+        if (options.json) {
+            console.log(
+                formatJson({
+                    targetType,
+                    targetId,
+                    emoji: normalizedEmoji,
+                    action: 'added',
+                    dryRun: true,
+                }),
+            )
+            return
+        }
         console.log(`Dry run: would add ${normalizedEmoji} to ${targetType} ${targetId}`)
         return
     }
@@ -70,6 +83,12 @@ async function addReaction(
     }
 
     await client.reactions.add(params)
+
+    if (options.json) {
+        console.log(formatJson({ targetType, targetId, emoji: normalizedEmoji, action: 'added' }))
+        return
+    }
+
     console.log(`Added ${normalizedEmoji} to ${targetType} ${targetId}`)
 }
 
@@ -83,6 +102,18 @@ async function removeReaction(
     const normalizedEmoji = normalizeEmoji(emoji)
 
     if (options.dryRun) {
+        if (options.json) {
+            console.log(
+                formatJson({
+                    targetType,
+                    targetId,
+                    emoji: normalizedEmoji,
+                    action: 'removed',
+                    dryRun: true,
+                }),
+            )
+            return
+        }
         console.log(`Dry run: would remove ${normalizedEmoji} from ${targetType} ${targetId}`)
         return
     }
@@ -103,6 +134,12 @@ async function removeReaction(
     }
 
     await client.reactions.remove(params)
+
+    if (options.json) {
+        console.log(formatJson({ targetType, targetId, emoji: normalizedEmoji, action: 'removed' }))
+        return
+    }
+
     console.log(`Removed ${normalizedEmoji} from ${targetType} ${targetId}`)
 }
 
@@ -111,13 +148,15 @@ export function registerReactCommand(program: Command): void {
         .command('react <target-type> <target-ref> <emoji>')
         .description('Add an emoji reaction (target-type: thread, comment, message)')
         .option('--dry-run', 'Show what would happen without executing')
+        .option('--json', 'Output result as JSON')
         .addHelpText(
             'after',
             `
 Examples:
   tw react thread 12345 +1
   tw react comment 67890 heart
-  tw react message 11111 tada --dry-run`,
+  tw react message 11111 tada --dry-run
+  tw react thread 12345 +1 --json`,
         )
         .action((targetType: string, targetRef: string, emoji: string, options: ReactOptions) => {
             if (!['thread', 'comment', 'message'].includes(targetType)) {
@@ -133,12 +172,14 @@ Examples:
         .command('unreact <target-type> <target-ref> <emoji>')
         .description('Remove an emoji reaction (target-type: thread, comment, message)')
         .option('--dry-run', 'Show what would happen without executing')
+        .option('--json', 'Output result as JSON')
         .addHelpText(
             'after',
             `
 Examples:
   tw unreact thread 12345 +1
-  tw unreact comment 67890 heart`,
+  tw unreact comment 67890 heart
+  tw unreact thread 12345 +1 --json`,
         )
         .action((targetType: string, targetRef: string, emoji: string, options: ReactOptions) => {
             if (!['thread', 'comment', 'message'].includes(targetType)) {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -208,7 +208,9 @@ tw away clear                    # Clear away status
 tw react thread <ref> 👍         # Add reaction to thread
 tw react comment <ref> +1        # Add reaction (shortcode)
 tw react message <ref> heart     # Add reaction to DM message
+tw react thread <ref> 👍 --json  # Output result as JSON
 tw unreact thread <ref> 👍       # Remove reaction
+tw unreact thread <ref> 👍 --json # Output result as JSON
 \`\`\`
 
 Supported shortcodes: +1, -1, heart, tada, smile, laughing, thinking, fire, check, x, eyes, pray, clap, rocket, wave

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -109,6 +109,7 @@ tw comment <comment-ref>                       # View a comment (shorthand for v
 tw comment view <comment-ref>                  # View a single thread comment
 tw comment view <comment-ref> --raw            # Show raw markdown
 tw comment view <comment-ref> --json           # Output as JSON
+tw comment view <comment-ref> --ndjson         # Output as newline-delimited JSON
 tw comment view <comment-ref> --json --full    # Include all fields in JSON output
 tw comment update <comment-ref> "new content"  # Update a thread comment
 tw comment update <comment-ref> "content" --json  # Update and return updated comment as JSON


### PR DESCRIPTION
## Summary
Follow-up to #175 — audits every command for missing `--json` / `--ndjson` support and closes three gaps:

- **`tw react` / `tw unreact`** — emitted plain text only; the only mutating commands without `--json`. Adds `--json` that outputs `{ targetType, targetId, emoji, action }` (and `dryRun: true` for dry-run).
- **`tw comment view`** — declared `--json` but not `--ndjson`, even though `tw thread view` and `tw msg view` both do. Adds `--ndjson` matching the single-item-wrapped-in-array pattern those siblings use.
- **`tw conversation with`** — declared `--json` / `--ndjson` but the not-found branch fell back to a plain-English message, breaking JSON consumers. Routes the empty case through `listConversationsWithUser` so `--json` emits `[]` and `--ndjson` emits nothing.

Each gap is its own commit so they can be reviewed independently. A final commit regenerates `skills/twist-cli/SKILL.md`.

## Test plan
- [x] `npm test` passes (448 tests, +5 new)
- [x] `npm run type-check`, `npm run lint:check`, pre-push test hook all clean
- [x] `npm run sync:skill` clean; SKILL.md regenerated
- [ ] Manual smoke: `tw react thread <id> +1 --json | jq .` returns `{ action: "added", ... }`
- [ ] Manual smoke: `tw unreact thread <id> +1 --json --dry-run | jq .dryRun` returns `true` and the API is not called
- [ ] Manual smoke: `tw comment view <id> --ndjson` emits a single NDJSON line
- [ ] Manual smoke: `tw conversation with <user> --json` when no DM exists returns `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)