### PR TITLE
fix(dry-run): run validation before short-circuit and print structured preview

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -274,7 +274,7 @@ All list/view commands support:
 
 ## Dry Run
 
-Mutating commands accept `--dry-run` to preview the operation without making the change. Validation (resource fetches, permission checks) runs first, so dry-run fails the same way the real command would if the target doesn't exist or isn't accessible. The preview is structured:
+Mutating commands accept `--dry-run` to preview the operation without making the change. Where a command performs pre-flight validation (e.g. fetching the target thread to check channel access or ownership), those checks still run in dry-run — only the mutating write is skipped. Commands that have no pre-flight validation parse the reference and print the preview without hitting the API. The preview is structured:
 
 ```
 [dry-run] Would <action>:

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -272,6 +272,17 @@ All list/view commands support:
 --full    # Include all fields (default shows essential fields only)
 ```
 
+## Dry Run
+
+Mutating commands accept `--dry-run` to preview the operation without making the change. Validation (resource fetches, permission checks) runs first, so dry-run fails the same way the real command would if the target doesn't exist or isn't accessible. The preview is structured:
+
+```
+[dry-run] Would <action>:
+  <Key>: <resolved value>
+  ...
+Run without --dry-run to execute.
+```
+
 ## Reference System
 
 Commands accept flexible references:

--- a/src/__tests__/away.test.ts
+++ b/src/__tests__/away.test.ts
@@ -124,7 +124,7 @@ describe('away', () => {
             ])
 
             expect(apiMocks.updateUser).not.toHaveBeenCalled()
-            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Dry run'))
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would set away status'))
             logSpy.mockRestore()
         })
 
@@ -169,7 +169,7 @@ describe('away', () => {
             await program.parseAsync(['node', 'tw', 'away', 'clear', '--dry-run'])
 
             expect(apiMocks.updateUser).not.toHaveBeenCalled()
-            expect(logSpy).toHaveBeenCalledWith('Dry run: would clear away status')
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Would clear away status'))
             logSpy.mockRestore()
         })
     })

--- a/src/__tests__/comment.test.ts
+++ b/src/__tests__/comment.test.ts
@@ -176,8 +176,9 @@ describe('comment update', () => {
             '--dry-run',
         ])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would update comment 300')
-        expect(consoleSpy).toHaveBeenCalledWith('New content')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update comment'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Comment: 300')
+        expect(consoleSpy).toHaveBeenCalledWith('  Content: New content')
         consoleSpy.mockRestore()
     })
 
