### PR TITLE
feat(thread): opt-in unarchive of newly-created threads

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -24,6 +24,7 @@ tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions
 tw config view                   # Show the current CLI configuration file (token masked)
+tw config set <key> <value>      # Set a user preference (e.g. unarchive-new-threads true)
 tw doctor                        # Diagnose CLI setup and environment issues
 tw update                        # Update CLI to latest version
 tw changelog                     # Show recent changelog entries
@@ -75,6 +76,8 @@ tw thread create <channel-ref> "Title" "content"    # Create a new thread
 tw thread create <channel-ref> "Title" "content" --json       # Create and return as JSON
 tw thread create <channel-ref> "Title" "content" --json --full # Include all thread fields
 tw thread create <channel-ref> "Title" "content" --notify 123,456  # Notify specific users
+tw thread create <channel-ref> "Title" "content" --unarchive  # Land thread in author's Inbox (overrides default Twist auto-archive)
+tw thread create <channel-ref> "Title" "content" --no-unarchive  # Force archive even when userSettings.unarchiveNewThreads=true
 tw thread create <channel-ref> "Title" "content" --dry-run  # Preview without posting
 tw thread reply <ref> "content"  # Post a comment (notifies EVERYONE_IN_THREAD by default)
 tw thread reply <ref> "content" --notify EVERYONE  # Notify all workspace members
@@ -255,7 +258,11 @@ tw doctor --json                 # JSON output with per-check results
 tw config view                   # Pretty-printed config, token masked, labels actual token source
 tw config view --json            # Raw JSON, token masked
 tw config view --show-token      # Include the full token
