### PR TITLE
fix: emit empty JSON/NDJSON when inbox/unread results empty

### DIFF
--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -252,9 +252,9 @@ describe('conversation unread empty output', () => {
         const program = createProgram()
         await program.parseAsync(['node', 'tw', 'conversation', 'unread', '--ndjson'])
 
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output.trim()).toBe('')
-        expect(output).not.toContain('No unread conversations')
+        // Must not call console.log at all — `console.log('')` still emits a
+        // stray newline and would break strict NDJSON consumers.
+        expect(logSpy).not.toHaveBeenCalled()
     })
 
     it('still prints human message when --json/--ndjson not set', async () => {

--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CliError } from '../../lib/errors.js'
+import { describeEmptyMachineOutput } from '../../test-helpers/empty-output.js'
 
 const apiMocks = vi.hoisted(() => ({
     getTwistClient: vi.fn(),
@@ -228,42 +229,18 @@ describe('conversation unread --workspace conflict', () => {
     })
 })
 
-describe('conversation unread empty output', () => {
-    let logSpy: ReturnType<typeof vi.spyOn>
-
-    beforeEach(() => {
+describeEmptyMachineOutput('conversation unread empty output', {
+    setup: () => {
         vi.clearAllMocks()
         const client = createClient({})
         client.conversations.getUnread = vi.fn().mockResolvedValue([])
         apiMocks.getTwistClient.mockResolvedValue(client)
-        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    it('outputs [] for --json when there are no unread conversations', async () => {
+    },
+    run: async (extraArgs) => {
         const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'conversation', 'unread', '--json'])
-
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output.trim()).toBe('[]')
-        expect(output).not.toContain('No unread conversations')
-    })
-
-    it('outputs nothing for --ndjson when there are no unread conversations', async () => {
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'conversation', 'unread', '--ndjson'])
-
-        // Must not call console.log at all — `console.log('')` still emits a
-        // stray newline and would break strict NDJSON consumers.
-        expect(logSpy).not.toHaveBeenCalled()
-    })
-
-    it('still prints human message when --json/--ndjson not set', async () => {
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'conversation', 'unread'])
-
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output).toContain('No unread conversations.')
-    })
+        await program.parseAsync(['node', 'tw', 'conversation', 'unread', ...extraArgs])
+    },
+    humanMessage: 'No unread conversations.',
 })
 
 describe('conversation with', () => {

--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -228,6 +228,44 @@ describe('conversation unread --workspace conflict', () => {
     })
 })
 