@@ -247,7 +248,8 @@ describe('comment delete', () => {
 
         await program.parseAsync(['node', 'tw', 'comment', 'delete', '300', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would delete comment 300')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete comment'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Comment: 300')
         consoleSpy.mockRestore()
     })
 

--- a/src/__tests__/conversation.test.ts
+++ b/src/__tests__/conversation.test.ts
@@ -582,9 +582,9 @@ describe('conversation mute', () => {
 
         await program.parseAsync(['node', 'tw', 'conversation', 'mute', '42', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith(
-            'Dry run: would mute conversation 42 for 60 minutes',
-        )
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would mute conversation'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Conversation: 42')
+        expect(consoleSpy).toHaveBeenCalledWith('  Duration: 60 minutes')
 
         consoleSpy.mockRestore()
     })
@@ -625,7 +625,10 @@ describe('conversation unmute', () => {
 
         await program.parseAsync(['node', 'tw', 'conversation', 'unmute', '42', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would unmute conversation 42')
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Would unmute conversation'),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith('  Conversation: 42')
 
         consoleSpy.mockRestore()
     })

--- a/src/__tests__/lib/output.test.ts
+++ b/src/__tests__/lib/output.test.ts
@@ -71,6 +71,22 @@ describe('printDryRun', () => {
         logSpy.mockRestore()
     })
 
+    it('indents continuation lines for multiline values', () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        printDryRun('update thread', {
+            Content: 'First line\nSecond line\nThird line',
+        })
+
+        expect(logSpy).toHaveBeenNthCalledWith(1, '[dry-run] Would update thread:')
+        expect(logSpy).toHaveBeenNthCalledWith(2, '  Content: First line')
+        expect(logSpy).toHaveBeenNthCalledWith(3, '    Second line')
+        expect(logSpy).toHaveBeenNthCalledWith(4, '    Third line')
+        expect(logSpy).toHaveBeenNthCalledWith(5, 'Run without --dry-run to execute.')
+
+        logSpy.mockRestore()
+    })
+
     it('works without details', () => {
         const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 

--- a/src/__tests__/lib/output.test.ts
+++ b/src/__tests__/lib/output.test.ts
@@ -1,5 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isAccessible, resetGlobalArgs } from '../../lib/global-args.js'
+import { printDryRun } from '../../lib/output.js'
+
+vi.mock('chalk')
 
 describe('isAccessible', () => {
     const originalArgv = [...process.argv]
@@ -35,5 +38,47 @@ describe('isAccessible', () => {
         process.argv = ['node', 'tw', '--accessible']
         resetGlobalArgs()
         expect(isAccessible()).toBe(true)
+    })
+})
+
+describe('printDryRun', () => {
+    it('prints header, details, and footer', () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        printDryRun('delete thread', { Thread: 'My thread (500)' })
+
+        expect(logSpy).toHaveBeenNthCalledWith(1, '[dry-run] Would delete thread:')
+        expect(logSpy).toHaveBeenNthCalledWith(2, '  Thread: My thread (500)')
+        expect(logSpy).toHaveBeenNthCalledWith(3, 'Run without --dry-run to execute.')
+
+        logSpy.mockRestore()
+    })
+
+    it('skips undefined values', () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        printDryRun('mute thread', {
+            Thread: 'My thread (500)',
+            Notes: undefined,
+            Duration: '60 minutes',
+        })
+
+        const calls = logSpy.mock.calls.map((c) => c[0])
+        expect(calls).toContain('  Thread: My thread (500)')
+        expect(calls).toContain('  Duration: 60 minutes')
+        expect(calls.some((line) => String(line).includes('Notes'))).toBe(false)
+
+        logSpy.mockRestore()
+    })
+
+    it('works without details', () => {
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        printDryRun('clear away status')
+
+        expect(logSpy).toHaveBeenCalledWith('[dry-run] Would clear away status:')
+        expect(logSpy).toHaveBeenCalledWith('Run without --dry-run to execute.')
+
+        logSpy.mockRestore()
     })
 })

--- a/src/__tests__/thread.test.ts
+++ b/src/__tests__/thread.test.ts
@@ -136,6 +136,9 @@ function createClient({
                 return Promise.resolve(channel)
             }),
         },
+        inbox: {
+            archiveThread: vi.fn(async () => undefined),
+        },
         workspaceUsers: {
             getUserById: vi.fn(
                 (
@@ -219,7 +222,9 @@ describe('thread implicit view', () => {
             '--dry-run',
         ])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would post comment to thread 100')
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Would post comment to thread'),
+        )
         consoleSpy.mockRestore()
     })
 
@@ -243,7 +248,7 @@ describe('thread implicit view', () => {
         ])
 
         expect(consoleSpy).toHaveBeenCalledWith(
-            'Dry run: would post comment to thread 100 and close it',
+            expect.stringContaining('Would post comment to thread and close it'),
         )
         consoleSpy.mockRestore()
     })
@@ -268,7 +273,7 @@ describe('thread implicit view', () => {
         ])
 
         expect(consoleSpy).toHaveBeenCalledWith(
-            'Dry run: would post comment to thread 100 and reopen it',
+            expect.stringContaining('Would post comment to thread and reopen it'),
         )
         consoleSpy.mockRestore()
     })
@@ -566,9 +571,9 @@ describe('thread create', () => {
             '--dry-run',
         ])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would create thread in channel', 100)
-        expect(consoleSpy).toHaveBeenCalledWith('Title: Test Title')
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run content')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would create thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Title: Test Title')
+        expect(consoleSpy).toHaveBeenCalledWith('  Content: Dry run content')
 
         consoleSpy.mockRestore()
     })