+tw config set unarchive-new-threads true   # Persist: always unarchive new threads so they land in your Inbox
+tw config set unarchive-new-threads false  # Persist: keep Twist's default (thread auto-archived for author)
 ```
+
+User preferences are stored under `userSettings` in the config file. Currently supported keys: `unarchive-new-threads`. The flag on `tw thread create` (`--unarchive` / `--no-unarchive`) overrides this default per-invocation.
 
 ### Update
 

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -9,7 +9,6 @@ vi.mock('../../lib/config.js', async (importOriginal) => {
         ...actual,
         CONFIG_PATH: '/tmp/fake-twist-cli/config.json',
         readConfigStrict: vi.fn(),
-        getConfig: vi.fn(),
         setConfig: vi.fn(),
     }
 })
@@ -23,14 +22,13 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
 })
 
 import { NoTokenError, probeApiToken } from '../../lib/auth.js'
-import { type Config, getConfig, readConfigStrict, setConfig } from '../../lib/config.js'
+import { type Config, readConfigStrict, setConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { SecureStoreUnavailableError } from '../../lib/secure-store.js'
 import { registerConfigCommand } from './index.js'
 
 const mockReadConfigStrict = vi.mocked(readConfigStrict)
 const mockProbeApiToken = vi.mocked(probeApiToken)
-const mockGetConfig = vi.mocked(getConfig)
 const mockSetConfig = vi.mocked(setConfig)
 
 function createProgram() {
@@ -297,7 +295,7 @@ describe('config set', () => {
     })
 
     it('writes userSettings.unarchiveNewThreads = true', async () => {
-        mockGetConfig.mockResolvedValue({})
+        mockReadConfigStrict.mockResolvedValue({ state: 'present', config: {} })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync([
@@ -318,7 +316,10 @@ describe('config set', () => {
     })
 
     it('writes false for off/0/no', async () => {
-        mockGetConfig.mockResolvedValue({ userSettings: { unarchiveNewThreads: true } })
+        mockReadConfigStrict.mockResolvedValue({
+            state: 'present',
+            config: { userSettings: { unarchiveNewThreads: true } },
+        })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync([
@@ -337,10 +338,13 @@ describe('config set', () => {
     })
 
     it('preserves other userSettings keys when updating', async () => {
-        mockGetConfig.mockResolvedValue({
-            userSettings: { unarchiveNewThreads: false },
-            currentWorkspace: 7,
-        } as Config)
+        mockReadConfigStrict.mockResolvedValue({
+            state: 'present',
+            config: {
+                userSettings: { unarchiveNewThreads: false },
+                currentWorkspace: 7,
+            } as Config,
+        })
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await createProgram().parseAsync([
@@ -360,7 +364,7 @@ describe('config set', () => {
     })
 
     it('rejects unknown keys', async () => {
-        mockGetConfig.mockResolvedValue({})
+        mockReadConfigStrict.mockResolvedValue({ state: 'present', config: {} })
 
         await expect(
             createProgram().parseAsync(['node', 'tw', 'config', 'set', 'nope', 'true']),
@@ -369,7 +373,7 @@ describe('config set', () => {
     })
 
     it('rejects invalid boolean values', async () => {
-        mockGetConfig.mockResolvedValue({})
+        mockReadConfigStrict.mockResolvedValue({ state: 'present', config: {} })
 
         await expect(
             createProgram().parseAsync([
@@ -381,6 +385,41 @@ describe('config set', () => {
                 'maybe',
             ]),
         ).rejects.toMatchObject({ code: 'INVALID_VALUE' })
+        expect(mockSetConfig).not.toHaveBeenCalled()
+    })
+
+    it('writes a fresh config when the file is missing', async () => {
+        mockReadConfigStrict.mockResolvedValue({ state: 'missing' })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync([
+            'node',
+            'tw',
+            'config',
+            'set',
+            'unarchive-new-threads',
+            'true',
+        ])
+
+        expect(mockSetConfig).toHaveBeenCalledWith({
+            userSettings: { unarchiveNewThreads: true },
+        })
+        consoleSpy.mockRestore()
+    })
+
+    it('refuses to overwrite a malformed config file', async () => {
+        mockReadConfigStrict.mockRejectedValue(new CliError('CONFIG_INVALID_JSON', 'broken'))
+
+        await expect(
+            createProgram().parseAsync([
+                'node',
+                'tw',
+                'config',
+                'set',
+                'unarchive-new-threads',
+                'true',
+            ]),
+        ).rejects.toMatchObject({ code: 'CONFIG_INVALID_JSON' })
         expect(mockSetConfig).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/config/config.test.ts
+++ b/src/commands/config/config.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../lib/config.js', async (importOriginal) => {
         ...actual,
         CONFIG_PATH: '/tmp/fake-twist-cli/config.json',
         readConfigStrict: vi.fn(),
+        getConfig: vi.fn(),
+        setConfig: vi.fn(),
     }
 })
 
@@ -21,13 +23,15 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
 })
 
 import { NoTokenError, probeApiToken } from '../../lib/auth.js'
-import { type Config, readConfigStrict } from '../../lib/config.js'
+import { type Config, getConfig, readConfigStrict, setConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { SecureStoreUnavailableError } from '../../lib/secure-store.js'
 import { registerConfigCommand } from './index.js'
 
 const mockReadConfigStrict = vi.mocked(readConfigStrict)
 const mockProbeApiToken = vi.mocked(probeApiToken)
+const mockGetConfig = vi.mocked(getConfig)
+const mockSetConfig = vi.mocked(setConfig)
 
 function createProgram() {
     const program = new Command()
@@ -269,5 +273,114 @@ describe('config view', () => {
         expect(parsed.token).not.toContain('abcd')
 
         consoleSpy.mockRestore()
+    })
+
+    it('shows the user settings section', async () => {
+        presentConfig({ userSettings: { unarchiveNewThreads: true } })
+        mockProbeApiToken.mockRejectedValue(new NoTokenError())
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync(['node', 'tw', 'config', 'view'])
+
+        const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n')
+        expect(output).toContain('User settings')
+        expect(output).toContain('Unarchive new threads')
+        expect(output).toContain('true')
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('config set', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockSetConfig.mockResolvedValue()
+    })
+
+    it('writes userSettings.unarchiveNewThreads = true', async () => {
+        mockGetConfig.mockResolvedValue({})
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync([
+            'node',
+            'tw',
+            'config',
+            'set',
+            'unarchive-new-threads',
+            'true',
+        ])
+
+        expect(mockSetConfig).toHaveBeenCalledWith({
+            userSettings: { unarchiveNewThreads: true },
+        })
+        const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+        expect(output).toContain('userSettings.unarchiveNewThreads = true')
+        consoleSpy.mockRestore()
+    })
+
+    it('writes false for off/0/no', async () => {
+        mockGetConfig.mockResolvedValue({ userSettings: { unarchiveNewThreads: true } })
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync([
+            'node',
+            'tw',
+            'config',
+            'set',
+            'unarchive-new-threads',
+            'off',
+        ])
+
+        expect(mockSetConfig).toHaveBeenCalledWith({
+            userSettings: { unarchiveNewThreads: false },
+        })
+        consoleSpy.mockRestore()
+    })
+
+    it('preserves other userSettings keys when updating', async () => {
+        mockGetConfig.mockResolvedValue({
+            userSettings: { unarchiveNewThreads: false },
+            currentWorkspace: 7,
+        } as Config)
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await createProgram().parseAsync([
+            'node',
+            'tw',
+            'config',
+            'set',
+            'unarchive-new-threads',
+            'true',
+        ])
+
+        expect(mockSetConfig).toHaveBeenCalledWith({
+            userSettings: { unarchiveNewThreads: true },
+            currentWorkspace: 7,
+        })
+        consoleSpy.mockRestore()
+    })
+
+    it('rejects unknown keys', async () => {
+        mockGetConfig.mockResolvedValue({})
+
+        await expect(
+            createProgram().parseAsync(['node', 'tw', 'config', 'set', 'nope', 'true']),
+        ).rejects.toBeInstanceOf(CliError)
+        expect(mockSetConfig).not.toHaveBeenCalled()
+    })
+
+    it('rejects invalid boolean values', async () => {
+        mockGetConfig.mockResolvedValue({})
+
+        await expect(
+            createProgram().parseAsync([
+                'node',
+                'tw',
+                'config',
+                'set',
+                'unarchive-new-threads',
+                'maybe',
+            ]),
+        ).rejects.toMatchObject({ code: 'INVALID_VALUE' })
+        expect(mockSetConfig).not.toHaveBeenCalled()
     })
 })

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { listSettableKeys, setConfigValue } from './set.js'
 import { viewConfig } from './view.js'
 
 export function registerConfigCommand(program: Command): void {
@@ -11,12 +12,28 @@ export function registerConfigCommand(program: Command): void {
         .option('--show-token', 'Include the full token instead of masking it')
         .action(viewConfig)
 
+    config
+        .command('set <key> <value>')
+        .description('Set a user preference in the config file')
+        .addHelpText(
+            'after',
+            `
+Settable keys:
+${listSettableKeys()}
+
+Examples:
+  $ tw config set unarchive-new-threads true
+  $ tw config set unarchive-new-threads false`,
+        )
+        .action(setConfigValue)
+
     config.addHelpText(
         'after',
         `
 Examples:
-  $ tw config view                  # pretty-printed, token masked
-  $ tw config view --json           # raw JSON, token masked
-  $ tw config view --show-token     # include the full token`,
+  $ tw config view                              # pretty-printed, token masked
+  $ tw config view --json                       # raw JSON, token masked
+  $ tw config view --show-token                 # include the full token
+  $ tw config set unarchive-new-threads true    # change a user preference`,
     )
 }

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -1,0 +1,49 @@
+import chalk from 'chalk'
+import { getConfig, setConfig, type UserSettings } from '../../lib/config.js'
+import { CliError } from '../../lib/errors.js'
+
+const TRUE_VALUES = new Set(['true', 'on', '1', 'yes'])
+const FALSE_VALUES = new Set(['false', 'off', '0', 'no'])
+
+function parseBoolean(raw: string, key: string): boolean {
+    const normalized = raw.trim().toLowerCase()
+    if (TRUE_VALUES.has(normalized)) return true
+    if (FALSE_VALUES.has(normalized)) return false
+    throw new CliError(
+        'INVALID_VALUE',
+        `Invalid boolean value "${raw}" for ${key}. Use one of: true, false, on, off, 1, 0.`,
+    )
+}
+
+type Setter = (config: { userSettings?: UserSettings }, value: string) => string
+
+const SETTERS: Record<string, { description: string; apply: Setter }> = {
+    'unarchive-new-threads': {
+        description: 'Unarchive newly-created threads so they appear in your Inbox',
+        apply: (config, value) => {
+            const parsed = parseBoolean(value, 'unarchive-new-threads')
+            config.userSettings = { ...config.userSettings, unarchiveNewThreads: parsed }
+            return `userSettings.unarchiveNewThreads = ${parsed}`
+        },
+    },
+}
+
+export async function setConfigValue(key: string, value: string): Promise<void> {
+    const setter = SETTERS[key]
+    if (!setter) {
+        const known = Object.keys(SETTERS).join(', ')
+        throw new CliError('UNKNOWN_KEY', `Unknown config key "${key}". Known keys: ${known}.`)
+    }
+
+    const config = await getConfig()
+    const summary = setter.apply(config, value)
+    await setConfig(config)
+
+    console.log(chalk.green('✓'), `Set ${chalk.cyan(summary)}`)
+}
+
+export function listSettableKeys(): string {
+    return Object.entries(SETTERS)
+        .map(([key, { description }]) => `  ${key.padEnd(28)} ${description}`)
+        .join('\n')
+}

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import { getConfig, setConfig, type UserSettings } from '../../lib/config.js'
+import { type Config, readConfigStrict, setConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 
 const TRUE_VALUES = new Set(['true', 'on', '1', 'yes'])
@@ -15,7 +15,7 @@ function parseBoolean(raw: string, key: string): boolean {
     )
 }
 
