### PR TITLE
feat: add mentions command and search pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ tw auth logout   # remove saved token
 ```bash
 tw inbox                           # inbox threads
 tw inbox --unread                  # unread threads only
+tw mentions                        # content mentioning you
+tw mentions --since 2026-04-01 --all --json
 tw thread view <ref>               # view thread with comments
 tw thread view <ref> --comment 123 # view a specific comment
 tw thread reply <ref>              # reply to a thread
@@ -109,6 +111,7 @@ tw conversation unread             # list unread conversations
 tw conversation view <ref>         # view conversation messages
 tw msg view <ref>                  # view a conversation message
 tw search "keyword"                # search across workspace
+tw search "keyword" --all          # fetch all result pages
 tw react thread <ref> 👍          # add reaction
 tw away                            # show away status
 tw away set vacation 2026-03-20    # set away until date

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: twist-cli
-description: "Twist messaging CLI. View and respond to inbox threads, channel threads, direct messages, and group conversations; search, react, archive, mute, and manage workspaces. Use when the user mentions Twist, asks about their inbox, threads, DMs, channels, or wants to read or send Twist messages."
+description: "Twist messaging CLI. View and respond to inbox threads, channel threads, direct messages, mentions, and group conversations; search, react, archive, mute, and manage workspaces. Use when the user mentions Twist, asks about their inbox, mentions, threads, DMs, channels, or wants to read or send Twist messages."
 license: MIT
 metadata:
   author: Doist
@@ -168,6 +168,9 @@ Alias: `tw message` works the same as `tw msg`.
 ## Search
 
 ```bash
+tw mentions                      # Show content mentioning current user
+tw mentions --since 2026-04-01 --all # Fetch every mention since a date
+tw mentions --type threads --json # Limit mentions to threads
 tw search "query"                # Search content
 tw search "query" --type threads # Filter: threads, messages, or all
 tw search "query" --author <ref> # Filter by author
@@ -180,6 +183,7 @@ tw search "query" --until <date> # Content until date
 tw search "query" --channel <refs> # Filter by channel refs (comma-separated)
 tw search "query" --limit <n>    # Max results (default: 50)
 tw search "query" --cursor <cur> # Pagination cursor
+tw search "query" --all          # Fetch all result pages
 ```
 
 ## Users, Channels & Groups
@@ -351,6 +355,7 @@ tw thread done <id>
 
 **Search and review:**
 ```bash