@@ -734,14 +739,33 @@ describe('thread mute', () => {
     })
 
     it('shows dry run output', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await program.parseAsync(['node', 'tw', 'thread', 'mute', '500', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would mute thread 500 for 60 minutes')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would mute thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Thread: Test Thread (500)')
+        expect(consoleSpy).toHaveBeenCalledWith('  Duration: 60 minutes')
+        expect(client.threads.muteThread).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
+    })
+
+    it('runs validation in dry-run mode', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        client.threads.getThread.mockRejectedValueOnce(new Error('thread not found'))
+
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'mute', '500', '--dry-run']),
+        ).rejects.toThrow('thread not found')
+        expect(client.threads.muteThread).not.toHaveBeenCalled()
     })
 
     it('outputs JSON with --json including id and mutedUntil', async () => {
@@ -791,14 +815,32 @@ describe('thread unmute', () => {
     })
 
     it('shows dry run output', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await program.parseAsync(['node', 'tw', 'thread', 'unmute', '500', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would unmute thread 500')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would unmute thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Thread: Test Thread (500)')
+        expect(client.threads.unmuteThread).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
+    })
+
+    it('runs validation in dry-run mode', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        client.threads.getThread.mockRejectedValueOnce(new Error('thread not found'))
+
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'unmute', '500', '--dry-run']),
+        ).rejects.toThrow('thread not found')
+        expect(client.threads.unmuteThread).not.toHaveBeenCalled()
     })
 })
 