-type Setter = (config: { userSettings?: UserSettings }, value: string) => string
+type Setter = (config: Config, value: string) => string
 
 const SETTERS: Record<string, { description: string; apply: Setter }> = {
     'unarchive-new-threads': {
@@ -35,7 +35,8 @@ export async function setConfigValue(key: string, value: string): Promise<void> 
         throw new CliError('UNKNOWN_KEY', `Unknown config key "${key}". Known keys: ${known}.`)
     }
 
-    const config = await getConfig()
+    const read = await readConfigStrict()
+    const config: Config = read.state === 'present' ? read.config : {}
     const summary = setter.apply(config, value)
     await setConfig(config)
 

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -109,6 +109,10 @@ function formatConfigView(
 
     lines.push(chalk.bold('Updates'))
     lines.push(`  Channel:       ${formatValue(config.updateChannel)}`)
+    lines.push('')
+
+    lines.push(chalk.bold('User settings'))
+    lines.push(`  Unarchive new threads: ${formatValue(config.userSettings?.unarchiveNewThreads)}`)
 
     return lines.join('\n')
 }

--- a/src/commands/thread/create.ts
+++ b/src/commands/thread/create.ts
@@ -1,4 +1,5 @@
 import { getTwistClient } from '../../lib/api.js'
+import { getConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
@@ -9,6 +10,7 @@ import { type ResolvedNotify, formatNotifyLabel, resolveNotifyIds } from './help
 
 type CreateOptions = MutationOptions & {
     notify?: string
+    unarchive?: boolean
 }
 
 export async function createThread(
@@ -44,6 +46,9 @@ export async function createThread(
         resolved = await resolveNotifyIds(allIds, channel.workspaceId)
     }
 
+    const config = await getConfig()
+    const shouldUnarchive = options.unarchive ?? config.userSettings?.unarchiveNewThreads ?? false
+
     if (options.dryRun) {
         const preview =
             threadContent.length > 200 ? `${threadContent.slice(0, 200)}...` : threadContent
@@ -58,6 +63,7 @@ export async function createThread(
                 resolved && resolved.notified.groups.length > 0
                     ? formatNotifyLabel(resolved.notified.groups)
                     : undefined,
+            Unarchive: shouldUnarchive ? 'yes' : undefined,
             Content: preview,
         })
         return
@@ -70,6 +76,15 @@ export async function createThread(
         recipients: resolved?.recipients,
         groups: resolved?.groups,
     })
+
+    if (shouldUnarchive) {
+        try {
+            await client.inbox.unarchiveThread(thread.id)
+        } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error)
+            console.error(`Warning: created thread but failed to unarchive it (${detail})`)
+        }
+    }
 
     if (options.json) {
         const output = resolved ? { ...thread, notified: resolved.notified } : thread

--- a/src/commands/thread/index.ts
+++ b/src/commands/thread/index.ts
@@ -72,6 +72,11 @@ Examples:
         .command('create <channel-ref> <title> [content]')
         .description('Create a new thread in a channel')
         .option('--notify <recipients>', 'Comma-separated user IDs to notify')
+        .option(
+            '--unarchive',
+            'Unarchive after creation so the thread appears in your Inbox (overrides userSettings.unarchiveNewThreads when false)',
+        )
+        .option('--no-unarchive', 'Skip unarchive even if userSettings.unarchiveNewThreads is true')
         .option('--dry-run', 'Show what would be posted without posting')
         .option('--json', 'Output created thread as JSON')
         .option('--full', 'Include all fields in JSON output')
@@ -81,7 +86,8 @@ Examples:
 Examples:
   tw thread create 12345 "Weekly update" "Here's what happened..."
   echo "Body from stdin" | tw thread create id:12345 "Title"
-  tw thread create 12345 "Title" "Body" --notify 67890,11111 --json`,
+  tw thread create 12345 "Title" "Body" --notify 67890,11111 --json
+  tw thread create 12345 "Title" "Body" --unarchive`,
         )
         .action(createThread)
 

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -5,6 +5,15 @@ const apiMocks = vi.hoisted(() => ({
     getTwistClient: vi.fn(),
 }))
 
