### PR TITLE
feat!: require --yes on msg/comment delete and thread/conversation done

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -205,6 +205,7 @@ Arguments:
 
 Options:
 
+- `--yes` - Confirm archive (required to execute)
 - `--dry-run` - Show what would happen without executing
 
 ---
@@ -276,6 +277,7 @@ Arguments:
 
 Options:
 
+- `--yes` - Confirm archive (required to execute)
 - `--dry-run` - Show what would happen without executing
 
 ---
@@ -322,6 +324,7 @@ Arguments:
 
 Options:
 
+- `--yes` - Confirm deletion (required to execute)
 - `--dry-run` - Show what would happen without executing
 
 ---
@@ -499,7 +502,7 @@ echo "Multiline\nreply" | tw thread reply id:123456
 tw thread reply id:123456  # opens $EDITOR
 
 # Mark thread as done
-tw thread done id:123456
+tw thread done id:123456 --yes
 
 # List unread conversations
 tw conversation unread

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -82,8 +82,9 @@ tw thread reply <ref> "content" --json  # Post and return comment as JSON
 tw thread reply <ref> "content" --json --full  # Include all comment fields
 tw thread reply <ref> "content" --close       # Reply and close the thread
 tw thread reply <ref> "content" --reopen      # Reply and reopen a closed thread
-tw thread done <ref>             # Archive thread (mark done)
-tw thread done <ref> --json      # Archive and return status as JSON
+tw thread done <ref>                 # Preview thread archive (requires --yes to execute)
+tw thread done <ref> --yes           # Archive thread (mark done)
+tw thread done <ref> --yes --json    # Archive and return status as JSON
 tw thread mute <ref>             # Mute thread for 60 minutes (default)
 tw thread mute <ref> --minutes 480  # Mute for custom duration
 tw thread mute <ref> --json      # Mute and return { id, mutedUntil } as JSON
@@ -119,8 +120,9 @@ tw comment view <comment-ref> --json --full    # Include all fields in JSON outp
 tw comment update <comment-ref> "new content"  # Update a thread comment
 tw comment update <comment-ref> "content" --json  # Update and return updated comment as JSON
 tw comment update <comment-ref> "content" --json --full  # Include all comment fields
-tw comment delete <comment-ref>                # Delete a thread comment
-tw comment delete <comment-ref> --json         # Delete and return status as JSON
+tw comment delete <comment-ref>                     # Preview comment deletion (requires --yes to execute)
+tw comment delete <comment-ref> --yes               # Delete a thread comment
+tw comment delete <comment-ref> --yes --json        # Delete and return status as JSON
 ```
 
 ## Conversations (DMs/Groups)
@@ -135,8 +137,9 @@ tw conversation with <user-ref> --include-groups # List any conversations with t
 tw conversation reply <ref> "content"     # Send a message
 tw conversation reply <ref> "content" --json  # Send and return message as JSON
 tw conversation reply <ref> "content" --json --full  # Include all message fields
-tw conversation done <ref>                # Archive conversation
-tw conversation done <ref> --json         # Archive and return status as JSON
+tw conversation done <ref>                    # Preview conversation archive (requires --yes to execute)
+tw conversation done <ref> --yes              # Archive conversation
+tw conversation done <ref> --yes --json       # Archive and return status as JSON
 tw conversation mute <ref>               # Mute conversation for 60 minutes (default)
 tw conversation mute <ref> --minutes 480 # Mute for custom duration
 tw conversation mute <ref> --json        # Mute and return { id, mutedUntil } as JSON
@@ -155,8 +158,9 @@ tw msg view <message-ref>        # View a single conversation message
 tw msg update <ref> "content"    # Edit a conversation message
 tw msg update <ref> "content" --json  # Edit and return updated message as JSON
 tw msg update <ref> "content" --json --full  # Include all message fields
-tw msg delete <ref>              # Delete a conversation message
-tw msg delete <ref> --json       # Delete and return status as JSON
+tw msg delete <ref>                  # Preview message deletion (requires --yes to execute)
+tw msg delete <ref> --yes            # Delete a conversation message
+tw msg delete <ref> --yes --json     # Delete and return status as JSON
 ```
 
 Alias: `tw message` works the same as `tw msg`.