@@ -842,7 +884,8 @@ describe('thread delete', () => {
 
         await program.parseAsync(['node', 'tw', 'thread', 'delete', '500', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would delete thread 500')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would delete thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Thread: Test Thread (500)')
         expect(client.threads.deleteThread).not.toHaveBeenCalled()
         consoleSpy.mockRestore()
     })
@@ -906,6 +949,9 @@ describe('thread rename', () => {
     })
 
     it('shows dry run output', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
@@ -919,9 +965,25 @@ describe('thread rename', () => {
             '--dry-run',
         ])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would rename thread 500 to "New Title"')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would rename thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Thread: Test Thread (500)')
+        expect(consoleSpy).toHaveBeenCalledWith('  New title: New Title')
+        expect(client.threads.updateThread).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
+    })
+
+    it('runs validation in dry-run mode', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        client.threads.getThread.mockRejectedValueOnce(new Error('thread not found'))
+
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'rename', '500', 'New Title', '--dry-run']),
+        ).rejects.toThrow('thread not found')
+        expect(client.threads.updateThread).not.toHaveBeenCalled()
     })
 
     it('outputs JSON with --json including id and title', async () => {
@@ -1001,8 +1063,9 @@ describe('thread update', () => {
 
         await program.parseAsync(['node', 'tw', 'thread', 'update', '500', 'New body', '--dry-run'])
 
-        expect(consoleSpy).toHaveBeenCalledWith('Dry run: would update thread 500')
-        expect(consoleSpy).toHaveBeenCalledWith('New body')
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would update thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Thread: Test Thread (500)')
+        expect(consoleSpy).toHaveBeenCalledWith('  Content: New body')
         expect(client.threads.updateThread).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
@@ -1052,5 +1115,68 @@ describe('thread update', () => {
         expect(Object.keys(jsonOutput)).toEqual(['id', 'content'])
 
         consoleSpy.mockRestore()
+    })
+
+    it('runs validation in dry-run mode', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        client.threads.getThread.mockRejectedValueOnce(new Error('thread not found'))
+
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'update', '500', 'New body', '--dry-run']),
+        ).rejects.toThrow('thread not found')
+        expect(client.threads.updateThread).not.toHaveBeenCalled()
+    })
+})
+
+describe('thread done', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('archives a thread', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'done', '500'])
+
+        expect(client.inbox.archiveThread).toHaveBeenCalledWith(500)
+        expect(consoleSpy).toHaveBeenCalledWith('Thread 500 archived.')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('shows dry run output', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'done', '500', '--dry-run'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Would archive thread'))
+        expect(consoleSpy).toHaveBeenCalledWith('  Thread: Test Thread (500)')
+        expect(client.inbox.archiveThread).not.toHaveBeenCalled()
+
+        consoleSpy.mockRestore()
+    })
+
+    it('runs validation in dry-run mode', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        client.threads.getThread.mockRejectedValueOnce(new Error('thread not found'))
+
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'done', '500', '--dry-run']),
+        ).rejects.toThrow('thread not found')
+        expect(client.inbox.archiveThread).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/away/clear.ts
+++ b/src/commands/away/clear.ts
@@ -1,9 +1,9 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions, ViewOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 export async function clearAway(options: MutationOptions & ViewOptions): Promise<void> {
     if (options.dryRun) {
-        console.log('Dry run: would clear away status')
+        printDryRun('clear away status')
         return
     }
 

--- a/src/commands/away/set.ts
+++ b/src/commands/away/set.ts
@@ -2,7 +2,7 @@ import { AWAY_MODE_TYPES, type AwayModeType } from '@doist/twist-sdk'
 import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { MutationOptions, ViewOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { formatAwayType, todayStr, tomorrowStr } from './helpers.js'
 
 type SetAwayOptions = ViewOptions & MutationOptions & { from?: string }
@@ -23,9 +23,11 @@ export async function setAway(
     const dateTo = until ?? tomorrowStr()
 
     if (options.dryRun) {
-        console.log(
-            `Dry run: would set away to ${formatAwayType(type)} from ${dateFrom} until ${dateTo}`,
-        )
+        printDryRun('set away status', {
+            Type: formatAwayType(type),
+            From: dateFrom,
+            Until: dateTo,
+        })
         return
     }
 

--- a/src/commands/comment/delete.ts
+++ b/src/commands/comment/delete.ts
@@ -1,6 +1,6 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveCommentId } from '../../lib/refs.js'
 
 type DeleteOptions = MutationOptions
@@ -9,7 +9,9 @@ export async function deleteComment(ref: string, options: DeleteOptions): Promis
     const commentId = resolveCommentId(ref)
 
     if (options.dryRun) {
-        console.log(`Dry run: would delete comment ${commentId}`)
+        printDryRun('delete comment', {
+            Comment: String(commentId),
+        })
         return
     }
 

--- a/src/commands/comment/update.ts
+++ b/src/commands/comment/update.ts
@@ -2,7 +2,7 @@ import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveCommentId } from '../../lib/refs.js'
 
 type UpdateOptions = MutationOptions
@@ -29,9 +29,11 @@ export async function updateComment(
     }
 
     if (options.dryRun) {
-        console.log(`Dry run: would update comment ${commentId}`)
-        console.log('')
-        console.log(newContent)
+        const preview = newContent.length > 200 ? `${newContent.slice(0, 200)}...` : newContent
+        printDryRun('update comment', {
+            Comment: String(commentId),
+            Content: preview,
+        })
         return
     }
 

--- a/src/commands/conversation/done.ts
+++ b/src/commands/conversation/done.ts
@@ -1,5 +1,5 @@
 import { getTwistClient } from '../../lib/api.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveConversationId } from '../../lib/refs.js'
 import type { DoneOptions } from './helpers.js'
 
@@ -7,7 +7,9 @@ export async function markConversationDone(ref: string, options: DoneOptions): P
     const conversationId = resolveConversationId(ref)
 
     if (options.dryRun) {
-        console.log(`Dry run: would archive conversation ${conversationId}`)
+        printDryRun('archive conversation', {
+            Conversation: String(conversationId),
+        })
         return
     }
 

--- a/src/commands/conversation/mute.ts
+++ b/src/commands/conversation/mute.ts
@@ -1,5 +1,5 @@
 import { getTwistClient } from '../../lib/api.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveConversationId } from '../../lib/refs.js'
 import { type MuteOptions, parseMinutes } from './helpers.js'
 
@@ -8,7 +8,10 @@ export async function muteConversation(ref: string, options: MuteOptions): Promi
     const minutes = parseMinutes(options.minutes)
 
     if (options.dryRun) {
-        console.log(`Dry run: would mute conversation ${conversationId} for ${minutes} minutes`)
+        printDryRun('mute conversation', {
+            Conversation: String(conversationId),
+            Duration: `${minutes} minutes`,
+        })
         return
     }
 

--- a/src/commands/conversation/reply.ts
+++ b/src/commands/conversation/reply.ts
@@ -1,7 +1,7 @@
 import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveConversationId } from '../../lib/refs.js'
 import type { ReplyOptions } from './helpers.js'
 