+const configMocks = vi.hoisted(() => ({
+    getConfig: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('../../lib/config.js', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../lib/config.js')>()),
+    getConfig: configMocks.getConfig,
+}))
+
 vi.mock('../../lib/public-channels.js', () => ({
     assertChannelIsPublic: vi.fn(),
 }))
@@ -138,6 +147,7 @@ function createClient({
         },
         inbox: {
             archiveThread: vi.fn(async () => undefined),
+            unarchiveThread: vi.fn(async () => undefined),
         },
         workspaceUsers: {
             getUserById: vi.fn(
@@ -522,6 +532,7 @@ describe('thread view with failed batch response', () => {
 describe('thread create', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        configMocks.getConfig.mockResolvedValue({})
     })
 
     it('creates a thread with positional title and content', async () => {
@@ -700,6 +711,109 @@ describe('thread create', () => {
         await expect(
             program.parseAsync(['node', 'tw', 'thread', 'create', '100', 'My Title']),
         ).rejects.toHaveProperty('code', 'MISSING_CONTENT')
+    })
+
+    it('does not unarchive by default', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'create', '100', 'T', 'body'])
+
+        expect(client.inbox.unarchiveThread).not.toHaveBeenCalled()
+        consoleSpy.mockRestore()
+    })
+
+    it('unarchives the new thread when --unarchive is passed', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'create',
+            '100',
+            'T',
+            'body',
+            '--unarchive',
+        ])
+
+        expect(client.inbox.unarchiveThread).toHaveBeenCalledWith(999)
+        consoleSpy.mockRestore()
+    })
+
+    it('unarchives when userSettings.unarchiveNewThreads is true', async () => {
+        configMocks.getConfig.mockResolvedValueOnce({
+            userSettings: { unarchiveNewThreads: true },
+        })
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'thread', 'create', '100', 'T', 'body'])
+
+        expect(client.inbox.unarchiveThread).toHaveBeenCalledWith(999)
+        consoleSpy.mockRestore()
+    })
+
+    it('--no-unarchive overrides config default of true', async () => {
+        configMocks.getConfig.mockResolvedValueOnce({
+            userSettings: { unarchiveNewThreads: true },
+        })
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'create',
+            '100',
+            'T',
+            'body',
+            '--no-unarchive',
+        ])
+
+        expect(client.inbox.unarchiveThread).not.toHaveBeenCalled()
+        consoleSpy.mockRestore()
+    })
+
+    it('unarchive failure does not fail the command', async () => {
+        const client = createClient()
+        client.inbox.unarchiveThread.mockRejectedValueOnce(new Error('boom'))
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'create',
+            '100',
+            'T',
+            'body',
+            '--unarchive',
+        ])
+
+        expect(client.threads.createThread).toHaveBeenCalled()
+        expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('failed to unarchive'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Thread created:'))
+        consoleSpy.mockRestore()
+        errorSpy.mockRestore()
     })
 })
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -81,6 +81,7 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         // Inbox operations
         'inbox.getInbox': { text: 'Loading inbox...', color: 'blue' },
         'inbox.archiveThread': { text: 'Archiving thread...', color: 'yellow' },