@@ -321,7 +325,7 @@ tw view https://twist.com/a/1585/msg/400/m/500 --json    # View message as JSON
 tw inbox --unread --json
 tw thread view <id> --unread
 tw thread reply <id> "Thanks, I'll look into this."
-tw thread done <id>
+tw thread done <id> --yes
 ```
 
 **Search and review:**

--- a/src/commands/comment/comment.test.ts
+++ b/src/commands/comment/comment.test.ts
@@ -254,7 +254,20 @@ describe('comment delete', () => {
         vi.clearAllMocks()
     })
 
-    it('deletes a comment', async () => {
+    it('deletes a comment with --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'comment', 'delete', '300', '--yes'])
+
+        expect(client.comments.deleteComment).toHaveBeenCalledWith(300)
+        expect(consoleSpy).toHaveBeenCalledWith('Comment 300 deleted.')
+        consoleSpy.mockRestore()
+    })
+
+    it('prompts for confirmation without --yes', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)
         const program = createProgram()
@@ -262,8 +275,9 @@ describe('comment delete', () => {
 
         await program.parseAsync(['node', 'tw', 'comment', 'delete', '300'])
 
-        expect(client.comments.deleteComment).toHaveBeenCalledWith(300)
-        expect(consoleSpy).toHaveBeenCalledWith('Comment 300 deleted.')
+        expect(consoleSpy).toHaveBeenCalledWith('Would delete comment 300')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        expect(client.comments.deleteComment).not.toHaveBeenCalled()
         consoleSpy.mockRestore()
     })
 
@@ -307,16 +321,28 @@ describe('comment delete', () => {
         expect(client.comments.deleteComment).not.toHaveBeenCalled()
     })
 
-    it('outputs JSON with --json', async () => {
+    it('outputs JSON with --json --yes', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'comment', 'delete', '300', '--json'])
+        await program.parseAsync(['node', 'tw', 'comment', 'delete', '300', '--json', '--yes'])
 
         const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
         expect(jsonOutput).toEqual({ id: 300, deleted: true })
         consoleSpy.mockRestore()
+    })
+
+    it('errors when --json is used without --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'comment', 'delete', '300', '--json']),
+        ).rejects.toHaveProperty('code', 'MISSING_YES_FLAG')
+
+        expect(client.comments.deleteComment).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/comment/delete.ts
+++ b/src/commands/comment/delete.ts
@@ -5,7 +5,7 @@ import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveCommentId } from '../../lib/refs.js'
 
-type DeleteOptions = MutationOptions
+type DeleteOptions = MutationOptions & { yes?: boolean }
 
 export async function deleteComment(ref: string, options: DeleteOptions): Promise<void> {
     const commentId = resolveCommentId(ref)
@@ -33,6 +33,18 @@ export async function deleteComment(ref: string, options: DeleteOptions): Promis
             Thread: String(comment.threadId),
             Content: preview,
         })
+        return
+    }
+
+    if (!options.yes) {
+        if (options.json) {
+            throw new CliError(
+                'MISSING_YES_FLAG',
+                '--yes is required to execute deletion in --json mode.',
+            )
+        }
+        console.log(`Would delete comment ${commentId}`)
+        console.log('Use --yes to confirm.')
         return
     }
 

--- a/src/commands/comment/index.ts
+++ b/src/commands/comment/index.ts
@@ -49,13 +49,14 @@ Examples:
     comment
         .command('delete <comment-ref>')
         .description('Delete a thread comment')
+        .option('--yes', 'Confirm deletion')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
         .addHelpText(
             'after',
             `
 Examples:
-  tw comment delete 12345
+  tw comment delete 12345 --yes
   tw comment delete 12345 --dry-run`,
         )
         .action(deleteComment)

--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -679,7 +679,23 @@ describe('conversation done', () => {
         vi.clearAllMocks()
     })
 
-    it('archives a conversation', async () => {
+    it('archives a conversation with --yes', async () => {
+        const conversation = createConversation(42, [1, 2], '2026-03-08T10:00:00.000Z')
+        const client = createClient({ activeConversations: [conversation] })
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'conversation', 'done', '42', '--yes'])
+
+        expect(client.conversations.archiveConversation).toHaveBeenCalledWith(42)
+        expect(consoleSpy).toHaveBeenCalledWith('Conversation 42 archived.')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('prompts for confirmation without --yes', async () => {
         const conversation = createConversation(42, [1, 2], '2026-03-08T10:00:00.000Z')
         const client = createClient({ activeConversations: [conversation] })
         apiMocks.getTwistClient.mockResolvedValue(client)
@@ -689,10 +705,40 @@ describe('conversation done', () => {
 
         await program.parseAsync(['node', 'tw', 'conversation', 'done', '42'])
 
-        expect(client.conversations.archiveConversation).toHaveBeenCalledWith(42)
-        expect(consoleSpy).toHaveBeenCalledWith('Conversation 42 archived.')
+        expect(consoleSpy).toHaveBeenCalledWith('Would archive: conversation 42')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        expect(client.conversations.archiveConversation).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json --yes', async () => {
+        const conversation = createConversation(42, [1, 2], '2026-03-08T10:00:00.000Z')
+        const client = createClient({ activeConversations: [conversation] })
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'conversation', 'done', '42', '--json', '--yes'])
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput).toEqual({ id: 42, archived: true })
+
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when --json is used without --yes', async () => {
+        const conversation = createConversation(42, [1, 2], '2026-03-08T10:00:00.000Z')
+        const client = createClient({ activeConversations: [conversation] })
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'conversation', 'done', '42', '--json']),
+        ).rejects.toHaveProperty('code', 'MISSING_YES_FLAG')
+
+        expect(client.conversations.archiveConversation).not.toHaveBeenCalled()
     })
 
     it('shows dry run output', async () => {

--- a/src/commands/conversation/done.ts
+++ b/src/commands/conversation/done.ts
@@ -1,4 +1,5 @@
 import { getTwistClient } from '../../lib/api.js'
+import { CliError } from '../../lib/errors.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveConversationId } from '../../lib/refs.js'
 import { conversationLabel, type DoneOptions } from './helpers.js'
@@ -7,13 +8,25 @@ export async function markConversationDone(ref: string, options: DoneOptions): P
     const conversationId = resolveConversationId(ref)
 
     const client = await getTwistClient()
+    const conversation = await client.conversations.getConversation(conversationId)
 
     if (options.dryRun) {
-        const conversation = await client.conversations.getConversation(conversationId)
         printDryRun('archive conversation', {
             Conversation: conversationLabel(conversation),
             Status: conversation.archived ? 'already archived' : undefined,
         })
+        return
+    }
+
+    if (!options.yes) {
+        if (options.json) {
+            throw new CliError(
+                'MISSING_YES_FLAG',
+                '--yes is required to execute archive in --json mode.',
+            )
+        }
+        console.log(`Would archive: ${conversationLabel(conversation)}`)
+        console.log('Use --yes to confirm.')
         return
     }
 

--- a/src/commands/conversation/done.ts
+++ b/src/commands/conversation/done.ts
@@ -8,9 +8,9 @@ export async function markConversationDone(ref: string, options: DoneOptions): P
     const conversationId = resolveConversationId(ref)
 
     const client = await getTwistClient()
-    const conversation = await client.conversations.getConversation(conversationId)
 
     if (options.dryRun) {
+        const conversation = await client.conversations.getConversation(conversationId)
         printDryRun('archive conversation', {
             Conversation: conversationLabel(conversation),
             Status: conversation.archived ? 'already archived' : undefined,
@@ -25,6 +25,7 @@ export async function markConversationDone(ref: string, options: DoneOptions): P
                 '--yes is required to execute archive in --json mode.',
             )
         }
+        const conversation = await client.conversations.getConversation(conversationId)
         console.log(`Would archive: ${conversationLabel(conversation)}`)
         console.log('Use --yes to confirm.')
         return

--- a/src/commands/conversation/helpers.ts
+++ b/src/commands/conversation/helpers.ts
@@ -22,7 +22,7 @@ export type ReplyOptions = MutationOptions
 
 export type MuteOptions = MutationOptions & { minutes?: string }
 
-export type DoneOptions = MutationOptions
+export type DoneOptions = MutationOptions & { yes?: boolean }
 
 export const CONVERSATION_PAGE_LIMIT = 100
 

--- a/src/commands/conversation/index.ts
+++ b/src/commands/conversation/index.ts
@@ -93,13 +93,14 @@ Examples:
     conversation
         .command('done <conversation-ref>')
         .description('Archive a conversation')
+        .option('--yes', 'Confirm archive')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
         .addHelpText(
             'after',
             `
 Examples:
-  tw conversation done 12345
+  tw conversation done 12345 --yes
   tw conversation done 12345 --dry-run`,
         )
         .action(markConversationDone)

--- a/src/commands/msg/delete.ts
+++ b/src/commands/msg/delete.ts
@@ -4,7 +4,7 @@ import type { MutationOptions } from '../../lib/options.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { resolveMessageId } from '../../lib/refs.js'
 
-type DeleteOptions = MutationOptions
+type DeleteOptions = MutationOptions & { yes?: boolean }
 
 export async function deleteMessage(ref: string, options: DeleteOptions): Promise<void> {
     const messageId = resolveMessageId(ref)
@@ -30,6 +30,18 @@ export async function deleteMessage(ref: string, options: DeleteOptions): Promis
             Conversation: String(message.conversationId),
             Content: preview,
         })
+        return
+    }
+
+    if (!options.yes) {
+        if (options.json) {
+            throw new CliError(
+                'MISSING_YES_FLAG',
+                '--yes is required to execute deletion in --json mode.',
+            )
+        }
+        console.log(`Would delete message ${messageId}`)
+        console.log('Use --yes to confirm.')
         return
     }
 

--- a/src/commands/msg/index.ts
+++ b/src/commands/msg/index.ts
@@ -47,13 +47,14 @@ Examples:
 
     msg.command('delete <message-ref>')
         .description('Delete a conversation message')
+        .option('--yes', 'Confirm deletion')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
         .addHelpText(
             'after',
             `
 Examples:
-  tw msg delete 12345
+  tw msg delete 12345 --yes
   tw msg delete 12345 --dry-run`,
         )
         .action(deleteMessage)

--- a/src/commands/msg/msg.test.ts
+++ b/src/commands/msg/msg.test.ts
@@ -102,7 +102,20 @@ describe('msg delete', () => {
         vi.clearAllMocks()
     })
 
-    it('deletes a message', async () => {
+    it('deletes a message with --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'msg', 'delete', '200', '--yes'])
+
+        expect(client.conversationMessages.deleteMessage).toHaveBeenCalledWith(200)
+        expect(consoleSpy).toHaveBeenCalledWith('Message 200 deleted.')
+        consoleSpy.mockRestore()
+    })
+
+    it('prompts for confirmation without --yes', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)
         const program = createProgram()
@@ -110,8 +123,9 @@ describe('msg delete', () => {
 
         await program.parseAsync(['node', 'tw', 'msg', 'delete', '200'])
 
-        expect(client.conversationMessages.deleteMessage).toHaveBeenCalledWith(200)
-        expect(consoleSpy).toHaveBeenCalledWith('Message 200 deleted.')
+        expect(consoleSpy).toHaveBeenCalledWith('Would delete message 200')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        expect(client.conversationMessages.deleteMessage).not.toHaveBeenCalled()
         consoleSpy.mockRestore()
     })
 
@@ -141,16 +155,28 @@ describe('msg delete', () => {
         expect(client.conversationMessages.deleteMessage).not.toHaveBeenCalled()
     })
 
-    it('outputs JSON with --json', async () => {
+    it('outputs JSON with --json --yes', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'msg', 'delete', '200', '--json'])
+        await program.parseAsync(['node', 'tw', 'msg', 'delete', '200', '--json', '--yes'])
 
         const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
         expect(jsonOutput).toEqual({ id: 200, deleted: true })
         consoleSpy.mockRestore()
+    })
+
+    it('errors when --json is used without --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'msg', 'delete', '200', '--json']),
+        ).rejects.toHaveProperty('code', 'MISSING_YES_FLAG')
+
+        expect(client.conversationMessages.deleteMessage).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/thread/index.ts
+++ b/src/commands/thread/index.ts
@@ -88,15 +88,16 @@ Examples:
     thread
         .command('done <thread-ref>')
         .description('Archive a thread (mark as done)')
+        .option('--yes', 'Confirm archive')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
         .addHelpText(
             'after',
             `
 Examples:
-  tw thread done 12345
+  tw thread done 12345 --yes
   tw thread done 12345 --dry-run