@@ -27,9 +27,12 @@ export async function replyToConversation(
     }
 
     if (options.dryRun) {
-        console.log('Dry run: would send message to conversation', conversationId)
-        console.log('')
-        console.log(replyContent)
+        const preview =
+            replyContent.length > 200 ? `${replyContent.slice(0, 200)}...` : replyContent
+        printDryRun('send message to conversation', {
+            Conversation: String(conversationId),
+            Content: preview,
+        })
         return
     }
 

--- a/src/commands/conversation/unmute.ts
+++ b/src/commands/conversation/unmute.ts
@@ -1,13 +1,15 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveConversationId } from '../../lib/refs.js'
 
 export async function unmuteConversation(ref: string, options: MutationOptions): Promise<void> {
     const conversationId = resolveConversationId(ref)
 
     if (options.dryRun) {
-        console.log(`Dry run: would unmute conversation ${conversationId}`)
+        printDryRun('unmute conversation', {
+            Conversation: String(conversationId),
+        })
         return
     }
 

--- a/src/commands/msg/delete.ts
+++ b/src/commands/msg/delete.ts
@@ -1,6 +1,6 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveMessageId } from '../../lib/refs.js'
 
 type DeleteOptions = MutationOptions
@@ -9,7 +9,9 @@ export async function deleteMessage(ref: string, options: DeleteOptions): Promis
     const messageId = resolveMessageId(ref)
 
     if (options.dryRun) {
-        console.log(`Dry run: would delete message ${messageId}`)
+        printDryRun('delete message', {
+            Message: String(messageId),
+        })
         return
     }
 

--- a/src/commands/msg/update.ts
+++ b/src/commands/msg/update.ts
@@ -2,7 +2,7 @@ import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveMessageId } from '../../lib/refs.js'
 
 type UpdateOptions = MutationOptions
@@ -29,9 +29,11 @@ export async function updateMessage(
     }
 
     if (options.dryRun) {
-        console.log(`Dry run: would update message ${messageId}`)
-        console.log('')
-        console.log(newContent)
+        const preview = newContent.length > 200 ? `${newContent.slice(0, 200)}...` : newContent
+        printDryRun('update message', {
+            Message: String(messageId),
+            Content: preview,
+        })
         return
     }
 

--- a/src/commands/react.ts
+++ b/src/commands/react.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander'
 import { getTwistClient } from '../lib/api.js'
 import { CliError } from '../lib/errors.js'
 import type { MutationOptions } from '../lib/options.js'
-import { formatJson } from '../lib/output.js'
+import { formatJson, printDryRun } from '../lib/output.js'
 import { resolveCommentId, resolveMessageId, resolveThreadId } from '../lib/refs.js'
 
 type TargetType = 'thread' | 'comment' | 'message'
@@ -63,7 +63,10 @@ async function addReaction(
             )
             return
         }
-        console.log(`Dry run: would add ${normalizedEmoji} to ${targetType} ${targetId}`)
+        printDryRun('add reaction', {
+            Target: `${targetType} ${targetId}`,
+            Emoji: normalizedEmoji,
+        })
         return
     }
 
@@ -114,7 +117,10 @@ async function removeReaction(
             )
             return
         }
-        console.log(`Dry run: would remove ${normalizedEmoji} from ${targetType} ${targetId}`)
+        printDryRun('remove reaction', {
+            Target: `${targetType} ${targetId}`,
+            Emoji: normalizedEmoji,
+        })
         return
     }
 