+        'inbox.unarchiveThread': { text: 'Unarchiving thread...', color: 'yellow' },
 
         // Batch operations
         batch: { text: 'Processing batch operations...', color: 'blue' },

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { validateConfigForDoctor } from './config.js'
+
+describe('validateConfigForDoctor', () => {
+    it('accepts an empty config', () => {
+        expect(validateConfigForDoctor({})).toEqual([])
+    })
+
+    it('accepts a valid userSettings.unarchiveNewThreads', () => {
+        expect(validateConfigForDoctor({ userSettings: { unarchiveNewThreads: true } })).toEqual([])
+        expect(validateConfigForDoctor({ userSettings: { unarchiveNewThreads: false } })).toEqual(
+            [],
+        )
+        expect(validateConfigForDoctor({ userSettings: {} })).toEqual([])
+    })
+
+    it('rejects non-boolean unarchiveNewThreads', () => {
+        const issues = validateConfigForDoctor({
+            userSettings: { unarchiveNewThreads: 'yes' },
+        })
+        expect(issues).toContain('userSettings.unarchiveNewThreads must be a boolean')
+    })
+
+    it('rejects unknown nested keys under userSettings', () => {
+        const issues = validateConfigForDoctor({
+            userSettings: { somethingElse: 1 },
+        })
+        expect(issues).toContain('userSettings contains unrecognized key "somethingElse"')
+    })
+
+    it('rejects userSettings that is not an object', () => {
+        expect(validateConfigForDoctor({ userSettings: true })).toContain(
+            'userSettings must be an object',
+        )
+        expect(validateConfigForDoctor({ userSettings: [] })).toContain(
+            'userSettings must be an object',
+        )
+        expect(validateConfigForDoctor({ userSettings: null })).toContain(
+            'userSettings must be an object',
+        )
+    })
+})

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,10 +15,17 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     'authMode',
     'authScope',
     'updateChannel',
+    'userSettings',
 ])
+
+const KNOWN_USER_SETTINGS_KEYS: ReadonlySet<string> = new Set(['unarchiveNewThreads'])
 
 const AUTH_MODES: ReadonlySet<AuthMode> = new Set(['read-only', 'read-write', 'unknown'])
 const UPDATE_CHANNELS: ReadonlySet<UpdateChannel> = new Set(['stable', 'pre-release'])
+
+export interface UserSettings {
+    unarchiveNewThreads?: boolean
+}
 
 export interface Config {
     // Legacy plaintext token storage retained for migration and secure-store fallback only.
@@ -30,6 +37,7 @@ export interface Config {
     authMode?: AuthMode
     authScope?: string
     updateChannel?: UpdateChannel
+    userSettings?: UserSettings
 }
 
 export async function getConfig(): Promise<Config> {
@@ -149,6 +157,30 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
             !UPDATE_CHANNELS.has(config.updateChannel as UpdateChannel))
     ) {
         issues.push('updateChannel must be one of: stable, pre-release')
+    }
+
+    if (config.userSettings !== undefined) {
+        const userSettings = config.userSettings
+        if (
+            userSettings === null ||
+            typeof userSettings !== 'object' ||
+            Array.isArray(userSettings)
+        ) {
+            issues.push('userSettings must be an object')
+        } else {
+            const settingsRecord = userSettings as Record<string, unknown>
+            for (const key of Object.keys(settingsRecord)) {
+                if (!KNOWN_USER_SETTINGS_KEYS.has(key)) {
+                    issues.push(`userSettings contains unrecognized key "${key}"`)
+                }
+            }
+            if (
+                settingsRecord.unarchiveNewThreads !== undefined &&
+                typeof settingsRecord.unarchiveNewThreads !== 'boolean'
+            ) {
+                issues.push('userSettings.unarchiveNewThreads must be a boolean')
+            }
+        }
     }
 
     return issues

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -21,8 +21,10 @@ export type ErrorCode =
     | 'INVALID_STATE'
     | 'INVALID_TYPE'
     | 'INVALID_URL'