+describe('conversation unread empty output', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        const client = createClient({})
+        client.conversations.getUnread = vi.fn().mockResolvedValue([])
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('outputs [] for --json when there are no unread conversations', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'conversation', 'unread', '--json'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output.trim()).toBe('[]')
+        expect(output).not.toContain('No unread conversations')
+    })
+
+    it('outputs nothing for --ndjson when there are no unread conversations', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'conversation', 'unread', '--ndjson'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output.trim()).toBe('')
+        expect(output).not.toContain('No unread conversations')
+    })
+
+    it('still prints human message when --json/--ndjson not set', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'conversation', 'unread'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output).toContain('No unread conversations.')
+    })
+})
+
 describe('conversation with', () => {
     beforeEach(() => {
         vi.clearAllMocks()

--- a/src/commands/conversation/helpers.ts
+++ b/src/commands/conversation/helpers.ts
@@ -6,7 +6,7 @@ import { CliError } from '../../lib/errors.js'
 import { isAccessible } from '../../lib/global-args.js'
 import { renderMarkdown } from '../../lib/markdown.js'
 import type { MutationOptions, PaginatedViewOptions, ViewOptions } from '../../lib/options.js'
-import { colors, formatJson, formatNdjson } from '../../lib/output.js'
+import { colors, formatJson, formatNdjson, printEmpty } from '../../lib/output.js'
 
 export type UnreadOptions = ViewOptions & { workspace?: string }
 
@@ -163,14 +163,7 @@ export async function listConversationsWithUser(
     options: ConversationWithOptions,
 ): Promise<void> {
     if (conversations.length === 0) {
-        if (options.json) {
-            console.log(formatJson([], 'conversation', options.full))
-            return
-        }
-        if (options.ndjson) {
-            return
-        }
-        console.log('No matching conversations found.')
+        printEmpty(options, 'conversation', 'No matching conversations found.')
         return
     }
 

--- a/src/commands/conversation/helpers.ts
+++ b/src/commands/conversation/helpers.ts
@@ -163,7 +163,11 @@ export async function listConversationsWithUser(
     options: ConversationWithOptions,
 ): Promise<void> {
     if (conversations.length === 0) {
-        printEmpty(options, 'conversation', 'No matching conversations found.')
+        printEmpty({
+            options,
+            type: 'conversation',
+            message: 'No matching conversations found.',
+        })
         return
     }
 

--- a/src/commands/conversation/unread.ts
+++ b/src/commands/conversation/unread.ts
@@ -31,7 +31,7 @@ export async function showUnread(
     const unreadConversations = await client.conversations.getUnread(workspaceId)
 
     if (unreadConversations.length === 0) {
-        printEmpty(options, 'conversation', 'No unread conversations.')
+        printEmpty({ options, type: 'conversation', message: 'No unread conversations.' })
         return
     }
 

--- a/src/commands/conversation/unread.ts
+++ b/src/commands/conversation/unread.ts
@@ -31,6 +31,14 @@ export async function showUnread(
     const unreadConversations = await client.conversations.getUnread(workspaceId)
 
     if (unreadConversations.length === 0) {
+        if (options.json) {
+            console.log(formatJson([], 'conversation', options.full))
+            return
+        }
+        if (options.ndjson) {
+            console.log(formatNdjson([], 'conversation', options.full))
+            return
+        }
         console.log('No unread conversations.')
         return
     }

--- a/src/commands/conversation/unread.ts
+++ b/src/commands/conversation/unread.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { getCurrentWorkspaceId, getTwistClient } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import { isAccessible } from '../../lib/global-args.js'
-import { colors, formatJson, formatNdjson } from '../../lib/output.js'
+import { colors, formatJson, formatNdjson, printEmpty } from '../../lib/output.js'
 import { resolveWorkspaceRef } from '../../lib/refs.js'
 import type { UnreadOptions } from './helpers.js'
 
@@ -31,15 +31,7 @@ export async function showUnread(
     const unreadConversations = await client.conversations.getUnread(workspaceId)
 
     if (unreadConversations.length === 0) {
-        if (options.json) {
-            console.log(formatJson([], 'conversation', options.full))
-            return
-        }
-        if (options.ndjson) {
-            console.log(formatNdjson([], 'conversation', options.full))
-            return
-        }
-        console.log('No unread conversations.')
+        printEmpty(options, 'conversation', 'No unread conversations.')
         return
     }
 

--- a/src/commands/groups/groups.test.ts
+++ b/src/commands/groups/groups.test.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describeEmptyMachineOutput } from '../../test-helpers/empty-output.js'
 
 const mockBatch = vi.fn()
 const mockGetUserById = vi.fn()
@@ -69,6 +70,19 @@ beforeEach(() => {
         workspaceUsers: { getUserById: mockGetUserById },
         batch: mockBatch,
     })
+})
+
+describeEmptyMachineOutput('tw groups list empty output', {
+    setup: () => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        apiMocks.getWorkspaceGroups.mockResolvedValue([])
+    },
+    run: async (extraArgs) => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'groups', ...extraArgs])
+    },
+    humanMessage: 'No groups found.',
 })
 
 describe('tw groups list (default)', () => {

--- a/src/commands/groups/list.ts
+++ b/src/commands/groups/list.ts
@@ -1,7 +1,7 @@
 import { getCurrentWorkspaceId, getWorkspaceGroups } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { ViewOptions } from '../../lib/options.js'
-import { colors, formatJson, formatNdjson, pluralize } from '../../lib/output.js'
+import { colors, formatJson, formatNdjson, pluralize, printEmpty } from '../../lib/output.js'
 import { resolveWorkspaceRef } from '../../lib/refs.js'
 
 export type ListGroupsOptions = ViewOptions & { workspace?: string; search?: string }
@@ -34,6 +34,11 @@ export async function listGroups(
         groups = groups.filter((g) => g.name.toLowerCase().includes(query))
     }
 
+    if (groups.length === 0) {
+        printEmpty(options, 'group', 'No groups found.')
+        return
+    }
+
     if (options.json) {
         console.log(formatJson(groups, 'group', options.full))
         return
@@ -41,11 +46,6 @@ export async function listGroups(
 
     if (options.ndjson) {
         console.log(formatNdjson(groups, 'group', options.full))
-        return
-    }
-
-    if (groups.length === 0) {
-        console.log('No groups found.')
         return
     }
 

--- a/src/commands/groups/list.ts
+++ b/src/commands/groups/list.ts
@@ -35,7 +35,7 @@ export async function listGroups(
     }
 
     if (groups.length === 0) {
-        printEmpty(options, 'group', 'No groups found.')
+        printEmpty({ options, type: 'group', message: 'No groups found.' })
         return
     }
 

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describeEmptyMachineOutput } from '../test-helpers/empty-output.js'
 
 const apiMocks = vi.hoisted(() => ({
     getTwistClient: vi.fn(),
@@ -88,57 +89,36 @@ describe('inbox --archive-filter', () => {
     })
 })
 
-describe('inbox empty output', () => {
-    const mockGetInbox = vi.fn()
-    const mockGetUnread = vi.fn()
-    const mockGetChannel = vi.fn()
+const emptyInboxMockBatch = vi.fn()
+
+describeEmptyMachineOutput('inbox empty output', {
+    setup: () => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        emptyInboxMockBatch.mockImplementation((..._calls: unknown[]) =>
+            Promise.resolve([{ data: [] }, { data: [] }]),
+        )
+        apiMocks.getTwistClient.mockResolvedValue({
+            inbox: { getInbox: vi.fn().mockReturnValue({ data: [] }) },
+            threads: { getUnread: vi.fn().mockReturnValue({ data: [] }) },
+            channels: { getChannel: vi.fn() },
+            batch: emptyInboxMockBatch,
+        })
+    },
+    run: async (extraArgs) => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox', ...extraArgs])
+    },
+    humanMessage: 'No threads in inbox.',
+})
+
+describe('inbox empty output (channel filter)', () => {
     const mockBatch = vi.fn()
     let logSpy: ReturnType<typeof vi.spyOn>
 
     beforeEach(() => {
         vi.clearAllMocks()
         apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
-        mockGetInbox.mockReturnValue({ data: [] })
-        mockGetUnread.mockReturnValue({ data: [] })
-        mockBatch.mockImplementation((..._calls: unknown[]) =>
-            Promise.resolve([{ data: [] }, { data: [] }]),
-        )
-        apiMocks.getTwistClient.mockResolvedValue({
-            inbox: { getInbox: mockGetInbox },
-            threads: { getUnread: mockGetUnread },
-            channels: { getChannel: mockGetChannel },
-            batch: mockBatch,
-        })
-        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    })
-
-    it('outputs [] for --json when inbox is empty', async () => {
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'inbox', '--json'])
-
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output.trim()).toBe('[]')
-        expect(output).not.toContain('No threads')
-    })
-
-    it('outputs nothing for --ndjson when inbox is empty', async () => {
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'inbox', '--ndjson'])
-
-        // Must not call console.log at all — `console.log('')` still emits a
-        // stray newline and would break strict NDJSON consumers.
-        expect(logSpy).not.toHaveBeenCalled()
-    })
-
-    it('still prints human message when --json/--ndjson not set', async () => {
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'inbox'])
-
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output).toContain('No threads in inbox.')
-    })
-
-    it('outputs [] for --json when --channel filter matches nothing', async () => {
         const thread = {
             id: 1,
             channelId: 10,
@@ -146,15 +126,23 @@ describe('inbox empty output', () => {
             posted: '2026-05-01T00:00:00Z',
             url: 'http://example/t',
         }
-        mockBatch.mockReset()
         mockBatch
             .mockResolvedValueOnce([{ data: [thread] }, { data: [] }])
             .mockResolvedValueOnce([{ data: { id: 10, name: 'engineering' } }])
+        apiMocks.getTwistClient.mockResolvedValue({
+            inbox: { getInbox: vi.fn() },
+            threads: { getUnread: vi.fn() },
+            channels: { getChannel: vi.fn() },
+            batch: mockBatch,
+        })
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
 
+    it('outputs [] for --json when --channel filter matches nothing', async () => {
         const program = createProgram()
         await program.parseAsync(['node', 'tw', 'inbox', '--channel', 'nonexistent', '--json'])
 
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output.trim()).toBe('[]')
+        expect(logSpy).toHaveBeenCalledTimes(1)
+        expect(logSpy).toHaveBeenCalledWith('[]')
     })
 })

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -87,3 +87,74 @@ describe('inbox --archive-filter', () => {
         )
     })
 })