--- a/src/commands/thread/create.ts
+++ b/src/commands/thread/create.ts
@@ -2,10 +2,10 @@ import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { parseUserIdRefs, resolveChannelId } from '../../lib/refs.js'
-import { type ResolvedNotify, printNotifyLines, resolveNotifyIds } from './helpers.js'
+import { type ResolvedNotify, formatNotifyLabel, resolveNotifyIds } from './helpers.js'
 
 type CreateOptions = MutationOptions & {
     notify?: string
@@ -45,13 +45,21 @@ export async function createThread(
     }
 
     if (options.dryRun) {
-        console.log('Dry run: would create thread in channel', channelId)
-        console.log(`Title: ${title}`)
-        if (resolved) {
-            printNotifyLines(resolved.notified)
-        }
-        console.log('')
-        console.log(threadContent)
+        const preview =
+            threadContent.length > 200 ? `${threadContent.slice(0, 200)}...` : threadContent
+        printDryRun('create thread', {
+            Channel: `${channel.name} (${channelId})`,
+            Title: title,
+            'Notify users':
+                resolved && resolved.notified.users.length > 0
+                    ? formatNotifyLabel(resolved.notified.users)
+                    : undefined,
+            'Notify groups':
+                resolved && resolved.notified.groups.length > 0
+                    ? formatNotifyLabel(resolved.notified.groups)
+                    : undefined,
+            Content: preview,
+        })
         return
     }
 

--- a/src/commands/thread/delete.ts
+++ b/src/commands/thread/delete.ts
@@ -1,7 +1,7 @@
 import { assertBatchData, getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveThreadId } from '../../lib/refs.js'
 
@@ -26,7 +26,9 @@ export async function deleteThread(ref: string, options: DeleteOptions): Promise
     }
 
     if (options.dryRun) {
-        console.log(`Dry run: would delete thread ${threadId}`)
+        printDryRun('delete thread', {
+            Thread: `${thread.title} (${threadId})`,
+        })
         return
     }
 

--- a/src/commands/thread/helpers.ts
+++ b/src/commands/thread/helpers.ts
@@ -75,12 +75,3 @@ export async function resolveNotifyIds(
 export function formatNotifyLabel(items: NamedEntity[]): string {
     return items.map((i) => `${i.name} (${i.id})`).join(', ')
 }
-
-export function printNotifyLines(notified: NotifiedInfo): void {
-    if (notified.users.length > 0) {
-        console.log(`Notify users: ${formatNotifyLabel(notified.users)}`)
-    }
-    if (notified.groups.length > 0) {
-        console.log(`Notify groups: ${formatNotifyLabel(notified.groups)}`)
-    }
-}

--- a/src/commands/thread/mutate.ts
+++ b/src/commands/thread/mutate.ts
@@ -1,6 +1,6 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveThreadId } from '../../lib/refs.js'
 