+tw mentions --since 2026-04-01 --all --json
 tw search "deployment" --type threads --json
 tw thread view <thread-id>
 ```

--- a/src/commands/mentions.test.ts
+++ b/src/commands/mentions.test.ts
@@ -113,4 +113,34 @@ describe('mentions', () => {
 
         logSpy.mockRestore()
     })
+
+    it('emits an empty JSON payload when no mentions match', async () => {
+        const program = createProgram()
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'mentions', '--json'])
+
+        expect(logSpy).toHaveBeenCalledTimes(1)
+        expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({
+            results: [],
+            nextCursor: null,
+        })
+
+        logSpy.mockRestore()
+    })
+
+    it('emits NDJSON metadata when no mentions match', async () => {
+        const program = createProgram()
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'mentions', '--ndjson'])
+
+        expect(logSpy).toHaveBeenCalledTimes(1)
+        expect(JSON.parse(logSpy.mock.calls[0][0])).toEqual({
+            _meta: true,
+            nextCursor: null,
+        })
+
+        logSpy.mockRestore()
+    })
 })

--- a/src/commands/mentions.test.ts
+++ b/src/commands/mentions.test.ts
@@ -31,16 +31,16 @@ vi.mock('../lib/search-api.js', () => searchApiMocks)
 
 vi.mock('chalk')
 
-import { registerSearchCommand } from './search.js'
+import { registerMentionsCommand } from './mentions.js'
 
 function createProgram() {
     const program = new Command()
     program.exitOverride()
-    registerSearchCommand(program)
+    registerMentionsCommand(program)
     return program
 }
 
-describe('search --workspace conflict', () => {
+describe('mentions', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         refsMocks.resolveWorkspaceRef.mockResolvedValue({ id: 1, name: 'Doist' })
@@ -55,39 +55,22 @@ describe('search --workspace conflict', () => {
         const program = createProgram()
 
         await expect(
-            program.parseAsync(['node', 'tw', 'search', 'query', 'Doist', '--workspace', 'Other']),
+            program.parseAsync(['node', 'tw', 'mentions', 'Doist', '--workspace', 'Other']),
         ).rejects.toThrow('Cannot specify workspace both as argument and --workspace flag')
     })
 
-    it('parses channel and conversation refs using resolvers', async () => {
-        refsMocks.resolveChannelId.mockImplementation((ref: string) => {
-            if (ref === 'id:10') return 10
-            if (ref === 'https://twist.com/a/1/ch/20') return 20
-            throw new Error('Unexpected channel ref')
-        })
-        refsMocks.resolveConversationId.mockImplementation((ref: string) => {
-            if (ref === 'id:30') return 30
-            if (ref === 'https://twist.com/a/1/msg/40') return 40
-            throw new Error('Unexpected conversation ref')
-        })
-
+    it('searches using mentionSelf without a query', async () => {
         const program = createProgram()
         const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-        await program.parseAsync([
-            'node',
-            'tw',
-            'search',
-            'query',
-            '--channel',
-            'id:10,https://twist.com/a/1/ch/20',
-            '--conversation',
-            'id:30,https://twist.com/a/1/msg/40',
-        ])
+
+        await program.parseAsync(['node', 'tw', 'mentions'])
 
         expect(searchApiMocks.extendedSearch).toHaveBeenCalledWith(
             expect.objectContaining({
-                channelIds: [10, 20],
-                conversationIds: [30, 40],
+                workspaceId: 1,
+                mentionSelf: true,
+                query: undefined,
+                title: undefined,
             }),
         )
 
@@ -111,19 +94,19 @@ describe('search --workspace conflict', () => {
         const program = createProgram()
         const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'search', 'query', '--all'])
+        await program.parseAsync(['node', 'tw', 'mentions', '--all'])
 
         expect(searchApiMocks.extendedSearch).toHaveBeenNthCalledWith(
             1,
             expect.objectContaining({
-                query: 'query',
+                mentionSelf: true,
                 cursor: undefined,
             }),
         )
         expect(searchApiMocks.extendedSearch).toHaveBeenNthCalledWith(
             2,
             expect.objectContaining({
-                query: 'query',
+                mentionSelf: true,
                 cursor: 'cursor-1',
             }),
         )

--- a/src/commands/mentions.ts
+++ b/src/commands/mentions.ts
@@ -1,21 +1,21 @@
 import { Command } from 'commander'
 import {
     addSharedSearchOptions,
-    printSearchCommandResults,
-    runSearchCommand,
-    type SearchCommandOptions,
-} from '../lib/search-command.js'
+    printSearchResults,
+    runSearch,
+    type SharedSearchOptions,
+} from '../lib/search-helpers.js'
 
 async function mentions(
     workspaceRef: string | undefined,
-    options: SearchCommandOptions,
+    options: SharedSearchOptions,
 ): Promise<void> {
-    const { workspaceId, response } = await runSearchCommand(workspaceRef, {
+    const { workspaceId, response } = await runSearch(workspaceRef, {
         ...options,
         mentionSelf: true,
     })
 
-    printSearchCommandResults(workspaceId, response, options)
+    printSearchResults(workspaceId, response, options)
 }
 
 export function registerMentionsCommand(program: Command): void {

--- a/src/commands/mentions.ts
+++ b/src/commands/mentions.ts
@@ -1,6 +1,6 @@
-import { Command, Option } from 'commander'
-import { withCaseInsensitiveChoices } from '../lib/completion.js'
+import { Command } from 'commander'
 import {
+    addSharedSearchOptions,
     printSearchCommandResults,
     runSearchCommand,
     type SearchCommandOptions,
@@ -19,28 +19,16 @@ async function mentions(
 }
 
 export function registerMentionsCommand(program: Command): void {
-    program
-        .command('mentions [workspace-ref]')
-        .description('Show content mentioning the current user')
-        .option('--workspace <ref>', 'Workspace ID or name')
-        .option('--channel <channel-refs>', 'Filter by channels (comma-separated refs)')
-        .option('--author <user-refs>', 'Filter by author (comma-separated refs)')
-        .option('--to <user-refs>', 'Messages sent to user (comma-separated refs)')
-        .addOption(
-            withCaseInsensitiveChoices(
-                new Option('--type <type>', 'Filter: threads, messages, or all'),
-                ['threads', 'messages', 'all'],
-            ),
-        )
-        .option('--conversation <refs>', 'Limit to conversations (comma-separated refs)')
-        .option('--since <date>', 'Content from date')
-        .option('--until <date>', 'Content until date')
-        .option('--limit <n>', 'Max results per page (default: 50)')
-        .option('--cursor <cursor>', 'Pagination cursor')
-        .option('--all', 'Fetch all pages of results')
-        .option('--json', 'Output as JSON')
-        .option('--ndjson', 'Output as newline-delimited JSON')
-        .option('--full', 'Include all fields in JSON output')
+    const command = addSharedSearchOptions(
+        program
+            .command('mentions [workspace-ref]')
+            .description('Show content mentioning the current user'),
+        {
+            limitDescription: 'Max results per page (default: 50)',
+        },
+    )
+
+    command
         .addHelpText(
             'after',
             `