-  tw thread done 12345 --json`,
+  tw thread done 12345 --json --yes`,
         )
         .action(markThreadDone)
 

--- a/src/commands/thread/mutate.ts
+++ b/src/commands/thread/mutate.ts
@@ -1,10 +1,11 @@
 import { getTwistClient } from '../../lib/api.js'
+import { CliError } from '../../lib/errors.js'
 import type { MutationOptions } from '../../lib/options.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
 import { assertChannelIsPublic } from '../../lib/public-channels.js'
 import { resolveThreadId } from '../../lib/refs.js'
 
-type DoneOptions = MutationOptions
+type DoneOptions = MutationOptions & { yes?: boolean }
 
 export async function markThreadDone(ref: string, options: DoneOptions): Promise<void> {
     const threadId = resolveThreadId(ref)
@@ -17,6 +18,18 @@ export async function markThreadDone(ref: string, options: DoneOptions): Promise
         printDryRun('archive thread', {
             Thread: `${thread.title} (${threadId})`,
         })
+        return
+    }
+
+    if (!options.yes) {
+        if (options.json) {
+            throw new CliError(
+                'MISSING_YES_FLAG',
+                '--yes is required to execute archive in --json mode.',
+            )
+        }
+        console.log(`Would archive: ${thread.title}`)
+        console.log('Use --yes to confirm.')
         return
     }
 

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -1136,7 +1136,22 @@ describe('thread done', () => {
         vi.clearAllMocks()
     })
 