@@ -9,14 +9,17 @@ type DoneOptions = MutationOptions
 export async function markThreadDone(ref: string, options: DoneOptions): Promise<void> {
     const threadId = resolveThreadId(ref)
 
-    if (options.dryRun) {
-        console.log(`Dry run: would archive thread ${threadId}`)
-        return
-    }
-
     const client = await getTwistClient()
     const thread = await client.threads.getThread(threadId)
     await assertChannelIsPublic(thread.channelId, thread.workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('archive thread', {
+            Thread: `${thread.title} (${threadId})`,
+        })
+        return
+    }
+
     await client.inbox.archiveThread(threadId)
 
     if (options.json) {

--- a/src/commands/thread/mute.ts
+++ b/src/commands/thread/mute.ts
@@ -1,7 +1,7 @@
 import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveThreadId } from '../../lib/refs.js'
 
@@ -25,14 +25,17 @@ export async function muteThread(ref: string, options: MuteOptions): Promise<voi
     const threadId = resolveThreadId(ref)
     const minutes = parseMinutes(options.minutes)
 
-    if (options.dryRun) {
-        console.log(`Dry run: would mute thread ${threadId} for ${minutes} minutes`)
-        return
-    }
-
     const client = await getTwistClient()
     const thread = await client.threads.getThread(threadId)
     await assertChannelIsPublic(thread.channelId, thread.workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('mute thread', {
+            Thread: `${thread.title} (${threadId})`,
+            Duration: `${minutes} minutes`,
+        })
+        return
+    }
 
     const updated = await client.threads.muteThread({ id: threadId, minutes })
 
@@ -51,14 +54,16 @@ export async function muteThread(ref: string, options: MuteOptions): Promise<voi
 export async function unmuteThread(ref: string, options: MutationOptions): Promise<void> {
     const threadId = resolveThreadId(ref)
 
-    if (options.dryRun) {
-        console.log(`Dry run: would unmute thread ${threadId}`)
-        return
-    }
-
     const client = await getTwistClient()
     const thread = await client.threads.getThread(threadId)
     await assertChannelIsPublic(thread.channelId, thread.workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('unmute thread', {
+            Thread: `${thread.title} (${threadId})`,
+        })
+        return
+    }
 
     const updated = await client.threads.unmuteThread(threadId)
 

--- a/src/commands/thread/rename.ts
+++ b/src/commands/thread/rename.ts
@@ -1,6 +1,6 @@
 import { getTwistClient } from '../../lib/api.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveThreadId } from '../../lib/refs.js'
 
@@ -11,14 +11,17 @@ export async function renameThread(
 ): Promise<void> {
     const threadId = resolveThreadId(ref)
 
-    if (options.dryRun) {
-        console.log(`Dry run: would rename thread ${threadId} to "${title}"`)
-        return
-    }
-
     const client = await getTwistClient()
     const thread = await client.threads.getThread(threadId)
     await assertChannelIsPublic(thread.channelId, thread.workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('rename thread', {
+            Thread: `${thread.title} (${threadId})`,
+            'New title': title,
+        })
+        return
+    }
 
     const updated = await client.threads.updateThread({ id: threadId, title })
 

--- a/src/commands/thread/reply.ts
+++ b/src/commands/thread/reply.ts
@@ -2,10 +2,10 @@ import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { parseUserIdRefs, resolveThreadId } from '../../lib/refs.js'
-import { type ResolvedNotify, printNotifyLines, resolveNotifyIds } from './helpers.js'
+import { type ResolvedNotify, formatNotifyLabel, resolveNotifyIds } from './helpers.js'
 
 type ReplyOptions = MutationOptions & {
     notify?: string
@@ -60,14 +60,21 @@ export async function replyToThread(
 
     if (options.dryRun) {
         const actionSuffix = actionLabel ? ` and ${actionLabel} it` : ''
-        console.log(`Dry run: would post comment to thread ${threadId}${actionSuffix}`)
-        if (isSpecialRecipient) {
-            console.log(`Notify: ${notifyValue}`)
-        } else if (resolved) {
-            printNotifyLines(resolved.notified)
-        }
-        console.log('')
-        console.log(replyContent)
+        const preview =
+            replyContent.length > 200 ? `${replyContent.slice(0, 200)}...` : replyContent
+        printDryRun(`post comment to thread${actionSuffix}`, {
+            Thread: `${thread.title} (${threadId})`,
+            Notify: isSpecialRecipient ? notifyValue : undefined,
+            'Notify users':
+                !isSpecialRecipient && resolved && resolved.notified.users.length > 0
+                    ? formatNotifyLabel(resolved.notified.users)
+                    : undefined,
+            'Notify groups':
+                !isSpecialRecipient && resolved && resolved.notified.groups.length > 0
+                    ? formatNotifyLabel(resolved.notified.groups)
+                    : undefined,
+            Content: preview,
+        })
         return
     }
 

--- a/src/commands/thread/update.ts
+++ b/src/commands/thread/update.ts
@@ -2,7 +2,7 @@ import { getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
-import { formatJson } from '../../lib/output.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveThreadId } from '../../lib/refs.js'
 
@@ -34,9 +34,11 @@ export async function updateThread(
     await assertChannelIsPublic(thread.channelId, thread.workspaceId)
 
     if (options.dryRun) {
-        console.log(`Dry run: would update thread ${threadId}`)
-        console.log('')
-        console.log(newContent)
+        const preview = newContent.length > 200 ? `${newContent.slice(0, 200)}...` : newContent
+        printDryRun('update thread', {
+            Thread: `${thread.title} (${threadId})`,
+            Content: preview,
+        })
         return
     }
 

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -227,3 +227,16 @@ export function printNdjson<T extends object>(items: T[], type?: EntityType, ful
 export function pluralize(count: number, singular: string): string {
     return count === 1 ? singular : `${singular}s`
 }
+
+export function printDryRun(
+    action: string,
+    details: Record<string, string | undefined> = {},
+): void {
+    console.log(chalk.yellow(`[dry-run] Would ${action}:`))
+    for (const [key, value] of Object.entries(details)) {
+        if (value !== undefined) {
+            console.log(`  ${key}: ${value}`)
+        }
+    }
+    console.log(chalk.dim('Run without --dry-run to execute.'))
+}

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -235,7 +235,11 @@ export function printDryRun(
     console.log(chalk.yellow(`[dry-run] Would ${action}:`))
     for (const [key, value] of Object.entries(details)) {
         if (value !== undefined) {
-            console.log(`  ${key}: ${value}`)
+            const [firstLine, ...rest] = value.split('\n')
+            console.log(`  ${key}: ${firstLine}`)
+            for (const line of rest) {
+                console.log(`    ${line}`)
+            }
         }
     }
     console.log(chalk.dim('Run without --dry-run to execute.'))

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -273,7 +273,7 @@ All list/view commands support:
 
 ## Dry Run
 
-Mutating commands accept \`--dry-run\` to preview the operation without making the change. Validation (resource fetches, permission checks) runs first, so dry-run fails the same way the real command would if the target doesn't exist or isn't accessible. The preview is structured:
+Mutating commands accept \`--dry-run\` to preview the operation without making the change. Where a command performs pre-flight validation (e.g. fetching the target thread to check channel access or ownership), those checks still run in dry-run — only the mutating write is skipped. Commands that have no pre-flight validation parse the reference and print the preview without hitting the API. The preview is structured:
 
 \`\`\`
 [dry-run] Would <action>:

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -271,6 +271,17 @@ All list/view commands support:
 --full    # Include all fields (default shows essential fields only)
 \`\`\`
 
+## Dry Run
+
+Mutating commands accept \`--dry-run\` to preview the operation without making the change. Validation (resource fetches, permission checks) runs first, so dry-run fails the same way the real command would if the target doesn't exist or isn't accessible. The preview is structured:
+
+\`\`\`
+[dry-run] Would <action>:
+  <Key>: <resolved value>
+  ...
+Run without --dry-run to execute.
+\`\`\`
+
 ## Reference System
 
 Commands accept flexible references:


### PR DESCRIPTION
Part of #135.

## Summary
- **Bug fix**: `thread done`, `thread mute`, `thread unmute`, `thread rename` now run `getThread` + `assertChannelIsPublic` *before* the `--dry-run` short-circuit. Previously, a dry-run against a missing or inaccessible thread falsely reported success — it now fails the same way the real command would.
- **Actionable output**: new `printDryRun(action, details)` helper in `src/lib/output.ts` (modelled on the todoist-cli pattern) replaces the old `Dry run: would ...` one-liners with a structured preview showing resolved state.
- **Adopted everywhere**: all 18 `--dry-run` call sites (thread, conversation, msg, comment, away, react/unreact) now use the helper. Resource references show resolved data (e.g. thread title + id) instead of raw IDs.
- `SKILL_CONTENT` picks up a brief Dry Run section; `SKILL.md` regenerated.

### New output format
```
[dry-run] Would mute thread:
  Thread: Fix the login bug (500)
  Duration: 60 minutes
Run without --dry-run to execute.
```

### Breaking change (output only)
The dry-run message format changes from `Dry run: would mute thread 500 for 60 minutes` to the structured form above. Any external scraper of dry-run text needs to update its parser. CLI syntax is unchanged.

### Out of scope

These will be done in later PRs

- No new pre-fetch validation added to commands that currently have none (`conversation done/mute/unmute`, `msg delete`, `comment delete`). The issue asks that existing validation not be skipped; introducing new validation is a separate concern.
- JSON dry-run remains text-only except for `react`/`unreact`, which already emitted JSON dry-run and keeps its existing shape.

## Test plan
- [x] `npm run lint:check` — clean
- [x] `npm run type-check` — clean
- [x] `npm run check:skill-sync` — in sync
- [x] `npm test` — 458 tests pass (new tests prove validation runs in dry-run for the four fixed commands; new unit tests for `printDryRun`)
- [x] Smoke-tested `tw away clear --dry-run`, `tw away set vacation 2026-05-01 --dry-run`, `tw react thread 123 +1 --dry-run` (text + JSON) against the built binary
- [ ] Manual spot-check on a real workspace: `tw thread mute <valid-id> --minutes 30 --dry-run` renders resolved title; `tw thread mute 999999 --dry-run` fails with "thread not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)