+    | 'INVALID_VALUE'
     | 'MISSING_CONTENT'
     | 'MISSING_YES_FLAG'
+    | 'UNKNOWN_KEY'
     // Not found
     | 'CHANNEL_NOT_FOUND'
     | 'NOT_FOUND'

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -28,6 +28,7 @@ tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions
 tw config view                   # Show the current CLI configuration file (token masked)
+tw config set <key> <value>      # Set a user preference (e.g. unarchive-new-threads true)
 tw doctor                        # Diagnose CLI setup and environment issues
 tw update                        # Update CLI to latest version
 tw changelog                     # Show recent changelog entries
@@ -79,6 +80,8 @@ tw thread create <channel-ref> "Title" "content"    # Create a new thread
 tw thread create <channel-ref> "Title" "content" --json       # Create and return as JSON
 tw thread create <channel-ref> "Title" "content" --json --full # Include all thread fields
 tw thread create <channel-ref> "Title" "content" --notify 123,456  # Notify specific users
+tw thread create <channel-ref> "Title" "content" --unarchive  # Land thread in author's Inbox (overrides default Twist auto-archive)
+tw thread create <channel-ref> "Title" "content" --no-unarchive  # Force archive even when userSettings.unarchiveNewThreads=true
 tw thread create <channel-ref> "Title" "content" --dry-run  # Preview without posting
 tw thread reply <ref> "content"  # Post a comment (notifies EVERYONE_IN_THREAD by default)
 tw thread reply <ref> "content" --notify EVERYONE  # Notify all workspace members
@@ -259,7 +262,11 @@ tw doctor --json                 # JSON output with per-check results
 tw config view                   # Pretty-printed config, token masked, labels actual token source
 tw config view --json            # Raw JSON, token masked
 tw config view --show-token      # Include the full token
+tw config set unarchive-new-threads true   # Persist: always unarchive new threads so they land in your Inbox
+tw config set unarchive-new-threads false  # Persist: keep Twist's default (thread auto-archived for author)
 \`\`\`
+
+User preferences are stored under \`userSettings\` in the config file. Currently supported keys: \`unarchive-new-threads\`. The flag on \`tw thread create\` (\`--unarchive\` / \`--no-unarchive\`) overrides this default per-invocation.
 
 ### Update
 


### PR DESCRIPTION
## Summary

- Inspired by [twist-ai#178](https://github.com/Doist/twist-ai/pull/178), but factoring in the review feedback there: don't change Twist's default behaviour. Make it opt-in.
- New `--unarchive` flag on `tw thread create` calls `inbox.unarchiveThread` after creation so the thread lands in the author's Inbox. Failure is non-fatal (warning only — the thread itself was created).
- New persisted preference `userSettings.unarchiveNewThreads` settable via `tw config set unarchive-new-threads <true|false>`. The flag wins over the config value, so `--no-unarchive` can override a persisted `true` for a one-off post.
- `tw config view` now renders a "User settings" section.
- Default behaviour is unchanged: with no flag and no config, Twist still auto-archives the thread for the author.

## Test plan

- [x] `npm test` — all 537 tests pass, including new matrix coverage for `thread create` (no flag / `--unarchive` / config-true / `--no-unarchive` override / unarchive-failure non-fatal), `tw config set` (true, false, sibling preservation, unknown key, invalid value), and `validateConfigForDoctor` for the new nested key.
- [x] `npm run type-check` and `npm run lint:check` clean.
- [x] `npm run check:skill-sync` passes — `content.ts` updated and `SKILL.md` regenerated.
- [ ] Manual end-to-end against a real Twist workspace:
  - [ ] `tw thread create <ch> "T1" "body"` → archived for me (default).
  - [ ] `tw thread create <ch> "T2" "body" --unarchive` → appears in my Inbox.
  - [ ] `tw config set unarchive-new-threads true` → persisted to `~/.config/twist-cli/config.json`.
  - [ ] `tw thread create <ch> "T3" "body"` → in my Inbox (config default).
  - [ ] `tw thread create <ch> "T4" "body" --no-unarchive` → archived (flag overrides config).
  - [ ] `tw config view` shows the new "User settings" section.
  - [ ] `tw doctor` reports no spurious warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)