### PR TITLE
feat(config): add `tw config view` to inspect the CLI config file

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -23,6 +23,7 @@ tw auth logout                   # Remove saved token and auth metadata
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions
+tw config view                   # Show the current CLI configuration file (token masked)
 tw doctor                        # Diagnose CLI setup and environment issues
 tw update                        # Update CLI to latest version
 tw changelog                     # Show recent changelog entries
@@ -237,6 +238,14 @@ tw completion uninstall          # Remove completions
 tw doctor                        # Run local + network diagnostics
 tw doctor --offline              # Skip Twist and npm network checks
 tw doctor --json                 # JSON output with per-check results
+```
+
+### Configuration
+
+```bash
+tw config view                   # Pretty-printed config, token masked, labels actual token source
+tw config view --json            # Raw JSON, token masked
+tw config view --show-token      # Include the full token
 ```
 
 ### Update

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -1,0 +1,237 @@
+import { Command } from 'commander'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('chalk')
+
+vi.mock('../../lib/config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/config.js')>()
+    return {
+        ...actual,
+        CONFIG_PATH: '/tmp/fake-twist-cli/config.json',
+        readConfigStrict: vi.fn(),
+    }
+})
+
+vi.mock('../../lib/auth.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/auth.js')>()
+    return {
+        ...actual,
+        probeApiToken: vi.fn(),
+    }
+})
+
+import { NoTokenError, probeApiToken } from '../../lib/auth.js'
+import { type Config, readConfigStrict } from '../../lib/config.js'
+import { CliError } from '../../lib/errors.js'
+import { SecureStoreUnavailableError } from '../../lib/secure-store.js'
+import { registerConfigCommand } from './index.js'
+
+const mockReadConfigStrict = vi.mocked(readConfigStrict)
+const mockProbeApiToken = vi.mocked(probeApiToken)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerConfigCommand(program)
+    return program
+}
+
+const fullConfig: Config = {
+    token: 'tw_abcdefghij1234567890',
+    authMode: 'read-write',
+    authScope: 'user:read',
+    currentWorkspace: 12345,
+    updateChannel: 'stable',
+}
+
+function presentConfig(config: Config = fullConfig) {
+    mockReadConfigStrict.mockResolvedValue({ state: 'present', config })
+}
+
+function missingConfig() {
+    mockReadConfigStrict.mockResolvedValue({ state: 'missing' })
+}
+
+function mockToken(
+    source: 'env' | 'secure-store' | 'config-file',
+    overrides: Partial<{
+        token: string
+        authMode: 'read-only' | 'read-write' | 'unknown'
+        authScope: string
+    }> = {},
+) {
+    mockProbeApiToken.mockResolvedValue({
+        token: overrides.token ?? (fullConfig.token as string),
+        metadata: {
+            authMode: overrides.authMode ?? 'read-write',
+            authScope: overrides.authScope,
+            source,
+        },
+    })
+}
+
+describe('config view', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('prints a pretty layout with the token masked by default', async () => {
+        presentConfig()
+        mockToken('config-file', { authScope: 'user:read' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('/tmp/fake-twist-cli/config.json')
+        expect(output).toContain('Authentication')
+        expect(output).toContain('Workspace')
+        expect(output).toContain('Updates')
+        expect(output).toContain('****…7890')
+        expect(output).not.toContain('tw_abcdefghij1234567890')
+        expect(output).toContain('config file (plaintext fallback)')
+        expect(output).toContain('read-write')
+        expect(output).toContain('12345')
+        expect(output).toContain('stable')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('labels tokens stored in the system credential manager', async () => {
+        presentConfig({ authMode: 'read-write' })
+        mockToken('secure-store', { token: 'tw_keychainXXXXXXXX1234' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('****…1234')
+        expect(output).toContain('system credential manager')
+        expect(output).not.toContain('plaintext')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('labels env-sourced tokens and shows active mode, not stale config values', async () => {
+        // Config has a stale read-only entry from a previous `tw auth login`,
+        // but TWIST_API_TOKEN is now driving auth with an unknown scope.
+        presentConfig({
+            authMode: 'read-only',
+            authScope: 'user:read',
+        })
+        mockToken('env', { token: 'tw_envXXXXXXXX5678', authMode: 'unknown' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('****…5678')
+        expect(output).toContain('TWIST_API_TOKEN')
+        // Active mode is unknown (env scope isn't introspectable), not read-only.
+        expect(output).toContain('Mode:          unknown')
+        expect(output).not.toMatch(/Scope:\s+user:read/)
+
+        consoleSpy.mockRestore()
+    })
+
+    it('degrades gracefully when the credential manager is unavailable', async () => {
+        presentConfig({ authMode: 'read-write', updateChannel: 'stable' })
+        mockProbeApiToken.mockRejectedValue(new SecureStoreUnavailableError('macOS Keychain error'))
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('unknown')
+        expect(output).toContain('system credential manager unavailable')
+        expect(output).toContain('stable')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('--json emits the raw config with token masked', async () => {
+        presentConfig()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view', '--json'])
+
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(parsed.token).toBe('****…7890')
+        expect(parsed.authMode).toBe('read-write')
+        expect(parsed.currentWorkspace).toBe(12345)
+
+        consoleSpy.mockRestore()
+    })
+
+    it('--show-token reveals the full token in both views', async () => {
+        presentConfig()
+        mockToken('config-file')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view', '--show-token'])
+        const pretty = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(pretty).toContain('tw_abcdefghij1234567890')
+
+        consoleSpy.mockClear()
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view', '--json', '--show-token'])
+        const json = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(json.token).toBe('tw_abcdefghij1234567890')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('handles a missing config file gracefully', async () => {
+        missingConfig()
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+        expect(consoleSpy.mock.calls[0][0]).toContain('not created yet')
+
+        consoleSpy.mockClear()
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view', '--json'])
+        expect(consoleSpy.mock.calls[0][0]).toBe('{}')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('surfaces malformed-config errors instead of silently pretending it is empty', async () => {
+        mockReadConfigStrict.mockRejectedValue(
+            new CliError(
+                'CONFIG_INVALID_JSON',
+                'Config file at /tmp/fake-twist-cli/config.json is not valid JSON: Unexpected token',
+                ['Fix the JSON'],
+            ),
+        )
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+
+        await expect(
+            createProgram().parseAsync(['node', 'tw', 'config', 'view']),
+        ).rejects.toMatchObject({ code: 'CONFIG_INVALID_JSON' })
+    })
+
+    it('shows "not set" when no token can be found anywhere', async () => {
+        presentConfig({ updateChannel: 'stable' })
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('not set')
+        expect(output).toContain('stable')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('masks very short tokens without exposing characters', async () => {
+        presentConfig({ token: 'abcd' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view', '--json'])
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0] as string)
+        expect(parsed.token).toBe('****')
+        expect(parsed.token).not.toContain('abcd')
+
+        consoleSpy.mockRestore()
+    })
+})

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -129,7 +129,43 @@ describe('config view', () => {
         expect(output).toContain('TWIST_API_TOKEN')
         // Active mode is unknown (env scope isn't introspectable), not read-only.
         expect(output).toContain('Mode:          unknown')
+        // Scope is genuinely unintrospectable for env tokens — render as
+        // 'unknown', not 'not set', to avoid reading as an explicit empty scope.
+        expect(output).toContain('Scope:         unknown')
         expect(output).not.toMatch(/Scope:\s+user:read/)
+        expect(output).not.toMatch(/Scope:\s+not set/)
+
+        consoleSpy.mockRestore()
+    })
+
+    it('annotates a missing config file even when a token is present', async () => {
+        // User runs with TWIST_API_TOKEN set but no config file yet —
+        // the header must clearly report that the file does not exist.
+        missingConfig()
+        mockToken('env', { token: 'tw_envXXXXXXXX9999', authMode: 'unknown' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('/tmp/fake-twist-cli/config.json')
+        expect(output).toContain('not created yet')
+        expect(output).toContain('****…9999')
+        expect(output).toContain('TWIST_API_TOKEN')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('runs view by default when no subcommand is given', async () => {
+        presentConfig()
+        mockToken('config-file')
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('Authentication')
+        expect(output).toContain('****…7890')
 
         consoleSpy.mockRestore()
     })

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,22 @@
+import { Command } from 'commander'
+import { viewConfig } from './view.js'
+
+export function registerConfigCommand(program: Command): void {
+    const config = program.command('config').description('Manage CLI configuration')
+
+    config
+        .command('view')
+        .description('Show the current CLI configuration file')
+        .option('--json', 'Output the raw config as JSON')
+        .option('--show-token', 'Include the full token instead of masking it')
+        .action(viewConfig)
+
+    config.addHelpText(
+        'after',
+        `
+Examples:
+  $ tw config view                  # pretty-printed, token masked
+  $ tw config view --json           # raw JSON, token masked
+  $ tw config view --show-token     # include the full token`,
+    )
+}

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -5,7 +5,7 @@ export function registerConfigCommand(program: Command): void {
     const config = program.command('config').description('Manage CLI configuration')
 
     config
-        .command('view')
+        .command('view', { isDefault: true })
         .description('Show the current CLI configuration file')
         .option('--json', 'Output the raw config as JSON')
         .option('--show-token', 'Include the full token instead of masking it')

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -69,9 +69,15 @@ function renderTokenLine(token: TokenStatus, showToken: boolean): string {
     }
 }
 