+
+describe('inbox empty output', () => {
+    const mockGetInbox = vi.fn()
+    const mockGetUnread = vi.fn()
+    const mockGetChannel = vi.fn()
+    const mockBatch = vi.fn()
+    let logSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        mockGetInbox.mockReturnValue({ data: [] })
+        mockGetUnread.mockReturnValue({ data: [] })
+        mockBatch.mockImplementation((..._calls: unknown[]) =>
+            Promise.resolve([{ data: [] }, { data: [] }]),
+        )
+        apiMocks.getTwistClient.mockResolvedValue({
+            inbox: { getInbox: mockGetInbox },
+            threads: { getUnread: mockGetUnread },
+            channels: { getChannel: mockGetChannel },
+            batch: mockBatch,
+        })
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    it('outputs [] for --json when inbox is empty', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox', '--json'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output.trim()).toBe('[]')
+        expect(output).not.toContain('No threads')
+    })
+
+    it('outputs nothing for --ndjson when inbox is empty', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox', '--ndjson'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output.trim()).toBe('')
+        expect(output).not.toContain('No threads')
+    })
+
+    it('still prints human message when --json/--ndjson not set', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output).toContain('No threads in inbox.')
+    })
+
+    it('outputs [] for --json when --channel filter matches nothing', async () => {
+        const thread = {
+            id: 1,
+            channelId: 10,
+            title: 't',
+            posted: '2026-05-01T00:00:00Z',
+            url: 'http://example/t',
+        }
+        mockBatch.mockReset()
+        mockBatch
+            .mockResolvedValueOnce([{ data: [thread] }, { data: [] }])
+            .mockResolvedValueOnce([{ data: { id: 10, name: 'engineering' } }])
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'inbox', '--channel', 'nonexistent', '--json'])
+
+        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
+        expect(output.trim()).toBe('[]')
+    })
+})

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -125,9 +125,9 @@ describe('inbox empty output', () => {
         const program = createProgram()
         await program.parseAsync(['node', 'tw', 'inbox', '--ndjson'])
 
-        const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n')
-        expect(output.trim()).toBe('')
-        expect(output).not.toContain('No threads')
+        // Must not call console.log at all — `console.log('')` still emits a
+        // stray newline and would break strict NDJSON consumers.
+        expect(logSpy).not.toHaveBeenCalled()
     })
 
     it('still prints human message when --json/--ndjson not set', async () => {

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -64,6 +64,14 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
     }
 
     if (inboxThreads.length === 0) {
+        if (options.json) {
+            console.log(formatJson([], 'thread', options.full))
+            return
+        }
+        if (options.ndjson) {
+            console.log(formatNdjson([], 'thread', options.full))
+            return
+        }
         console.log('No threads in inbox.')
         return
     }
@@ -78,6 +86,14 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         inboxThreads = inboxThreads.filter((t) => publicIds.has(t.channelId))
 
         if (inboxThreads.length === 0) {
+            if (options.json) {
+                console.log(formatJson([], 'thread', options.full))
+                return
+            }
+            if (options.ndjson) {
+                console.log(formatNdjson([], 'thread', options.full))
+                return
+            }
             console.log('No threads in public channels.')
             return
         }
@@ -93,6 +109,14 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         inboxThreads = inboxThreads.filter((t) => matchingChannelIds.has(t.channelId))
 
         if (inboxThreads.length === 0) {
+            if (options.json) {
+                console.log(formatJson([], 'thread', options.full))
+                return
+            }
+            if (options.ndjson) {
+                console.log(formatNdjson([], 'thread', options.full))
+                return
+            }
             console.log(`No threads in channels matching "${options.channel}".`)
             return
         }

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -64,7 +64,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
     }
 
     if (inboxThreads.length === 0) {
-        printEmpty(options, 'thread', 'No threads in inbox.')
+        printEmpty({ options, type: 'thread', message: 'No threads in inbox.' })
         return
     }
 
