### PR TITLE
feat(skill): align with agentskills.io spec and validate in CI

### DIFF
--- a/.github/workflows/check-skill-sync.yml
+++ b/.github/workflows/check-skill-sync.yml
@@ -29,3 +29,13 @@ jobs:
 
             - name: Check SKILL.md is in sync
               run: npm run check:skill-sync
+
+            - name: Validate SKILL.md against agentskills.io spec
+              run: |
+                  if ! gh skill --help >/dev/null 2>&1; then
+                      echo "::notice::gh skill subcommand not available on this runner (requires gh >= 2.90.0); skipping validation"
+                      exit 0
+                  fi
+                  gh skill publish --dry-run
+              env:
+                  GH_TOKEN: ${{ github.token }}

--- a/release.config.js
+++ b/release.config.js
@@ -22,10 +22,16 @@ export default {
         ...(isPrerelease
             ? []
             : [
+                  ['@semantic-release/exec', { prepareCmd: 'npm run sync:skill' }],
                   [
                       '@semantic-release/git',
                       {
-                          assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+                          assets: [
+                              'CHANGELOG.md',
+                              'package.json',
+                              'package-lock.json',
+                              'skills/twist-cli/SKILL.md',
+                          ],
                           message:
                               'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
                       },

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: twist-cli
-description: "Twist messaging CLI for team communication"
+description: "Twist messaging CLI. View and respond to inbox threads, channel threads, direct messages, and group conversations; search, react, archive, mute, and manage workspaces. Use when the user mentions Twist, asks about their inbox, threads, DMs, channels, or wants to read or send Twist messages."
+license: MIT
+metadata:
+  author: Doist
+  version: "2.31.2"
 ---
 
 # Twist CLI (tw)

--- a/src/__tests__/skill.test.ts
+++ b/src/__tests__/skill.test.ts
@@ -7,9 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('chalk')
 
 import { registerSkillCommand } from '../commands/skill/index.js'
-import { SKILL_FILE_CONTENT } from '../lib/skills/content.js'
+import { SKILL_FILE_CONTENT, SKILL_VERSION } from '../lib/skills/content.js'
 import { createInstaller } from '../lib/skills/create-installer.js'
 import { getInstaller, listAgentNames, listAgents, skillInstallers } from '../lib/skills/index.js'
+
+const packageJson = JSON.parse(
+    await readFile(new URL('../../package.json', import.meta.url), 'utf-8'),
+) as { version: string }
 
 function createProgram() {
     const program = new Command()
@@ -120,7 +124,16 @@ describe('installer operations', () => {
         const skillPath = installer.getInstallPath({ local: true })
         const content = await readFile(skillPath, 'utf-8')
         expect(content).toBe(SKILL_FILE_CONTENT)
-        expect(content).toContain('description: "Twist messaging CLI for team communication"')
+        expect(content).toContain('name: twist-cli')
+        expect(content).toContain('description: "Twist messaging CLI.')
+        expect(content).toContain('license: MIT')
+        expect(content).toContain('author: Doist')
+        expect(content).toContain(`version: "${SKILL_VERSION}"`)
+    })
+
+    it('embeds the package.json version in skill metadata', () => {
+        expect(SKILL_VERSION).toBe(packageJson.version)
+        expect(SKILL_FILE_CONTENT).toContain(`version: "${packageJson.version}"`)
     })
 
     it('reports not installed initially', async () => {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -1,6 +1,18 @@
+import { readFileSync } from 'node:fs'
+
 export const SKILL_NAME = 'twist-cli'
 
-export const SKILL_DESCRIPTION = 'Twist messaging CLI for team communication'
+export const SKILL_DESCRIPTION =
+    'Twist messaging CLI. View and respond to inbox threads, channel threads, direct messages, and group conversations; search, react, archive, mute, and manage workspaces. Use when the user mentions Twist, asks about their inbox, threads, DMs, channels, or wants to read or send Twist messages.'
+
+export const SKILL_AUTHOR = 'Doist'
+
+export const SKILL_LICENSE = 'MIT'
+
+const packageJsonUrl = new URL('../../../package.json', import.meta.url)
+const packageJson = JSON.parse(readFileSync(packageJsonUrl, 'utf-8')) as { version: string }
+
+export const SKILL_VERSION = packageJson.version
 
 export const SKILL_CONTENT = `# Twist CLI (tw)
 
@@ -337,6 +349,10 @@ tw conversation reply <id> "Got it, thanks!"
 export const SKILL_FILE_CONTENT = `---
 name: ${SKILL_NAME}
 description: ${JSON.stringify(SKILL_DESCRIPTION)}
+license: ${SKILL_LICENSE}
+metadata:
+  author: ${SKILL_AUTHOR}
+  version: ${JSON.stringify(SKILL_VERSION)}
 ---
 
 ${SKILL_CONTENT}`

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import packageJson from '../../../package.json' with { type: 'json' }
 
 export const SKILL_NAME = 'twist-cli'
 
@@ -8,9 +8,6 @@ export const SKILL_DESCRIPTION =
 export const SKILL_AUTHOR = 'Doist'
 
 export const SKILL_LICENSE = 'MIT'
-
-const packageJsonUrl = new URL('../../../package.json', import.meta.url)
-const packageJson = JSON.parse(readFileSync(packageJsonUrl, 'utf-8')) as { version: string }
 
 export const SKILL_VERSION = packageJson.version
 


### PR DESCRIPTION
## Summary
- Brings the `twist-cli` skill up to the [agentskills.io spec](https://agentskills.io/specification): expands the `description` so it describes *what* the skill does and *when* to use it (with discovery keywords — inbox, threads, DMs, channels, etc.), and adds the optional `license: MIT` plus a `metadata` block with `author: Doist` and a `version` sourced dynamically from `package.json`.
- Wires `@semantic-release/exec` into the stable-release pipeline to run `npm run sync:skill` after `@semantic-release/npm` bumps the version, and includes `skills/twist-cli/SKILL.md` in the `@semantic-release/git` assets — so the committed skill file never lags the package version and `check:skill-sync` stays green post-release.
- Adds a `gh skill publish --dry-run` step to the existing **Skill Sync Check** workflow so broken frontmatter, naming violations, or stripped install metadata are caught on PRs rather than surfacing at release time. The step is guarded with a `gh skill --help` probe: if the subcommand isn't present on the runner (it is a preview feature in `gh >= 2.90.0`), the step emits a GitHub Actions notice and exits 0 instead of failing.

Inspired by Doist/todoist-cli#275 and Doist/todoist-cli#276.

## Why this (and not a release-pipeline hook for publishing)?
`gh skill install` resolves to the latest tagged release in the repo, and our semantic-release flow already produces those tags plus the matching GitHub release. The `agent-skills` topic is already set. So no separate skill-publish step is needed — every CLI release is already the skill release. Validation in CI was the only missing piece.

## Test plan
- [x] `npm run build && npm run sync:skill` regenerates `skills/twist-cli/SKILL.md` cleanly
- [x] `npm run check:skill-sync` passes
- [x] `npm run type-check` and `npm run lint:check` clean
- [x] `npm test` — 471 tests pass, including the new `SKILL_VERSION === package.json.version` assertion
- [x] Local `gh skill publish --dry-run` (gh 2.90.0) reports `Dry run complete.`
- [ ] Confirm **Skill Sync Check** CI job runs both the sync check and the new validation step
- [ ] On the next stable release: verify the `chore(release)` commit includes the regenerated `SKILL.md` with the bumped `metadata.version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)