--- a/src/commands/mentions.ts
+++ b/src/commands/mentions.ts
@@ -6,45 +6,36 @@ import {
     type SearchCommandOptions,
 } from '../lib/search-command.js'
 
-type SearchOptions = SearchCommandOptions & {
-    titleOnly?: boolean
-    mentionMe?: boolean
-}
-
-async function search(
-    query: string,
+async function mentions(
     workspaceRef: string | undefined,
-    options: SearchOptions,
+    options: SearchCommandOptions,
 ): Promise<void> {
     const { workspaceId, response } = await runSearchCommand(workspaceRef, {
         ...options,
-        query: options.titleOnly ? undefined : query,
-        title: options.titleOnly ? query : undefined,
-        mentionSelf: options.mentionMe,
+        mentionSelf: true,
     })
+
     printSearchCommandResults(workspaceId, response, options)
 }
 
-export function registerSearchCommand(program: Command): void {
+export function registerMentionsCommand(program: Command): void {
     program
-        .command('search <query> [workspace-ref]')
-        .description('Search content across a workspace')
+        .command('mentions [workspace-ref]')
+        .description('Show content mentioning the current user')
         .option('--workspace <ref>', 'Workspace ID or name')
         .option('--channel <channel-refs>', 'Filter by channels (comma-separated refs)')
         .option('--author <user-refs>', 'Filter by author (comma-separated refs)')
-        .option('--to <user-refs>', 'Messages sent TO user (comma-separated refs)')
+        .option('--to <user-refs>', 'Messages sent to user (comma-separated refs)')
         .addOption(
             withCaseInsensitiveChoices(
                 new Option('--type <type>', 'Filter: threads, messages, or all'),
                 ['threads', 'messages', 'all'],
             ),
         )
-        .option('--title-only', 'Search in thread titles only')
         .option('--conversation <refs>', 'Limit to conversations (comma-separated refs)')
-        .option('--mention-me', 'Only results mentioning current user')
         .option('--since <date>', 'Content from date')
         .option('--until <date>', 'Content until date')
-        .option('--limit <n>', 'Max results (default: 50)')
+        .option('--limit <n>', 'Max results per page (default: 50)')
         .option('--cursor <cursor>', 'Pagination cursor')
         .option('--all', 'Fetch all pages of results')
         .option('--json', 'Output as JSON')
@@ -54,10 +45,9 @@ export function registerSearchCommand(program: Command): void {
             'after',
             `
 Examples:
-  tw search "deployment issue"
-  tw search "bug report" --type threads --channel id:12345
-  tw search "API" --author id:5678 --since 2025-01-01 --json
-  tw search "incident" --all --json`,
+  tw mentions
+  tw mentions --since 2026-04-01 --all
+  tw mentions --type threads --json`,
         )
-        .action(search)
+        .action(mentions)
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,6 +1,6 @@
-import { Command, Option } from 'commander'
-import { withCaseInsensitiveChoices } from '../lib/completion.js'
+import { Command } from 'commander'
 import {
+    addSharedSearchOptions,
     printSearchCommandResults,
     runSearchCommand,
     type SearchCommandOptions,
@@ -26,30 +26,20 @@ async function search(
 }
 
 export function registerSearchCommand(program: Command): void {
-    program
-        .command('search <query> [workspace-ref]')
-        .description('Search content across a workspace')
-        .option('--workspace <ref>', 'Workspace ID or name')
-        .option('--channel <channel-refs>', 'Filter by channels (comma-separated refs)')
-        .option('--author <user-refs>', 'Filter by author (comma-separated refs)')
-        .option('--to <user-refs>', 'Messages sent TO user (comma-separated refs)')
-        .addOption(
-            withCaseInsensitiveChoices(
-                new Option('--type <type>', 'Filter: threads, messages, or all'),
-                ['threads', 'messages', 'all'],
-            ),
-        )
-        .option('--title-only', 'Search in thread titles only')
-        .option('--conversation <refs>', 'Limit to conversations (comma-separated refs)')
-        .option('--mention-me', 'Only results mentioning current user')
-        .option('--since <date>', 'Content from date')
-        .option('--until <date>', 'Content until date')
-        .option('--limit <n>', 'Max results (default: 50)')
-        .option('--cursor <cursor>', 'Pagination cursor')
-        .option('--all', 'Fetch all pages of results')
-        .option('--json', 'Output as JSON')
-        .option('--ndjson', 'Output as newline-delimited JSON')
-        .option('--full', 'Include all fields in JSON output')
+    const command = addSharedSearchOptions(
+        program
+            .command('search <query> [workspace-ref]')
+            .description('Search content across a workspace'),
+        {
+            addUniqueFilters: (command) => {
+                command
+                    .option('--title-only', 'Search in thread titles only')
+                    .option('--mention-me', 'Only results mentioning current user')
+            },
+        },
+    )
+
+    command
         .addHelpText(
             'after',
             `

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,12 +1,12 @@
 import { Command } from 'commander'
 import {
     addSharedSearchOptions,
-    printSearchCommandResults,
-    runSearchCommand,
-    type SearchCommandOptions,
-} from '../lib/search-command.js'
+    printSearchResults,
+    runSearch,
+    type SharedSearchOptions,
+} from '../lib/search-helpers.js'
 
-type SearchOptions = SearchCommandOptions & {
+type SearchOptions = SharedSearchOptions & {
     titleOnly?: boolean
     mentionMe?: boolean
 }
@@ -16,13 +16,13 @@ async function search(
     workspaceRef: string | undefined,
     options: SearchOptions,
 ): Promise<void> {
-    const { workspaceId, response } = await runSearchCommand(workspaceRef, {
+    const { workspaceId, response } = await runSearch(workspaceRef, {
         ...options,
         query: options.titleOnly ? undefined : query,
         title: options.titleOnly ? query : undefined,
         mentionSelf: options.mentionMe,
     })
-    printSearchCommandResults(workspaceId, response, options)
+    printSearchResults(workspaceId, response, options)
 }
 
 export function registerSearchCommand(program: Command): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ const loadMsgCommand = async () => (await import('./commands/msg/index.js')).reg
 const loadCommentCommand = async () =>
     (await import('./commands/comment/index.js')).registerCommentCommand
 const loadSearchCommand = async () => (await import('./commands/search.js')).registerSearchCommand
+const loadMentionsCommand = async () =>
+    (await import('./commands/mentions.js')).registerMentionsCommand
 const loadReactCommand = async () => (await import('./commands/react.js')).registerReactCommand
 const loadAuthCommand = async () => (await import('./commands/auth/index.js')).registerAuthCommand
 const loadSkillCommand = async () =>
@@ -50,6 +52,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
     msg: ['Conversation message operations (view, update, delete)', loadMsgCommand],
     comment: ['Thread comment operations (view, update, delete)', loadCommentCommand],
     search: ['Search content across a workspace', loadSearchCommand],
+    mentions: ['Show content mentioning the current user', loadMentionsCommand],
     away: ['Manage away status', loadAwayCommand],
     react: ['Add an emoji reaction (target-type: thread, comment, message)', loadReactCommand],
     unreact: ['Remove an emoji reaction (target-type: thread, comment, message)', loadReactCommand],

--- a/src/lib/search-command.ts
+++ b/src/lib/search-command.ts
@@ -1,5 +1,7 @@
 import { getFullTwistURL, type SearchResult } from '@doist/twist-sdk'
+import { Command, Option } from 'commander'
 import { getCurrentWorkspaceId } from './api.js'
+import { withCaseInsensitiveChoices } from './completion.js'
 import { formatRelativeDate } from './dates.js'
 import { CliError } from './errors.js'
 import { includePrivateChannels } from './global-args.js'
@@ -57,6 +59,43 @@ type SearchRequestOptions = SearchCommandOptions & {
 export interface SearchCommandResult {
     workspaceId: number
     response: ExtendedSearchResponse
+}
+
+type SharedSearchOptionConfig = {
+    addUniqueFilters?: (command: Command) => void
+    limitDescription?: string
+}
+
+export function addSharedSearchOptions<T extends Command>(
+    command: T,
+    config: SharedSearchOptionConfig = {},
+): T {
+    const limitDescription = config.limitDescription ?? 'Max results (default: 50)'
+
+    command
+        .option('--workspace <ref>', 'Workspace ID or name')
+        .option('--channel <channel-refs>', 'Filter by channels (comma-separated refs)')
+        .option('--author <user-refs>', 'Filter by author (comma-separated refs)')
+        .option('--to <user-refs>', 'Messages sent to user (comma-separated refs)')
+        .addOption(
+            withCaseInsensitiveChoices(
+                new Option('--type <type>', 'Filter: threads, messages, or all'),
+                ['threads', 'messages', 'all'],
+            ),
+        )
+
+    config.addUniqueFilters?.(command)
+
+    return command
+        .option('--conversation <refs>', 'Limit to conversations (comma-separated refs)')
+        .option('--since <date>', 'Content from date')
+        .option('--until <date>', 'Content until date')
+        .option('--limit <n>', limitDescription)
+        .option('--cursor <cursor>', 'Pagination cursor')
+        .option('--all', 'Fetch all pages of results')
+        .option('--json', 'Output as JSON')
+        .option('--ndjson', 'Output as newline-delimited JSON')
+        .option('--full', 'Include all fields in JSON output')
 }
 
 async function resolveWorkspaceId(
@@ -207,18 +246,6 @@ export function printSearchCommandResults(
     response: ExtendedSearchResponse,
     options: SearchOutputOptions,
 ): void {
-    if (response.items.length === 0) {
-        if (!options.all && response.hasMore && response.nextCursorMark) {
-            console.log('No public results on this page.')
-            console.log(
-                colors.timestamp(`More results available. Use --cursor ${response.nextCursorMark}`),
-            )
-        } else {
-            console.log('No results found.')
-        }
-        return
-    }
-
     const resultsWithUrls = response.items.map((result) => ({
         ...result,
         url: buildSearchResultUrl(workspaceId, result),
@@ -242,8 +269,22 @@ export function printSearchCommandResults(
         for (const result of resultsWithUrls) {
             console.log(JSON.stringify(result))
         }
-        if (response.nextCursorMark) {
-            console.log(JSON.stringify({ _meta: true, nextCursor: response.nextCursorMark }))
+        if (resultsWithUrls.length === 0 || response.nextCursorMark) {
+            console.log(
+                JSON.stringify({ _meta: true, nextCursor: response.nextCursorMark || null }),
+            )
+        }
+        return
+    }
+
+    if (resultsWithUrls.length === 0) {
+        if (!options.all && response.hasMore && response.nextCursorMark) {
+            console.log('No public results on this page.')
+            console.log(
+                colors.timestamp(`More results available. Use --cursor ${response.nextCursorMark}`),
+            )
+        } else {
+            console.log('No results found.')
         }
         return
     }

--- a/src/lib/search-command.ts
+++ b/src/lib/search-command.ts
@@ -1,0 +1,267 @@
+import { getFullTwistURL, type SearchResult } from '@doist/twist-sdk'
+import { getCurrentWorkspaceId } from './api.js'
+import { formatRelativeDate } from './dates.js'
+import { CliError } from './errors.js'
+import { includePrivateChannels } from './global-args.js'
+import type { PaginatedViewOptions } from './options.js'
+import { colors, formatJson } from './output.js'
+import { getPublicChannelIds } from './public-channels.js'
+import {
+    resolveChannelId,
+    resolveConversationId,
+    resolveUserRefs,
+    resolveWorkspaceRef,
+} from './refs.js'
+import {
+    extendedSearch,
+    type ExtendedSearchParams,
+    type ExtendedSearchResponse,
+    type SearchType,
+} from './search-api.js'
+
+function resolveNumericRefs(
+    refs: string | undefined,
+    entityType: string,
+    resolver: (ref: string) => number,
+): number[] | undefined {
+    if (!refs) return undefined
+    return refs.split(',').map((raw) => {
+        const ref = raw.trim()
+        if (!ref) {
+            throw new CliError(
+                'INVALID_REF',
+                `Invalid ${entityType} reference list: found empty value`,
+            )
+        }
+        return resolver(ref)
+    })
+}
+
+export type SearchCommandOptions = PaginatedViewOptions & {
+    workspace?: string
+    channel?: string
+    author?: string
+    to?: string
+    type?: SearchType
+    conversation?: string
+    cursor?: string
+    all?: boolean
+}
+
+type SearchRequestOptions = SearchCommandOptions & {
+    query?: string
+    title?: string
+    mentionSelf?: boolean
+}
+
+export interface SearchCommandResult {
+    workspaceId: number
+    response: ExtendedSearchResponse
+}
+
+async function resolveWorkspaceId(
+    workspaceRef: string | undefined,
+    workspaceOption: string | undefined,
+): Promise<number> {
+    if (workspaceRef && workspaceOption) {
+        throw new CliError(
+            'CONFLICTING_OPTIONS',
+            'Cannot specify workspace both as argument and --workspace flag',
+        )
+    }
+
+    const ref = workspaceRef || workspaceOption
+    if (!ref) {
+        return getCurrentWorkspaceId()
+    }
+
+    const workspace = await resolveWorkspaceRef(ref)
+    return workspace.id
+}
+
+async function buildSearchParams(
+    workspaceId: number,
+    options: SearchRequestOptions,
+): Promise<ExtendedSearchParams> {
+    const limit = options.limit ? parseInt(options.limit, 10) : 50
+
+    const channelIds = resolveNumericRefs(options.channel, 'channel', resolveChannelId)
+    const authorIds = options.author
+        ? await resolveUserRefs(options.author, workspaceId)
+        : undefined
+    const toUserIds = options.to ? await resolveUserRefs(options.to, workspaceId) : undefined
+    const conversationIds = resolveNumericRefs(
+        options.conversation,
+        'conversation',
+        resolveConversationId,
+    )
+
+    return {
+        workspaceId,
+        query: options.query,
+        title: options.title,
+        type: options.type,
+        channelIds,
+        conversationIds,
+        authorIds,
+        toUserIds,
+        mentionSelf: options.mentionSelf,
+        dateFrom: options.since,
+        dateTo: options.until,
+        limit,
+        cursor: options.cursor,
+    }
+}
+
+async function fetchSearchPages(
+    params: ExtendedSearchParams,
+    all = false,
+): Promise<ExtendedSearchResponse> {
+    if (!all) {
+        return extendedSearch(params)
+    }
+
+    const items: SearchResult[] = []
+    let cursor = params.cursor
+    let hasMore = false
+    let isPlanRestricted = false
+
+    do {
+        const response = await extendedSearch({ ...params, cursor })
+        items.push(...response.items)
+        cursor = response.nextCursorMark
+        hasMore = response.hasMore
+        isPlanRestricted = isPlanRestricted || response.isPlanRestricted
+    } while (hasMore && cursor)
+
+    return {
+        items,
+        hasMore: false,
+        isPlanRestricted,
+    }
+}
+
+async function filterVisibleSearchResults(
+    workspaceId: number,
+    response: ExtendedSearchResponse,
+): Promise<ExtendedSearchResponse> {
+    if (includePrivateChannels()) {
+        return response
+    }
+
+    const publicIds = await getPublicChannelIds(workspaceId)
+    return {
+        ...response,
+        items: response.items.filter((item) => !item.channelId || publicIds.has(item.channelId)),
+    }
+}
+
+export async function runSearchCommand(
+    workspaceRef: string | undefined,
+    options: SearchRequestOptions,
+): Promise<SearchCommandResult> {
+    const workspaceId = await resolveWorkspaceId(workspaceRef, options.workspace)
+    const params = await buildSearchParams(workspaceId, options)
+    const response = await fetchSearchPages(params, options.all)
+    return {
+        workspaceId,
+        response: await filterVisibleSearchResults(workspaceId, response),
+    }
+}
+
+function buildSearchResultUrl(
+    workspaceId: number,
+    result: {
+        type: string
+        threadId?: number | null
+        channelId?: number | null
+        conversationId?: number | null
+        commentId?: number | null
+    },
+): string {
+    if (result.type === 'thread' && result.threadId && result.channelId) {
+        return getFullTwistURL({
+            workspaceId,
+            channelId: result.channelId,
+            threadId: result.threadId,
+        })
+    }
+    if (result.type === 'comment' && result.threadId && result.channelId && result.commentId) {
+        return getFullTwistURL({
+            workspaceId,
+            channelId: result.channelId,
+            threadId: result.threadId,
+            commentId: result.commentId,
+        })
+    }
+    if (result.type === 'message' && result.conversationId) {
+        return getFullTwistURL({ workspaceId, conversationId: result.conversationId })
+    }
+    return `https://twist.com/a/${workspaceId}`
+}
+
+type SearchOutputOptions = Pick<SearchCommandOptions, 'all' | 'json' | 'ndjson' | 'full'>
+
+export function printSearchCommandResults(
+    workspaceId: number,
+    response: ExtendedSearchResponse,
+    options: SearchOutputOptions,
+): void {
+    if (response.items.length === 0) {
+        if (!options.all && response.hasMore && response.nextCursorMark) {
+            console.log('No public results on this page.')
+            console.log(
+                colors.timestamp(`More results available. Use --cursor ${response.nextCursorMark}`),
+            )
+        } else {
+            console.log('No results found.')
+        }
+        return
+    }
+
+    const resultsWithUrls = response.items.map((result) => ({
+        ...result,
+        url: buildSearchResultUrl(workspaceId, result),
+    }))
+
+    if (options.json) {
+        console.log(
+            formatJson(
+                {
+                    results: resultsWithUrls,
+                    nextCursor: response.nextCursorMark || null,
+                },
+                undefined,
+                options.full,
+            ),
+        )
+        return
+    }
+
+    if (options.ndjson) {
+        for (const result of resultsWithUrls) {
+            console.log(JSON.stringify(result))
+        }
+        if (response.nextCursorMark) {
+            console.log(JSON.stringify({ _meta: true, nextCursor: response.nextCursorMark }))
+        }
+        return
+    }
+
+    for (const result of resultsWithUrls) {
+        const type = colors.channel(`[${result.type}]`)
+        const title = result.title || result.snippet.slice(0, 50)
+        const time = colors.timestamp(formatRelativeDate(result.snippetLastUpdated))
+
+        console.log(`${type} ${title}`)
+        console.log(`  ${colors.timestamp(result.snippet.slice(0, 100))}`)
+        console.log(`  ${time}  ${colors.url(result.url)}`)
+        console.log('')
+    }
+
+    if (!options.all && response.hasMore) {
+        console.log(
+            colors.timestamp(`More results available. Use --cursor ${response.nextCursorMark}`),
+        )
+    }
+}

--- a/src/lib/search-helpers.ts
+++ b/src/lib/search-helpers.ts
@@ -39,7 +39,7 @@ function resolveNumericRefs(
     })
 }
 
-export type SearchCommandOptions = PaginatedViewOptions & {
+export type SharedSearchOptions = PaginatedViewOptions & {
     workspace?: string
     channel?: string
     author?: string
@@ -50,13 +50,13 @@ export type SearchCommandOptions = PaginatedViewOptions & {
     all?: boolean
 }
 
-type SearchRequestOptions = SearchCommandOptions & {
+type SearchRequestOptions = SharedSearchOptions & {
     query?: string
     title?: string
     mentionSelf?: boolean
 }
 
-export interface SearchCommandResult {
+interface SearchRunResult {
     workspaceId: number
     response: ExtendedSearchResponse
 }
@@ -195,10 +195,10 @@ async function filterVisibleSearchResults(
     }
 }
 
-export async function runSearchCommand(
+export async function runSearch(
     workspaceRef: string | undefined,
     options: SearchRequestOptions,
-): Promise<SearchCommandResult> {
+): Promise<SearchRunResult> {
     const workspaceId = await resolveWorkspaceId(workspaceRef, options.workspace)
     const params = await buildSearchParams(workspaceId, options)
     const response = await fetchSearchPages(params, options.all)
@@ -239,9 +239,9 @@ function buildSearchResultUrl(
     return `https://twist.com/a/${workspaceId}`
 }
 
-type SearchOutputOptions = Pick<SearchCommandOptions, 'all' | 'json' | 'ndjson' | 'full'>
+type SearchOutputOptions = Pick<SharedSearchOptions, 'all' | 'json' | 'ndjson' | 'full'>
 
-export function printSearchCommandResults(
+export function printSearchResults(
     workspaceId: number,
     response: ExtendedSearchResponse,
     options: SearchOutputOptions,

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -3,7 +3,7 @@ import packageJson from '../../../package.json' with { type: 'json' }
 export const SKILL_NAME = 'twist-cli'
 
 export const SKILL_DESCRIPTION =
-    'Twist messaging CLI. View and respond to inbox threads, channel threads, direct messages, and group conversations; search, react, archive, mute, and manage workspaces. Use when the user mentions Twist, asks about their inbox, threads, DMs, channels, or wants to read or send Twist messages.'
+    'Twist messaging CLI. View and respond to inbox threads, channel threads, direct messages, mentions, and group conversations; search, react, archive, mute, and manage workspaces. Use when the user mentions Twist, asks about their inbox, mentions, threads, DMs, channels, or wants to read or send Twist messages.'
 
 export const SKILL_AUTHOR = 'Doist'
 
@@ -172,6 +172,9 @@ Alias: \`tw message\` works the same as \`tw msg\`.
 ## Search
 
 \`\`\`bash
+tw mentions                      # Show content mentioning current user
+tw mentions --since 2026-04-01 --all # Fetch every mention since a date
+tw mentions --type threads --json # Limit mentions to threads
 tw search "query"                # Search content
 tw search "query" --type threads # Filter: threads, messages, or all
 tw search "query" --author <ref> # Filter by author
@@ -184,6 +187,7 @@ tw search "query" --until <date> # Content until date
 tw search "query" --channel <refs> # Filter by channel refs (comma-separated)
 tw search "query" --limit <n>    # Max results (default: 50)
 tw search "query" --cursor <cur> # Pagination cursor
+tw search "query" --all          # Fetch all result pages
 \`\`\`
 
 ## Users, Channels & Groups
@@ -355,6 +359,7 @@ tw thread done <id>
 
 **Search and review:**
 \`\`\`bash
+tw mentions --since 2026-04-01 --all --json
 tw search "deployment" --type threads --json
 tw thread view <thread-id>
 \`\`\`


### PR DESCRIPTION
This adds a dedicated `tw mentions` command for fetching content that mentions the current user, with the same filters and output modes as search plus an `--all` option to walk every results page.

Mentions were previously only reachable through `tw search --mention-me`, which still required a query string and left full backlog traversal to manual cursor handling.

The change also refactors shared search plumbing so `tw search` reuses the same resolver and output path, while the CLI docs and generated Twist skill content now advertise both `tw mentions` and `tw search --all`.

Validation: `npm test`, `npx vitest run src/commands/search.test.ts src/commands/mentions.test.ts`, `npm run type-check`, `npm run lint:check`, and `npm run check:skill-sync`.