-    it('archives a thread', async () => {
+    it('archives a thread with --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'done', '500', '--yes'])
+
+        expect(client.inbox.archiveThread).toHaveBeenCalledWith(500)
+        expect(consoleSpy).toHaveBeenCalledWith('Thread 500 archived.')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('prompts for confirmation without --yes', async () => {
         const client = createClient()
         apiMocks.getTwistClient.mockResolvedValue(client)
 
@@ -1145,10 +1160,38 @@ describe('thread done', () => {
 
         await program.parseAsync(['node', 'tw', 'thread', 'done', '500'])
 
-        expect(client.inbox.archiveThread).toHaveBeenCalledWith(500)
-        expect(consoleSpy).toHaveBeenCalledWith('Thread 500 archived.')
+        expect(consoleSpy).toHaveBeenCalledWith('Would archive: Test Thread')
+        expect(consoleSpy).toHaveBeenCalledWith('Use --yes to confirm.')
+        expect(client.inbox.archiveThread).not.toHaveBeenCalled()
 
         consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'done', '500', '--json', '--yes'])
+
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput).toEqual({ id: 500, isArchived: true })
+
+        consoleSpy.mockRestore()
+    })
+
+    it('errors when --json is used without --yes', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'thread', 'done', '500', '--json']),
+        ).rejects.toHaveProperty('code', 'MISSING_YES_FLAG')
+
+        expect(client.inbox.archiveThread).not.toHaveBeenCalled()
     })
 
     it('shows dry run output', async () => {

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -86,8 +86,9 @@ tw thread reply <ref> "content" --json  # Post and return comment as JSON
 tw thread reply <ref> "content" --json --full  # Include all comment fields
 tw thread reply <ref> "content" --close       # Reply and close the thread
 tw thread reply <ref> "content" --reopen      # Reply and reopen a closed thread
-tw thread done <ref>             # Archive thread (mark done)
-tw thread done <ref> --json      # Archive and return status as JSON
+tw thread done <ref>                 # Preview thread archive (requires --yes to execute)
+tw thread done <ref> --yes           # Archive thread (mark done)
+tw thread done <ref> --yes --json    # Archive and return status as JSON
 tw thread mute <ref>             # Mute thread for 60 minutes (default)
 tw thread mute <ref> --minutes 480  # Mute for custom duration
 tw thread mute <ref> --json      # Mute and return { id, mutedUntil } as JSON
@@ -123,8 +124,9 @@ tw comment view <comment-ref> --json --full    # Include all fields in JSON outp
 tw comment update <comment-ref> "new content"  # Update a thread comment
 tw comment update <comment-ref> "content" --json  # Update and return updated comment as JSON
 tw comment update <comment-ref> "content" --json --full  # Include all comment fields
-tw comment delete <comment-ref>                # Delete a thread comment
-tw comment delete <comment-ref> --json         # Delete and return status as JSON
+tw comment delete <comment-ref>                     # Preview comment deletion (requires --yes to execute)
+tw comment delete <comment-ref> --yes               # Delete a thread comment
+tw comment delete <comment-ref> --yes --json        # Delete and return status as JSON
 \`\`\`
 
 ## Conversations (DMs/Groups)
@@ -139,8 +141,9 @@ tw conversation with <user-ref> --include-groups # List any conversations with t
 tw conversation reply <ref> "content"     # Send a message
 tw conversation reply <ref> "content" --json  # Send and return message as JSON
 tw conversation reply <ref> "content" --json --full  # Include all message fields
-tw conversation done <ref>                # Archive conversation
-tw conversation done <ref> --json         # Archive and return status as JSON
+tw conversation done <ref>                    # Preview conversation archive (requires --yes to execute)
+tw conversation done <ref> --yes              # Archive conversation
+tw conversation done <ref> --yes --json       # Archive and return status as JSON
 tw conversation mute <ref>               # Mute conversation for 60 minutes (default)
 tw conversation mute <ref> --minutes 480 # Mute for custom duration
 tw conversation mute <ref> --json        # Mute and return { id, mutedUntil } as JSON
@@ -159,8 +162,9 @@ tw msg view <message-ref>        # View a single conversation message
 tw msg update <ref> "content"    # Edit a conversation message
 tw msg update <ref> "content" --json  # Edit and return updated message as JSON
 tw msg update <ref> "content" --json --full  # Include all message fields
-tw msg delete <ref>              # Delete a conversation message
-tw msg delete <ref> --json       # Delete and return status as JSON
+tw msg delete <ref>                  # Preview message deletion (requires --yes to execute)
+tw msg delete <ref> --yes            # Delete a conversation message
+tw msg delete <ref> --yes --json     # Delete and return status as JSON
 \`\`\`
 
 Alias: \`tw message\` works the same as \`tw msg\`.
@@ -325,7 +329,7 @@ tw view https://twist.com/a/1585/msg/400/m/500 --json    # View message as JSON
 tw inbox --unread --json
 tw thread view <id> --unread
 tw thread reply <id> "Thanks, I'll look into this."
-tw thread done <id>
+tw thread done <id> --yes
 \`\`\`
 
 **Search and review:**


### PR DESCRIPTION
## Summary

Closes #134. Extends the existing `tw thread delete` `--yes` confirmation pattern to the remaining destructive/state-changing commands: `tw msg delete`, `tw comment delete`, `tw thread done`, and `tw conversation done`.

- Without `--yes`: prints a preview (`Would delete message 42` / `Would archive: …`) and exits without mutating.
- `--json` without `--yes`: throws `MISSING_YES_FLAG` — matches `thread delete`.
- `--dry-run` still short-circuits before the `--yes` gate (validation pre-checks continue to run, consistent with existing dry-run behavior).
- No shared helper introduced — the gate is inlined per-command to match the existing `thread/delete.ts` style.

### Why

Agents replay/retry commands more freely than humans; idempotent archive operations produce no error signal on repeat, and deletes can silently run twice. Requiring `--yes` makes the mutation intent explicit. See Principle 4 of the [7 Principles for Agent-Friendly CLIs](https://trevinsays.com/p/7-principles-for-agent-friendly-clis).

### Breaking change

Scripts/agents that call any of these four commands without `--yes` will now preview instead of mutating. The `feat!:` prefix signals a major version bump on release.

## Test plan

- [x] `npm test` — 481/481 pass (added preview, `--json --yes` success, and `--json` → `MISSING_YES_FLAG` cases to each command's test file)
- [x] `npm run type-check` — clean
- [x] `npm run lint:check` — clean
- [ ] Manual smoke on a scratch thread/conversation/message the session user owns:
  - [ ] `tw msg delete <id>` → preview; `--yes` → deletes; `--json` alone → errors.
  - [ ] `tw comment delete <id>` → preview; `--yes` → deletes; `--json` alone → errors.
  - [ ] `tw thread done <id>` → preview; `--yes` → archives; `--json` alone → errors; `--dry-run` alone → preview (no `--yes` needed).
  - [ ] `tw conversation done <id>` → same as above.
  - [ ] Regression: `tw thread delete` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)