@@ -78,7 +78,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         inboxThreads = inboxThreads.filter((t) => publicIds.has(t.channelId))
 
         if (inboxThreads.length === 0) {
-            printEmpty(options, 'thread', 'No threads in public channels.')
+            printEmpty({ options, type: 'thread', message: 'No threads in public channels.' })
             return
         }
     }
@@ -93,7 +93,11 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         inboxThreads = inboxThreads.filter((t) => matchingChannelIds.has(t.channelId))
 
         if (inboxThreads.length === 0) {
-            printEmpty(options, 'thread', `No threads in channels matching "${options.channel}".`)
+            printEmpty({
+                options,
+                type: 'thread',
+                message: `No threads in channels matching "${options.channel}".`,
+            })
             return
         }
     }

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -7,7 +7,7 @@ import { formatRelativeDate } from '../lib/dates.js'
 import { CliError } from '../lib/errors.js'
 import { includePrivateChannels, isAccessible } from '../lib/global-args.js'
 import type { PaginatedViewOptions } from '../lib/options.js'
-import { colors, formatJson, formatNdjson } from '../lib/output.js'
+import { colors, formatJson, formatNdjson, printEmpty } from '../lib/output.js'
 import { getPublicChannelIds } from '../lib/public-channels.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
 
@@ -64,15 +64,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
     }
 
     if (inboxThreads.length === 0) {
-        if (options.json) {
-            console.log(formatJson([], 'thread', options.full))
-            return
-        }
-        if (options.ndjson) {
-            console.log(formatNdjson([], 'thread', options.full))
-            return
-        }
-        console.log('No threads in inbox.')
+        printEmpty(options, 'thread', 'No threads in inbox.')
         return
     }
 