-function formatConfigView(config: Config, token: TokenStatus, showToken: boolean): string {
+function formatConfigView(
+    config: Config,
+    token: TokenStatus,
+    showToken: boolean,
+    configMissing: boolean,
+): string {
     const lines: string[] = []
-    lines.push(`${chalk.dim('Config file:')} ${CONFIG_PATH}`)
+    const headerSuffix = configMissing ? ` ${chalk.dim('(not created yet)')}` : ''
+    lines.push(`${chalk.dim('Config file:')} ${CONFIG_PATH}${headerSuffix}`)
     lines.push('')
 
     // When a token is present, its metadata is the ground truth for the active
@@ -82,10 +88,19 @@ function formatConfigView(config: Config, token: TokenStatus, showToken: boolean
     const effectiveMode = token.state === 'present' ? token.metadata.authMode : config.authMode
     const effectiveScope = token.state === 'present' ? token.metadata.authScope : config.authScope
 
+    // When the mode is 'unknown' and no scope is recorded, the scope is
+    // genuinely unintrospectable (env-sourced tokens, or tokens saved via
+    // `tw auth token` without metadata). Render 'unknown' rather than
+    // 'not set' to avoid reading as an explicit empty scope.
+    const scopeDisplay =
+        effectiveMode === 'unknown' && effectiveScope === undefined
+            ? 'unknown'
+            : formatValue(effectiveScope)
+
     lines.push(chalk.bold('Authentication'))
     lines.push(`  Token:         ${renderTokenLine(token, showToken)}`)
     lines.push(`  Mode:          ${formatValue(effectiveMode)}`)
-    lines.push(`  Scope:         ${formatValue(effectiveScope)}`)
+    lines.push(`  Scope:         ${scopeDisplay}`)
     lines.push('')
 
     lines.push(chalk.bold('Workspace'))
@@ -118,5 +133,7 @@ export async function viewConfig(options: ViewConfigOptions): Promise<void> {
         return
     }
 
-    console.log(formatConfigView(config, token, options.showToken ?? false))
+    console.log(
+        formatConfigView(config, token, options.showToken ?? false, read.state === 'missing'),
+    )
 }

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -1,0 +1,122 @@
+import chalk from 'chalk'
+import {
+    type AuthProbeMetadata,
+    NoTokenError,
+    probeApiToken,
+    TOKEN_ENV_VAR,
+} from '../../lib/auth.js'
+import { type Config, CONFIG_PATH, readConfigStrict } from '../../lib/config.js'
+import { SECURE_STORE_DESCRIPTION, SecureStoreUnavailableError } from '../../lib/secure-store.js'
+
+export interface ViewConfigOptions {
+    json?: boolean
+    showToken?: boolean
+}
+
+type TokenStatus =
+    | { state: 'present'; token: string; metadata: AuthProbeMetadata }
+    | { state: 'missing' }
+    | { state: 'unavailable'; reason: string }
+
+function maskToken(token: string): string {
+    if (token.length < 5) return '****'
+    return `****…${token.slice(-4)}`
+}
+
+function describeTokenSource(source: AuthProbeMetadata['source']): string {
+    switch (source) {
+        case 'env':
+            return `environment variable ${TOKEN_ENV_VAR}`
+        case 'secure-store':
+            return SECURE_STORE_DESCRIPTION
+        case 'config-file':
+            return 'config file (plaintext fallback)'
+    }
+}
+
+async function probeTokenPresence(): Promise<TokenStatus> {
+    try {
+        const { token, metadata } = await probeApiToken()
+        return { state: 'present', token, metadata }
+    } catch (error) {
+        if (error instanceof NoTokenError) return { state: 'missing' }
+        if (error instanceof SecureStoreUnavailableError) {
+            return {
+                state: 'unavailable',
+                reason: `${SECURE_STORE_DESCRIPTION} unavailable (${error.message})`,
+            }
+        }
+        throw error
+    }
+}
+
+function formatValue(value: unknown): string {
+    if (value === undefined || value === null) return chalk.dim('not set')
+    if (typeof value === 'boolean') return value ? 'true' : 'false'
+    return String(value)
+}
+
+function renderTokenLine(token: TokenStatus, showToken: boolean): string {
+    switch (token.state) {
+        case 'present': {
+            const value = showToken ? token.token : maskToken(token.token)
+            return `${value} ${chalk.dim(`(${describeTokenSource(token.metadata.source)})`)}`
+        }
+        case 'unavailable':
+            return chalk.dim(`unknown — ${token.reason}`)
+        case 'missing':
+            return formatValue(undefined)
+    }
+}
+
+function formatConfigView(config: Config, token: TokenStatus, showToken: boolean): string {
+    const lines: string[] = []
+    lines.push(`${chalk.dim('Config file:')} ${CONFIG_PATH}`)
+    lines.push('')
+
+    // When a token is present, its metadata is the ground truth for the active
+    // mode/scope — this matters most for env-sourced tokens, whose scope the CLI
+    // does not know and where config.auth* may be stale from an unrelated
+    // `tw auth login`. For missing/unavailable tokens, fall back to the config
+    // file values (what the CLI would attempt once auth recovers).
+    const effectiveMode = token.state === 'present' ? token.metadata.authMode : config.authMode
+    const effectiveScope = token.state === 'present' ? token.metadata.authScope : config.authScope
+
+    lines.push(chalk.bold('Authentication'))
+    lines.push(`  Token:         ${renderTokenLine(token, showToken)}`)
+    lines.push(`  Mode:          ${formatValue(effectiveMode)}`)
+    lines.push(`  Scope:         ${formatValue(effectiveScope)}`)
+    lines.push('')
+
+    lines.push(chalk.bold('Workspace'))
+    lines.push(`  Current:       ${formatValue(config.currentWorkspace)}`)
+    lines.push('')
+
+    lines.push(chalk.bold('Updates'))
+    lines.push(`  Channel:       ${formatValue(config.updateChannel)}`)
+
+    return lines.join('\n')
+}
+
+export async function viewConfig(options: ViewConfigOptions): Promise<void> {
+    const read = await readConfigStrict()
+    const config: Config = read.state === 'present' ? read.config : {}
+
+    if (options.json) {
+        const output: Config = { ...config }
+        if (output.token && !options.showToken) {
+            output.token = maskToken(output.token)
+        }
+        console.log(JSON.stringify(output, null, 2))
+        return
+    }
+
+    const token = await probeTokenPresence()
+
+    if (read.state === 'missing' && token.state === 'missing') {
+        console.log(`${chalk.dim('Config file:')} ${CONFIG_PATH} ${chalk.dim('(not created yet)')}`)
+        return
+    }
+
+    console.log(formatConfigView(config, token, options.showToken ?? false))
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ const loadChangelogCommand = async () =>
     (await import('./commands/changelog.js')).registerChangelogCommand
 const loadGroupsCommand = async () => (await import('./commands/groups.js')).registerGroupsCommand
 const loadDoctorCommand = async () => (await import('./commands/doctor.js')).registerDoctorCommand
+const loadConfigCommand = async () =>
+    (await import('./commands/config/index.js')).registerConfigCommand
 
 const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = {
     workspaces: ['List all workspaces', loadWorkspaceCommand],
@@ -62,6 +64,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
     changelog: ['Show recent changelog entries', loadChangelogCommand],
     doctor: ['Diagnose common CLI setup and environment issues', loadDoctorCommand],
     groups: ['List groups in a workspace', loadGroupsCommand],
+    config: ['Manage CLI configuration', loadConfigCommand],
 }
 
 const commandAliases: Record<string, string> = {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,8 +1,9 @@
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { CliError } from './errors.js'
 
-const CONFIG_PATH = join(homedir(), '.config', 'twist-cli', 'config.json')
+export const CONFIG_PATH = join(homedir(), '.config', 'twist-cli', 'config.json')
 
 export type AuthMode = 'read-only' | 'read-write' | 'unknown'
 export type UpdateChannel = 'stable' | 'pre-release'
@@ -38,6 +39,55 @@ export async function getConfig(): Promise<Config> {
     } catch {
         return {}
     }
+}
+
+export type StrictReadResult = { state: 'missing' } | { state: 'present'; config: Config }
+
+/**
+ * Read and parse the config file strictly — for inspection commands that need
+ * to distinguish "missing" from "present but broken". `getConfig` deliberately
+ * swallows errors for runtime code paths; this one surfaces them.
+ */
+export async function readConfigStrict(): Promise<StrictReadResult> {
+    let content: string
+    try {
+        content = await readFile(CONFIG_PATH, 'utf-8')
+    } catch (error) {
+        if (isMissingFileError(error)) return { state: 'missing' }
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new CliError(
+            'CONFIG_READ_FAILED',
+            `Could not read config file ${CONFIG_PATH}: ${detail}`,
+            ['Check file permissions, or run `tw doctor` to diagnose'],
+        )
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(content)
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new CliError(
+            'CONFIG_INVALID_JSON',
+            `Config file at ${CONFIG_PATH} is not valid JSON: ${detail}`,
+            ['Fix the JSON by hand, or delete the file and re-authenticate with `tw auth login`'],
+        )
+    }
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        const actual = Array.isArray(parsed) ? 'array' : parsed === null ? 'null' : typeof parsed
+        throw new CliError(
+            'CONFIG_INVALID_SHAPE',
+            `Config file at ${CONFIG_PATH} must contain a JSON object (got ${actual})`,
+            ['Fix the JSON by hand, or delete the file and re-authenticate with `tw auth login`'],
+        )
+    }
+
+    return { state: 'present', config: parsed as Config }
+}
+
+function isMissingFileError(error: unknown): boolean {
+    return error instanceof Error && 'code' in error && error.code === 'ENOENT'
 }
 
 export async function setConfig(config: Config): Promise<void> {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -38,6 +38,10 @@ export type ErrorCode =
     // API & internal
     | 'API_ERROR'
     | 'INTERNAL_ERROR'
+    // Config file inspection
+    | 'CONFIG_READ_FAILED'
+    | 'CONFIG_INVALID_JSON'
+    | 'CONFIG_INVALID_SHAPE'
     // Escape hatch for dynamic codes
     | (string & {})
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -27,6 +27,7 @@ tw auth logout                   # Remove saved token and auth metadata
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions
+tw config view                   # Show the current CLI configuration file (token masked)
 tw doctor                        # Diagnose CLI setup and environment issues
 tw update                        # Update CLI to latest version
 tw changelog                     # Show recent changelog entries
@@ -241,6 +242,14 @@ tw completion uninstall          # Remove completions
 tw doctor                        # Run local + network diagnostics
 tw doctor --offline              # Skip Twist and npm network checks
 tw doctor --json                 # JSON output with per-check results
+\`\`\`
+
+### Configuration
+
+\`\`\`bash
+tw config view                   # Pretty-printed config, token masked, labels actual token source
+tw config view --json            # Raw JSON, token masked
+tw config view --show-token      # Include the full token
 \`\`\`
 
 ### Update


### PR DESCRIPTION
## Summary

- Adds a new `tw config view` command that pretty-prints the CLI config at `~/.config/twist-cli/config.json`, grouped into Authentication / Workspace / Updates sections.
- `--json` echoes the raw config as-is (with the `token` masked).
- `token` is always masked to `****…<last4>` by default; `--show-token` reveals it. Short/unusable tokens mask to `****`.
- Pretty output labels the token's actual storage location: *system credential manager*, *config file (plaintext fallback)*, or *environment variable `TWIST_API_TOKEN`* — so users can verify storage without cross-referencing `tw auth status`.
- When the token is env-sourced, Mode/Scope come from the live probe (shown as `unknown`) rather than stale config values that may have been left over from a prior `tw auth login`.

Ports [Doist/todoist-cli#285](https://github.com/Doist/todoist-cli/pull/285) to twist-cli. Adapted to twist's simpler config shape (no `authFlags`, no Help Center; added a Workspace section for `currentWorkspace`).

## Sample output

```
Config file: /Users/you/.config/twist-cli/config.json

Authentication
  Token:         ****…4b06 (system credential manager)
  Mode:          read-write
  Scope:         not set

Workspace
  Current:       1585

Updates
  Channel:       not set
```

## Test plan

- [x] `npm run type-check`
- [x] `npm test` (481 passing, 10 new)
- [x] `npm run lint:check`
- [x] `npm run build && npm run check:skill-sync`
- [x] Manual smoke: `tw config view`, `tw config view --json`, `tw config view --show-token`, `tw config --help`
- [x] `TWIST_API_TOKEN=... tw config view` — source labels env var, Mode reads `unknown` (not stale config value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)