### PR TITLE
refactor: use new SDK time filter params for inbox and thread comments

### DIFF
--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -87,6 +87,31 @@ describe('inbox --archive-filter', () => {
             { batch: true },
         )
     })
+
+    it('maps --since to newerThan and --until to olderThan for getInbox', async () => {
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'inbox',
+            '--since',
+            '2026-01-01',
+            '--until',
+            '2026-02-01',
+            '--json',
+        ])
+
+        expect(mockGetInbox).toHaveBeenCalledWith(
+            expect.objectContaining({
+                newerThan: new Date('2026-01-01'),
+                olderThan: new Date('2026-02-01'),
+            }),
+            { batch: true },
+        )
+        const [args] = mockGetInbox.mock.calls[0] as [Record<string, unknown>]
+        expect(args).not.toHaveProperty('since')
+        expect(args).not.toHaveProperty('until')
+    })
 })
 
 const emptyInboxMockBatch = vi.fn()

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -43,8 +43,8 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         client.inbox.getInbox(
             {
                 workspaceId,
-                since: options.since ? new Date(options.since) : undefined,
-                until: options.until ? new Date(options.until) : undefined,
+                newerThan: options.since ? new Date(options.since) : undefined,
+                olderThan: options.until ? new Date(options.until) : undefined,
                 limit,
                 archiveFilter: options.archiveFilter ?? 'active',
             },

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -483,6 +483,46 @@ describe('thread view --unread', () => {
     })
 })
 
+describe('thread view --since', () => {
+    beforeEach(() => {
+        vi.resetAllMocks()
+    })
+
+    it('maps --since to newerThan for getComments', async () => {
+        const client = createClient({
+            comments: [createComment(1, 1)],
+            users: { 1: { id: 1, name: 'Alice' }, 2: { id: 2, name: 'Bob' } },
+        })
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'view',
+            '500',
+            '--since',
+            '2026-01-01',
+            '--json',
+        ])
+
+        expect(client.comments.getComments).toHaveBeenCalledWith(
+            expect.objectContaining({
+                threadId: 500,
+                newerThan: new Date('2026-01-01'),
+            }),
+            { batch: true },
+        )
+        const [args] = client.comments.getComments.mock.calls[0] as [Record<string, unknown>]
+        expect(args).not.toHaveProperty('from')
+
+        consoleSpy.mockRestore()
+    })
+})
+
 describe('thread view with failed batch response', () => {
     beforeEach(() => {
         vi.resetAllMocks()

--- a/src/commands/thread/view.ts
+++ b/src/commands/thread/view.ts
@@ -97,7 +97,7 @@ export async function viewThread(ref: string, options: ViewOptions): Promise<voi
         client.comments.getComments(
             {
                 threadId,
-                from: options.since ? new Date(options.since) : undefined,
+                newerThan: options.since ? new Date(options.since) : undefined,
                 limit,
             },
             { batch: true },


### PR DESCRIPTION
## Summary
- Bump `@doist/twist-sdk` from 2.4.0 → 2.4.1 to pick up the standardized `newerThan`/`olderThan` params.
- `client.comments.getComments`: `from` → `newerThan` (the old `from` was silently dropped by the API).
- `client.inbox.getInbox`: `since`/`until` → `newerThan`/`olderThan` (same — silently dropped).
- CLI-facing flags (`--since`, `--until`) are unchanged; only the SDK call sites were renamed.
- `threads.getThreads` and `inbox.archiveAll` got the same SDK treatment but aren't used in the CLI, so no call sites to update there.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm test` passes (471 tests)
- [x] `npm run lint:check` passes
- [ ] Smoke: `tw inbox --since 2025-01-01` returns threads filtered by date
- [ ] Smoke: `tw thread view <id> --since 2025-01-01` returns comments filtered by date