@@ -86,15 +78,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         inboxThreads = inboxThreads.filter((t) => publicIds.has(t.channelId))
 
         if (inboxThreads.length === 0) {
-            if (options.json) {
-                console.log(formatJson([], 'thread', options.full))
-                return
-            }
-            if (options.ndjson) {
-                console.log(formatNdjson([], 'thread', options.full))
-                return
-            }
-            console.log('No threads in public channels.')
+            printEmpty(options, 'thread', 'No threads in public channels.')
             return
         }
     }
@@ -109,15 +93,7 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         inboxThreads = inboxThreads.filter((t) => matchingChannelIds.has(t.channelId))
 
         if (inboxThreads.length === 0) {
-            if (options.json) {
-                console.log(formatJson([], 'thread', options.full))
-                return
-            }
-            if (options.ndjson) {
-                console.log(formatNdjson([], 'thread', options.full))
-                return
-            }
-            console.log(`No threads in channels matching "${options.channel}".`)
+            printEmpty(options, 'thread', `No threads in channels matching "${options.channel}".`)
             return
         }
     }

--- a/src/commands/user.test.ts
+++ b/src/commands/user.test.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describeEmptyMachineOutput } from '../test-helpers/empty-output.js'
 
 const apiMocks = vi.hoisted(() => ({
     getCurrentWorkspaceId: vi.fn().mockResolvedValue(1),
@@ -40,6 +41,19 @@ describe('users --workspace conflict', () => {
             program.parseAsync(['node', 'tw', 'users', 'Doist', '--workspace', 'Other']),
         ).rejects.toThrow('Cannot specify workspace both as argument and --workspace flag')
     })
+})
+
+describeEmptyMachineOutput('tw users empty output', {
+    setup: () => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        apiMocks.getWorkspaceUsers.mockResolvedValue([])
+    },
+    run: async (extraArgs) => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'users', ...extraArgs])
+    },
+    humanMessage: 'No users found.',
 })
 
 describe('user --json', () => {

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander'
 import { getCurrentWorkspaceId, getSessionUser, getWorkspaceUsers } from '../lib/api.js'
 import { CliError } from '../lib/errors.js'
 import type { ViewOptions } from '../lib/options.js'
-import { colors, formatJson, formatNdjson } from '../lib/output.js'
+import { colors, formatJson, formatNdjson, printEmpty } from '../lib/output.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
 
 type UsersOptions = ViewOptions & { workspace?: string; search?: string }
@@ -53,6 +53,11 @@ async function listUsers(workspaceRef: string | undefined, options: UsersOptions
         )
     }
 
+    if (users.length === 0) {
+        printEmpty(options, 'user', 'No users found.')
+        return
+    }
+
     if (options.json) {
         console.log(formatJson(users, 'user', options.full))
         return
@@ -60,11 +65,6 @@ async function listUsers(workspaceRef: string | undefined, options: UsersOptions
 
     if (options.ndjson) {
         console.log(formatNdjson(users, 'user', options.full))
-        return
-    }
-
-    if (users.length === 0) {
-        console.log('No users found.')
         return
     }
 

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -54,7 +54,7 @@ async function listUsers(workspaceRef: string | undefined, options: UsersOptions
     }
 
     if (users.length === 0) {
-        printEmpty(options, 'user', 'No users found.')
+        printEmpty({ options, type: 'user', message: 'No users found.' })
         return
     }
 

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -12,7 +12,7 @@ async function listWorkspaces(options: ListOptions): Promise<void> {
     const workspaces = await fetchWorkspaces()
 
     if (workspaces.length === 0) {
-        printEmpty(options, 'workspace', 'No workspaces found.')
+        printEmpty({ options, type: 'workspace', message: 'No workspaces found.' })
         return
     }
 

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -3,13 +3,18 @@ import { Command } from 'commander'
 import { fetchWorkspaces, getCurrentWorkspaceId } from '../lib/api.js'
 import { updateConfig } from '../lib/config.js'
 import type { ViewOptions } from '../lib/options.js'
-import { colors, formatJson, formatNdjson } from '../lib/output.js'
+import { colors, formatJson, formatNdjson, printEmpty } from '../lib/output.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
 
 type ListOptions = ViewOptions
 
 async function listWorkspaces(options: ListOptions): Promise<void> {
     const workspaces = await fetchWorkspaces()
+
+    if (workspaces.length === 0) {
+        printEmpty(options, 'workspace', 'No workspaces found.')
+        return
+    }
 
     if (options.json) {
         console.log(formatJson(workspaces, 'workspace', options.full))
@@ -18,11 +23,6 @@ async function listWorkspaces(options: ListOptions): Promise<void> {
 
     if (options.ndjson) {
         console.log(formatNdjson(workspaces, 'workspace', options.full))
-        return
-    }
-
-    if (workspaces.length === 0) {
-        console.log('No workspaces found.')
         return
     }
 

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { isAccessible, resetGlobalArgs } from './global-args.js'
-import { printDryRun } from './output.js'
+import { printDryRun, printEmpty } from './output.js'
 
 vi.mock('chalk')
 
@@ -96,5 +96,39 @@ describe('printDryRun', () => {
         expect(logSpy).toHaveBeenCalledWith('Run without --dry-run to execute.')
 
         logSpy.mockRestore()
+    })
+})
+
+describe('printEmpty', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        logSpy.mockRestore()
+    })
+
+    it('prints "[]" for --json', () => {
+        printEmpty({ json: true }, 'thread', 'No threads in inbox.')
+        expect(logSpy).toHaveBeenCalledTimes(1)
+        expect(logSpy).toHaveBeenCalledWith('[]')
+    })
+
+    it('does not call console.log at all for --ndjson (no stray newline)', () => {
+        printEmpty({ ndjson: true }, 'thread', 'No threads in inbox.')
+        expect(logSpy).not.toHaveBeenCalled()
+    })
+
+    it('prints the human message when neither --json nor --ndjson is set', () => {
+        printEmpty({}, 'thread', 'No threads in inbox.')
+        expect(logSpy).toHaveBeenCalledWith('No threads in inbox.')
+    })
+
+    it('--json takes precedence over --ndjson when both are set', () => {
+        printEmpty({ json: true, ndjson: true }, 'conversation', 'unused')
+        expect(logSpy).toHaveBeenCalledTimes(1)
+        expect(logSpy).toHaveBeenCalledWith('[]')
     })
 })

--- a/src/lib/output.test.ts
+++ b/src/lib/output.test.ts
@@ -111,23 +111,27 @@ describe('printEmpty', () => {
     })
 
     it('prints "[]" for --json', () => {
-        printEmpty({ json: true }, 'thread', 'No threads in inbox.')
+        printEmpty({ options: { json: true }, type: 'thread', message: 'No threads in inbox.' })
         expect(logSpy).toHaveBeenCalledTimes(1)
         expect(logSpy).toHaveBeenCalledWith('[]')
     })
 
     it('does not call console.log at all for --ndjson (no stray newline)', () => {
-        printEmpty({ ndjson: true }, 'thread', 'No threads in inbox.')
+        printEmpty({ options: { ndjson: true }, type: 'thread', message: 'No threads in inbox.' })
         expect(logSpy).not.toHaveBeenCalled()
     })
 
     it('prints the human message when neither --json nor --ndjson is set', () => {
-        printEmpty({}, 'thread', 'No threads in inbox.')
+        printEmpty({ options: {}, type: 'thread', message: 'No threads in inbox.' })
         expect(logSpy).toHaveBeenCalledWith('No threads in inbox.')
     })
 
     it('--json takes precedence over --ndjson when both are set', () => {
-        printEmpty({ json: true, ndjson: true }, 'conversation', 'unused')
+        printEmpty({
+            options: { json: true, ndjson: true },
+            type: 'conversation',
+            message: 'unused',
+        })
         expect(logSpy).toHaveBeenCalledTimes(1)
         expect(logSpy).toHaveBeenCalledWith('[]')
     })

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -227,11 +227,15 @@ export function printNdjson<T extends object>(items: T[], type?: EntityType, ful
     console.log(formatNdjson(items, type, full))
 }
 
-export function printEmpty(
-    options: { json?: boolean; ndjson?: boolean; full?: boolean },
-    type: EntityType,
-    message: string,
-): void {
+export function printEmpty({
+    options,
+    type,
+    message,
+}: {
+    options: { json?: boolean; ndjson?: boolean; full?: boolean }
+    type: EntityType
+    message: string
+}): void {
     if (options.json) {
         console.log(formatJson([], type, options.full))
         return

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -227,6 +227,21 @@ export function printNdjson<T extends object>(items: T[], type?: EntityType, ful
     console.log(formatNdjson(items, type, full))
 }
 
+export function printEmpty(
+    options: { json?: boolean; ndjson?: boolean; full?: boolean },
+    type: EntityType,
+    message: string,
+): void {
+    if (options.json) {
+        console.log(formatJson([], type, options.full))
+        return
+    }
+    if (options.ndjson) {
+        return
+    }
+    console.log(message)
+}
+
 export function pluralize(count: number, singular: string): string {
     return count === 1 ? singular : `${singular}s`
 }

--- a/src/test-helpers/empty-output.ts
+++ b/src/test-helpers/empty-output.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type EmptyOutputConfig = {
+    setup: () => void | Promise<void>
+    run: (extraArgs: string[]) => Promise<void>
+    humanMessage: string | RegExp
+}
+
+/**
+ * Asserts the standard `printEmpty` contract for a command:
+ *   --json   → prints exactly "[]"
+ *   --ndjson → does not call console.log at all (no stray newline)
+ *   neither  → prints the human-readable message
+ *
+ * `setup` runs before each test (use it to (re)wire mocks for an empty
+ * result). `run` is called with the extra CLI args to append to the
+ * command being tested.
+ */
+export function describeEmptyMachineOutput(label: string, config: EmptyOutputConfig): void {
+    describe(label, () => {
+        let logSpy: ReturnType<typeof vi.spyOn>
+
+        beforeEach(async () => {
+            await config.setup()
+            logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        })
+
+        afterEach(() => {
+            logSpy.mockRestore()
+        })
+
+        it('outputs "[]" for --json', async () => {
+            await config.run(['--json'])
+            expect(logSpy).toHaveBeenCalledTimes(1)
+            expect(logSpy).toHaveBeenCalledWith('[]')
+        })
+
+        it('does not call console.log for --ndjson (no stray newline)', async () => {
+            await config.run(['--ndjson'])
+            expect(logSpy).not.toHaveBeenCalled()
+        })
+
+        it('prints human message when no machine output flag is set', async () => {
+            await config.run([])
+            const output = logSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+            if (typeof config.humanMessage === 'string') {
+                expect(output).toContain(config.humanMessage)
+            } else {
+                expect(output).toMatch(config.humanMessage)
+            }
+        })
+    })
+}


### PR DESCRIPTION
## Summary
- `tw inbox --json` (and `--ndjson`) printed `No threads in inbox.` instead of `[]` when empty, breaking pipelines that parse the output as JSON. Same bug existed in `tw conversation unread --json`.
- Gate the empty-state human messages behind the non-machine-output branch so `--json` emits `[]` and `--ndjson` emits nothing.
- Added regression tests covering both commands for `--json`, `--ndjson`, and the human/text fallback. Also covers the inbox `--channel <filter>` no-match path.

Audited every other `--json`-supporting command (workspace, users, groups list, channel list, channel threads, conversation view/with/helpers, thread view, search/mentions) — they already gate JSON/NDJSON before any human empty message.

## Test plan
- [x] `npm run type-check`
- [x] `npx vitest run src/commands/inbox.test.ts src/commands/conversation/conversation.test.ts`
- [ ] Manual: `tw inbox --json` against an empty inbox → `[]`
- [ ] Manual: `tw inbox --ndjson` against an empty inbox → empty
- [ ] Manual: `tw conversation unread --json` with no unread → `[]`
- [ ] Manual: `tw inbox --json | jq '. | length'` → `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)