### PR TITLE
feat(auth): support multiple authenticated Twist accounts

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -34,6 +34,20 @@ Stored auth uses the system credential manager when available. If secure storage
 
 In read-only mode (`tw auth login --read-only`), commands that modify Twist data (reply, archive, react, delete, etc.) are blocked by the CLI. Externally provided tokens (`TWIST_API_TOKEN` or `tw auth token`) are treated as unknown scope and assumed write-capable.
 
+## Multi-account
+
+The CLI can hold credentials for multiple Twist accounts at once.
+
+```bash
+tw auth login                       # adds the account; first one becomes default
+tw account list                     # all stored accounts (with default marker)
+tw account use <id|email>           # set the default account
+tw --user <id|email> inbox          # one-off override for any command
+tw auth logout --user <id|email>    # log out a specific account
+```
+
+Resolution order: `--user <ref>` > `account.defaultAccount` from config > the only stored account. With multiple accounts and no default, commands error and ask for `--user` (or `tw account use`). `<ref>` matches an exact id or email (case-insensitive on email). `TWIST_API_TOKEN` still bypasses the resolver entirely.
+
 ## View by URL
 
 ```bash

--- a/src/commands/account/account.test.ts
+++ b/src/commands/account/account.test.ts
@@ -5,7 +5,6 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth.js')>()
     return {
         ...actual,
-        listStoredAccounts: vi.fn(),
         setDefaultAccountId: vi.fn(),
     }
 })
@@ -20,11 +19,11 @@ vi.mock('../../lib/config.js', async (importOriginal) => {
 
 vi.mock('chalk')
 
-import { listStoredAccounts, setDefaultAccountId } from '../../lib/auth.js'
+import { AccountNotFoundError } from '../../lib/accounts.js'
+import { setDefaultAccountId } from '../../lib/auth.js'
 import { getConfig } from '../../lib/config.js'
 import { registerAccountCommand } from './index.js'
 
-const mockListStoredAccounts = vi.mocked(listStoredAccounts)
 const mockSetDefaultAccountId = vi.mocked(setDefaultAccountId)
 const mockGetConfig = vi.mocked(getConfig)
 
@@ -50,21 +49,20 @@ describe('account command', () => {
 
     describe('list', () => {
         it('prints a hint when no accounts are stored', async () => {
-            mockListStoredAccounts.mockResolvedValue([])
+            mockGetConfig.mockResolvedValue({ configVersion: 2, accounts: [] })
             await createProgram().parseAsync(['node', 'tw', 'account', 'list'])
 
             expect(consoleSpy.mock.calls.flat().join('\n')).toContain('No stored Twist accounts')
         })
 
         it('marks the default account', async () => {
-            mockListStoredAccounts.mockResolvedValue([
-                { id: '1', email: 'a@b.c', name: 'Alice' },
-                { id: '2', email: 'd@e.f', name: 'Dan' },
-            ])
             mockGetConfig.mockResolvedValue({
                 configVersion: 2,
                 account: { defaultAccount: '2' },
-                accounts: [],
+                accounts: [
+                    { id: '1', email: 'a@b.c', name: 'Alice' },
+                    { id: '2', email: 'd@e.f', name: 'Dan' },
+                ],
             })
 
             await createProgram().parseAsync(['node', 'tw', 'account', 'list'])
@@ -76,13 +74,10 @@ describe('account command', () => {
         })
 
         it('outputs JSON when --json given', async () => {
-            mockListStoredAccounts.mockResolvedValue([
-                { id: '1', email: 'a@b.c', authMode: 'read-write' },
-            ])
             mockGetConfig.mockResolvedValue({
                 configVersion: 2,
                 account: { defaultAccount: '1' },
-                accounts: [],
+                accounts: [{ id: '1', email: 'a@b.c', authMode: 'read-write' }],
             })
 
             await createProgram().parseAsync(['node', 'tw', 'account', 'list', '--json'])
@@ -100,22 +95,17 @@ describe('account command', () => {
     })
 
     describe('use', () => {
-        it('sets the default account by id', async () => {
-            mockGetConfig.mockResolvedValue({
-                configVersion: 2,
-                accounts: [{ id: '111', email: 'a@b.c' }],
-            })
+        it('sets the default account by ref and reuses the resolved account in the success message', async () => {
+            mockSetDefaultAccountId.mockResolvedValue({ id: '111', email: 'a@b.c' })
 
             await createProgram().parseAsync(['node', 'tw', 'account', 'use', '111'])
 
             expect(mockSetDefaultAccountId).toHaveBeenCalledWith('111')
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('a@b.c')
         })
 
         it('rejects an unknown ref', async () => {
-            mockGetConfig.mockResolvedValue({
-                configVersion: 2,
-                accounts: [{ id: '111', email: 'a@b.c' }],
-            })
+            mockSetDefaultAccountId.mockRejectedValue(new AccountNotFoundError('nope'))
 
             await expect(
                 createProgram().parseAsync(['node', 'tw', 'account', 'use', 'nope']),

--- a/src/commands/account/account.test.ts
+++ b/src/commands/account/account.test.ts
@@ -1,0 +1,125 @@
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/auth.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/auth.js')>()
+    return {
+        ...actual,
+        listStoredAccounts: vi.fn(),
+        setDefaultAccountId: vi.fn(),
+    }
+})
+
+vi.mock('../../lib/config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/config.js')>()
+    return {
+        ...actual,
+        getConfig: vi.fn(),
+    }
+})
+
+vi.mock('chalk')
+
+import { listStoredAccounts, setDefaultAccountId } from '../../lib/auth.js'
+import { getConfig } from '../../lib/config.js'
+import { registerAccountCommand } from './index.js'
+
+const mockListStoredAccounts = vi.mocked(listStoredAccounts)
+const mockSetDefaultAccountId = vi.mocked(setDefaultAccountId)
+const mockGetConfig = vi.mocked(getConfig)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerAccountCommand(program)
+    return program
+}
+
+describe('account command', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        mockGetConfig.mockResolvedValue({})
+    })
+
+    afterEach(() => {
+        consoleSpy.mockRestore()
+    })
+
+    describe('list', () => {
+        it('prints a hint when no accounts are stored', async () => {
+            mockListStoredAccounts.mockResolvedValue([])
+            await createProgram().parseAsync(['node', 'tw', 'account', 'list'])
+
+            expect(consoleSpy.mock.calls.flat().join('\n')).toContain('No stored Twist accounts')
+        })
+
+        it('marks the default account', async () => {
+            mockListStoredAccounts.mockResolvedValue([
+                { id: '1', email: 'a@b.c', name: 'Alice' },
+                { id: '2', email: 'd@e.f', name: 'Dan' },
+            ])
+            mockGetConfig.mockResolvedValue({
+                configVersion: 2,
+                account: { defaultAccount: '2' },
+                accounts: [],
+            })
+
+            await createProgram().parseAsync(['node', 'tw', 'account', 'list'])
+
+            const lines = consoleSpy.mock.calls.flat().join('\n')
+            expect(lines).toContain('a@b.c')
+            expect(lines).toContain('d@e.f')
+            expect(lines).toContain('default')
+        })
+
+        it('outputs JSON when --json given', async () => {
+            mockListStoredAccounts.mockResolvedValue([
+                { id: '1', email: 'a@b.c', authMode: 'read-write' },
+            ])
+            mockGetConfig.mockResolvedValue({
+                configVersion: 2,
+                account: { defaultAccount: '1' },
+                accounts: [],
+            })
+
+            await createProgram().parseAsync(['node', 'tw', 'account', 'list', '--json'])
+
+            const printed = consoleSpy.mock.calls[0][0] as string
+            const payload = JSON.parse(printed)
+            expect(payload[0]).toMatchObject({
+                id: '1',
+                email: 'a@b.c',
+                isDefault: true,
+                authMode: 'read-write',
+                storage: 'secure-store',
+            })
+        })
+    })
+
+    describe('use', () => {
+        it('sets the default account by id', async () => {
+            mockGetConfig.mockResolvedValue({
+                configVersion: 2,
+                accounts: [{ id: '111', email: 'a@b.c' }],
+            })
+
+            await createProgram().parseAsync(['node', 'tw', 'account', 'use', '111'])
+
+            expect(mockSetDefaultAccountId).toHaveBeenCalledWith('111')
+        })
+
+        it('rejects an unknown ref', async () => {
+            mockGetConfig.mockResolvedValue({
+                configVersion: 2,
+                accounts: [{ id: '111', email: 'a@b.c' }],
+            })
+
+            await expect(
+                createProgram().parseAsync(['node', 'tw', 'account', 'use', 'nope']),
+            ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
+        })
+    })
+})

--- a/src/commands/account/index.ts
+++ b/src/commands/account/index.ts
@@ -1,0 +1,30 @@
+import { Command } from 'commander'
+import { listAccountsCommand } from './list.js'
+import { useAccountCommand } from './use.js'
+
+export function registerAccountCommand(program: Command): void {
+    const account = program
+        .command('account')
+        .description('Manage stored Twist accounts (multi-user)')
+
+    account
+        .command('list')
+        .description('List all stored Twist accounts')
+        .option('--json', 'Output as JSON')
+        .action(listAccountsCommand)
+
+    account
+        .command('use <ref>')
+        .description('Set the default account used when --user is not provided')
+        .action((ref: string) => useAccountCommand(ref))
+
+    account.addHelpText(
+        'after',
+        `
+Examples:
+  $ tw auth login                  # add an account (sets it as default if first)
+  $ tw account list                # see all stored accounts
+  $ tw account use me@example.com  # set default
+  $ tw --user other@example.com inbox   # one-off override`,
+    )
+}

--- a/src/commands/account/list.ts
+++ b/src/commands/account/list.ts
@@ -1,0 +1,46 @@
+import chalk from 'chalk'
+import { getDefaultAccountId } from '../../lib/accounts.js'
+import { listStoredAccounts } from '../../lib/auth.js'
+import { getConfig } from '../../lib/config.js'
+import { isAccessible } from '../../lib/global-args.js'
+import { formatJson } from '../../lib/output.js'
+
+export interface ListAccountsOptions {
+    json?: boolean
+}
+
+export async function listAccountsCommand(options: ListAccountsOptions): Promise<void> {
+    const accounts = await listStoredAccounts()
+    const config = await getConfig()
+    const defaultId = getDefaultAccountId(config)
+
+    if (options.json) {
+        console.log(
+            formatJson(
+                accounts.map((a) => ({
+                    id: a.id,
+                    email: a.email,
+                    name: a.name,
+                    isDefault: a.id === defaultId,
+                    authMode: a.authMode,
+                    authScope: a.authScope,
+                    storage: a.token ? 'config-file' : 'secure-store',
+                })),
+            ),
+        )
+        return
+    }
+
+    if (accounts.length === 0) {
+        console.log(chalk.dim('No stored Twist accounts. Run `tw auth login` to add one.'))
+        return
+    }
+
+    const accessible = isAccessible()
+    for (const a of accounts) {
+        const isDefault = a.id === defaultId
+        const marker = isDefault ? (accessible ? ' [default]' : chalk.green(' (default)')) : ''
+        const label = a.name ? `${a.name} <${a.email}>` : a.email
+        console.log(`${label} ${chalk.dim(`(id:${a.id})`)}${marker}`)
+    }
+}

--- a/src/commands/account/list.ts
+++ b/src/commands/account/list.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk'
-import { getDefaultAccountId } from '../../lib/accounts.js'
-import { listStoredAccounts } from '../../lib/auth.js'
+import { getDefaultAccountId, getStoredAccounts } from '../../lib/accounts.js'
 import { getConfig } from '../../lib/config.js'
 import { isAccessible } from '../../lib/global-args.js'
 import { formatJson } from '../../lib/output.js'
@@ -10,8 +9,9 @@ export interface ListAccountsOptions {
 }
 
 export async function listAccountsCommand(options: ListAccountsOptions): Promise<void> {
-    const accounts = await listStoredAccounts()
+    // One config read drives both the account list and the default lookup.
     const config = await getConfig()
+    const accounts = getStoredAccounts(config)
     const defaultId = getDefaultAccountId(config)
 
     if (options.json) {

--- a/src/commands/account/use.ts
+++ b/src/commands/account/use.ts
@@ -1,0 +1,20 @@
+import chalk from 'chalk'
+import { requireAccountByRef } from '../../lib/accounts.js'
+import { setDefaultAccountId } from '../../lib/auth.js'
+import { getConfig } from '../../lib/config.js'
+import { CliError } from '../../lib/errors.js'
+
+export async function useAccountCommand(ref: string | undefined): Promise<void> {
+    if (!ref) {
+        throw new CliError(
+            'MISSING_REF',
+            'Please provide an account id or email: `tw account use <id|email>`',
+        )
+    }
+
+    const config = await getConfig()
+    const { account } = requireAccountByRef(config, ref)
+    await setDefaultAccountId(account.id)
+
+    console.log(chalk.green('✓'), `Default account set to ${account.email} (id:${account.id})`)
+}

--- a/src/commands/account/use.ts
+++ b/src/commands/account/use.ts
@@ -1,7 +1,5 @@
 import chalk from 'chalk'
-import { requireAccountByRef } from '../../lib/accounts.js'
 import { setDefaultAccountId } from '../../lib/auth.js'
-import { getConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 
 export async function useAccountCommand(ref: string | undefined): Promise<void> {
@@ -12,9 +10,6 @@ export async function useAccountCommand(ref: string | undefined): Promise<void> 
         )
     }
 
-    const config = await getConfig()
-    const { account } = requireAccountByRef(config, ref)
-    await setDefaultAccountId(account.id)
-
+    const account = await setDefaultAccountId(ref)
     console.log(chalk.green('✓'), `Default account set to ${account.email} (id:${account.id})`)
 }

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -1,20 +1,31 @@
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock the auth module
+// Mock auth module
 vi.mock('../../lib/auth.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth.js')>()
     return {
         ...actual,
-        saveApiToken: vi.fn(),
+        upsertAccount: vi.fn(),
         clearApiToken: vi.fn(),
         getAuthMetadata: vi.fn(),
+        listStoredAccounts: vi.fn(),
     }
 })
 
-// Mock the api module
+// Mock config (status reads it for default-account marker)
+vi.mock('../../lib/config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/config.js')>()
+    return {
+        ...actual,
+        getConfig: vi.fn(),
+    }
+})
+
+// Mock api module — getSessionUser used by status, createWrappedTwistClient used by login/token
 vi.mock('../../lib/api.js', () => ({
     getSessionUser: vi.fn(),
+    createWrappedTwistClient: vi.fn(),
 }))
 
 // Mock OAuth modules
@@ -38,12 +49,10 @@ vi.mock('../../lib/pkce.js', () => ({
     generateState: vi.fn(),
 }))
 
-// Mock open package
 vi.mock('open', () => ({
     default: vi.fn(),
 }))
 
-// Mock readline for interactive token input
 vi.mock('node:readline', () => ({
     createInterface: vi.fn(() => {
         const rl = {
@@ -54,14 +63,19 @@ vi.mock('node:readline', () => ({
     }),
 }))
 
-// Mock chalk to avoid colors in tests
 vi.mock('chalk')
 
 import { createInterface, type Interface } from 'node:readline'
 import { type User } from '@doist/twist-sdk'
 import open from 'open'
-import { getSessionUser } from '../../lib/api.js'
-import { clearApiToken, getAuthMetadata, saveApiToken } from '../../lib/auth.js'
+import { createWrappedTwistClient, getSessionUser } from '../../lib/api.js'
+import {
+    clearApiToken,
+    getAuthMetadata,
+    listStoredAccounts,
+    upsertAccount,
+} from '../../lib/auth.js'
+import { getConfig } from '../../lib/config.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
 import {
     buildAuthorizationUrl,
@@ -72,13 +86,14 @@ import { generateCodeChallenge, generateCodeVerifier, generateState } from '../.
 import { registerAuthCommand } from './index.js'
 
 const mockCreateInterface = vi.mocked(createInterface)
-
-const mockSaveApiToken = vi.mocked(saveApiToken)
+const mockUpsertAccount = vi.mocked(upsertAccount)
 const mockClearApiToken = vi.mocked(clearApiToken)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
+const mockListStoredAccounts = vi.mocked(listStoredAccounts)
+const mockGetConfig = vi.mocked(getConfig)
 const mockGetSessionUser = vi.mocked(getSessionUser)
+const mockCreateWrappedTwistClient = vi.mocked(createWrappedTwistClient)
 
-// OAuth mocks
 const mockGenerateCodeVerifier = vi.mocked(generateCodeVerifier)
 const mockGenerateCodeChallenge = vi.mocked(generateCodeChallenge)
 const mockGenerateState = vi.mocked(generateState)
@@ -87,6 +102,24 @@ const mockStartCallbackServer = vi.mocked(startCallbackServer)
 const mockExchangeCodeForToken = vi.mocked(exchangeCodeForToken)
 const mockRegisterDynamicClient = vi.mocked(registerDynamicClient)
 const mockOpen = vi.mocked(open)
+
+const TEST_USER: User = {
+    id: 12345,
+    name: 'Scott',
+    shortName: 'scott',
+    bot: false,
+    timezone: 'UTC',
+    removed: false,
+    email: 'scott@example.com',
+    lang: 'en',
+}
+
+function stubProbeApiForUser(user: User = TEST_USER) {
+    mockCreateWrappedTwistClient.mockReturnValue({
+        users: { getSessionUser: vi.fn().mockResolvedValue(user) },
+        // biome-ignore lint/suspicious/noExplicitAny: minimal mock surface
+    } as any)
+}
 
 function createProgram() {
     const program = new Command()
@@ -101,10 +134,10 @@ describe('auth command', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
-
-        // Mock console.log to capture output
         consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
         errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        mockListStoredAccounts.mockResolvedValue([])
+        mockGetConfig.mockResolvedValue({})
     })
 
     afterEach(() => {
@@ -113,76 +146,66 @@ describe('auth command', () => {
     })
 
     describe('token subcommand', () => {
-        it('successfully saves a token', async () => {
+        it('saves a token after looking up the user', async () => {
             const program = createProgram()
-            const token = 'some_token_123456789'
+            stubProbeApiForUser()
+            mockUpsertAccount.mockResolvedValue({ storage: 'secure-store', replaced: false })
 
-            // Mock successful token save
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            await program.parseAsync(['node', 'tw', 'auth', 'token', 'some_token_123456789'])
 
-            await program.parseAsync(['node', 'tw', 'auth', 'token', token])
+            expect(mockCreateWrappedTwistClient).toHaveBeenCalledWith('some_token_123456789')
+            expect(mockUpsertAccount).toHaveBeenCalledWith({
+                id: '12345',
+                email: 'scott@example.com',
+                name: 'Scott',
+                token: 'some_token_123456789',
+                authMode: 'unknown',
+            })
+            expect(consoleSpy).toHaveBeenCalledWith('✓', 'Saved token for scott@example.com')
+        })
 
-            // Verify token was saved with unknown auth mode
-            expect(mockSaveApiToken).toHaveBeenCalledWith(token, { authMode: 'unknown' })
+        it('trims whitespace from token before identifying user', async () => {
+            const program = createProgram()
+            stubProbeApiForUser()
+            mockUpsertAccount.mockResolvedValue({ storage: 'secure-store', replaced: false })
 
-            // Verify success message
-            expect(consoleSpy).toHaveBeenCalledWith('✓', 'API token saved successfully!')
+            await program.parseAsync(['node', 'tw', 'auth', 'token', '  some_token_123456789  '])
+
+            expect(mockCreateWrappedTwistClient).toHaveBeenCalledWith('some_token_123456789')
+        })
+
+        it('shows "Updated stored token for" when account already existed', async () => {
+            const program = createProgram()
+            stubProbeApiForUser()
+            mockUpsertAccount.mockResolvedValue({ storage: 'secure-store', replaced: true })
+
+            await program.parseAsync(['node', 'tw', 'auth', 'token', 'some_token_123456789'])
+
             expect(consoleSpy).toHaveBeenCalledWith(
-                'Token stored securely in the system credential manager',
+                '✓',
+                'Updated stored token for scott@example.com',
             )
-        })
-
-        it('handles saveApiToken errors', async () => {
-            const program = createProgram()
-            const token = 'some_token_123456789'
-
-            // Mock save failure
-            mockSaveApiToken.mockRejectedValue(new Error('Permission denied'))
-
-            await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token', token]),
-            ).rejects.toThrow('Permission denied')
-
-            expect(mockSaveApiToken).toHaveBeenCalledWith(token, { authMode: 'unknown' })
-        })
-
-        it('trims whitespace from token', async () => {
-            const program = createProgram()
-            const tokenWithWhitespace = '  some_token_123456789  '
-            const expectedToken = 'some_token_123456789'
-
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'token', tokenWithWhitespace])
-
-            expect(mockSaveApiToken).toHaveBeenCalledWith(expectedToken, { authMode: 'unknown' })
         })
 
         it('prompts interactively when no token argument given', async () => {
             const originalIsTTY = process.stdin.isTTY
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: true,
-                configurable: true,
-            })
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             const program = createProgram()
             const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('interactive_token_456')
-                }),
+                question: vi.fn((_p: string, cb: (a: string) => void) => cb('interactive_456789')),
                 close: vi.fn(),
                 _writeToOutput: vi.fn(),
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            stubProbeApiForUser()
+            mockUpsertAccount.mockResolvedValue({ storage: 'secure-store', replaced: false })
             const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await program.parseAsync(['node', 'tw', 'auth', 'token'])
 
-            expect(mockRl.question).toHaveBeenCalled()
-            expect(mockRl.close).toHaveBeenCalled()
-            expect(mockSaveApiToken).toHaveBeenCalledWith('interactive_token_456', {
-                authMode: 'unknown',
-            })
+            expect(mockUpsertAccount).toHaveBeenCalledWith(
+                expect.objectContaining({ token: 'interactive_456789' }),
+            )
             writeSpy.mockRestore()
             Object.defineProperty(process.stdin, 'isTTY', {
                 value: originalIsTTY,
@@ -190,75 +213,7 @@ describe('auth command', () => {
             })
         })
 
-        it('warns when secure storage falls back to the config file', async () => {
-            const program = createProgram()
-            const token = 'some_token_123456789'
-
-            mockSaveApiToken.mockResolvedValue({
-                storage: 'config-file',
-                warning:
-                    'system credential manager unavailable; token saved as plaintext in /home/user/.config/twist-cli/config.json',
-            })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'token', token])
-
-            expect(errorSpy).toHaveBeenCalledWith(
-                'Warning:',
-                'system credential manager unavailable; token saved as plaintext in /home/user/.config/twist-cli/config.json',
-            )
-        })
-
-        it('warns when secure storage succeeds but plaintext cleanup fails', async () => {
-            const program = createProgram()
-            const token = 'some_token_123456789'
-
-            mockSaveApiToken.mockResolvedValue({
-                storage: 'secure-store',
-                warning:
-                    'Token was stored securely, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-            })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'token', token])
-
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'Token stored securely in the system credential manager',
-            )
-            expect(errorSpy).toHaveBeenCalledWith(
-                'Warning:',
-                'Token was stored securely, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-            )
-        })
-
-        it('shows error when interactive input is empty', async () => {
-            const originalIsTTY = process.stdin.isTTY
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: true,
-                configurable: true,
-            })
-            const program = createProgram()
-            const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('')
-                }),
-                close: vi.fn(),
-                _writeToOutput: vi.fn(),
-            }
-            mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
-            const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-
-            await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token']),
-            ).rejects.toHaveProperty('code', 'NO_TOKEN')
-
-            expect(mockSaveApiToken).not.toHaveBeenCalled()
-            writeSpy.mockRestore()
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: originalIsTTY,
-                configurable: true,
-            })
-        })
-
-        it('errors in non-interactive mode when no token argument given', async () => {
+        it('errors in non-interactive mode with no token argument', async () => {
             const originalIsTTY = process.stdin.isTTY
             Object.defineProperty(process.stdin, 'isTTY', {
                 value: undefined,
@@ -270,295 +225,190 @@ describe('auth command', () => {
                 program.parseAsync(['node', 'tw', 'auth', 'token']),
             ).rejects.toHaveProperty('code', 'NO_TOKEN')
 
-            expect(mockSaveApiToken).not.toHaveBeenCalled()
+            expect(mockUpsertAccount).not.toHaveBeenCalled()
             Object.defineProperty(process.stdin, 'isTTY', {
                 value: originalIsTTY,
                 configurable: true,
             })
+        })
+
+        it('surfaces config-file fallback warning', async () => {
+            const program = createProgram()
+            stubProbeApiForUser()
+            mockUpsertAccount.mockResolvedValue({
+                storage: 'config-file',
+                replaced: false,
+                warning: 'system credential manager unavailable; token saved as plaintext in /x',
+            })
+
+            await program.parseAsync(['node', 'tw', 'auth', 'token', 'some_token_123456789'])
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                'Warning:',
+                'system credential manager unavailable; token saved as plaintext in /x',
+            )
+        })
+    })
+
+    describe('login subcommand', () => {
+        function setupOAuthMocks(authCode = 'auth_code_123', accessToken = 'access_token_123') {
+            mockRegisterDynamicClient.mockResolvedValue({
+                client_id: 'twd_dyn',
+                client_secret: 'sec',
+            })
+            mockGenerateCodeVerifier.mockReturnValue('verifier')
+            mockGenerateCodeChallenge.mockReturnValue('challenge')
+            mockGenerateState.mockReturnValue('state')
+            mockBuildAuthorizationUrl.mockReturnValue('https://twist.com/oauth/authorize?…')
+            const cleanup = vi.fn()
+            mockStartCallbackServer.mockResolvedValue({ code: authCode, cleanup })
+            mockExchangeCodeForToken.mockResolvedValue(accessToken)
+            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
+            stubProbeApiForUser()
+            mockUpsertAccount.mockResolvedValue({ storage: 'secure-store', replaced: false })
+            return cleanup
+        }
+
+        it('completes OAuth flow and upserts the account', async () => {
+            const program = createProgram()
+            const cleanup = setupOAuthMocks()
+
+            await program.parseAsync(['node', 'tw', 'auth', 'login'])
+
+            expect(mockExchangeCodeForToken).toHaveBeenCalled()
+            expect(mockCreateWrappedTwistClient).toHaveBeenCalledWith('access_token_123')
+            expect(mockUpsertAccount).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    id: '12345',
+                    email: 'scott@example.com',
+                    token: 'access_token_123',
+                    authMode: 'read-write',
+                }),
+            )
+            expect(consoleSpy).toHaveBeenCalledWith('✓', 'Logged in as scott@example.com')
+            expect(cleanup).toHaveBeenCalled()
+        })
+
+        it('uses read-only mode when --read-only is set', async () => {
+            const program = createProgram()
+            setupOAuthMocks()
+
+            await program.parseAsync(['node', 'tw', 'auth', 'login', '--read-only'])
+
+            expect(mockUpsertAccount).toHaveBeenCalledWith(
+                expect.objectContaining({ authMode: 'read-only' }),
+            )
+        })
+
+        it('shows "Updated credentials for" when re-logging in', async () => {
+            const program = createProgram()
+            setupOAuthMocks()
+            mockUpsertAccount.mockResolvedValue({ storage: 'secure-store', replaced: true })
+
+            await program.parseAsync(['node', 'tw', 'auth', 'login'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                '✓',
+                'Updated credentials for scott@example.com',
+            )
+        })
+
+        it('cleanup runs on callback server error', async () => {
+            const program = createProgram()
+            mockRegisterDynamicClient.mockResolvedValue({
+                client_id: 'twd_dyn',
+                client_secret: 'sec',
+            })
+            mockGenerateCodeVerifier.mockReturnValue('verifier')
+            mockGenerateCodeChallenge.mockReturnValue('challenge')
+            mockGenerateState.mockReturnValue('state')
+            mockStartCallbackServer.mockRejectedValue(new Error('port in use'))
+
+            await expect(
+                program.parseAsync(['node', 'tw', 'auth', 'login']),
+            ).rejects.toHaveProperty('code', 'AUTH_FAILED')
+            expect(mockUpsertAccount).not.toHaveBeenCalled()
         })
     })
 
     describe('status subcommand', () => {
         it('shows authenticated status when logged in', async () => {
             const program = createProgram()
-
-            const mockUser: User = {
-                id: 1,
-                name: 'Test User',
-                shortName: 'test',
-                bot: false,
-                timezone: 'UTC',
-                removed: false,
-                email: 'test@example.com',
-                lang: 'en',
-            }
-
-            mockGetSessionUser.mockResolvedValue(mockUser)
+            mockGetSessionUser.mockResolvedValue(TEST_USER)
             mockGetAuthMetadata.mockResolvedValue({
                 authMode: 'read-write',
-                source: 'config',
+                source: 'secure-store',
             })
 
             await program.parseAsync(['node', 'tw', 'auth', 'status'])
 
-            expect(mockGetSessionUser).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Authenticated')
-            expect(consoleSpy).toHaveBeenCalledWith('  Email: test@example.com')
-            expect(consoleSpy).toHaveBeenCalledWith('  Name:  Test User')
+            expect(consoleSpy).toHaveBeenCalledWith('  Email: scott@example.com')
             expect(consoleSpy).toHaveBeenCalledWith('  Mode:  read-write')
+        })
+
+        it('marks the active account as default when matching', async () => {
+            const program = createProgram()
+            mockGetSessionUser.mockResolvedValue(TEST_USER)
+            mockGetAuthMetadata.mockResolvedValue({
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockGetConfig.mockResolvedValue({ account: { defaultAccount: '12345' } })
+
+            await program.parseAsync(['node', 'tw', 'auth', 'status'])
+
+            expect(consoleSpy).toHaveBeenCalledWith('✓', 'Authenticated (default)')
+        })
+
+        it('lists other stored accounts', async () => {
+            const program = createProgram()
+            mockGetSessionUser.mockResolvedValue(TEST_USER)
+            mockGetAuthMetadata.mockResolvedValue({
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockListStoredAccounts.mockResolvedValue([
+                { id: '12345', email: 'scott@example.com' },
+                { id: '67890', email: 'other@example.com' },
+            ])
+
+            await program.parseAsync(['node', 'tw', 'auth', 'status'])
+
+            const lines = consoleSpy.mock.calls.flat().join('\n')
+            expect(lines).toContain('Other stored accounts (1)')
+            expect(lines).toContain('other@example.com')
         })
 
         it('outputs JSON when --json flag is used', async () => {
             const program = createProgram()
-
-            const mockUser: User = {
-                id: 1,
-                name: 'Test User',
-                shortName: 'test',
-                bot: false,
-                timezone: 'UTC',
-                removed: false,
-                email: 'test@example.com',
-                lang: 'en',
-            }
-
-            mockGetSessionUser.mockResolvedValue(mockUser)
+            mockGetSessionUser.mockResolvedValue(TEST_USER)
+            mockGetAuthMetadata.mockResolvedValue({
+                authMode: 'read-write',
+                source: 'secure-store',
+            })
+            mockListStoredAccounts.mockResolvedValue([{ id: '12345', email: 'scott@example.com' }])
+            mockGetConfig.mockResolvedValue({ account: { defaultAccount: '12345' } })
 
             await program.parseAsync(['node', 'tw', 'auth', 'status', '--json'])
 
-            expect(consoleSpy).toHaveBeenCalledWith(
-                JSON.stringify({ id: 1, email: 'test@example.com', name: 'Test User' }, null, 2),
-            )
+            const printed = consoleSpy.mock.calls[0][0] as string
+            const parsed = JSON.parse(printed)
+            expect(parsed).toMatchObject({
+                id: 12345,
+                email: 'scott@example.com',
+                authMode: 'read-write',
+                isDefault: true,
+            })
         })
 
-        it('outputs JSON error when --json flag is used and not authenticated', async () => {
-            const program = createProgram()
-            mockGetSessionUser.mockRejectedValue(new Error('No API token found'))
-
-            await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'status', '--json']),
-            ).rejects.toThrow('No API token found')
-        })
-
-        it('shows not authenticated when no token', async () => {
+        it('rejects when no token', async () => {
             const program = createProgram()
             mockGetSessionUser.mockRejectedValue(new Error('No API token found'))
 
             await expect(program.parseAsync(['node', 'tw', 'auth', 'status'])).rejects.toThrow(
                 'No API token found',
             )
-        })
-    })
-
-    describe('login subcommand', () => {
-        it('successfully completes OAuth flow with dynamic client registration', async () => {
-            const program = createProgram()
-
-            // Mock dynamic client registration
-            mockRegisterDynamicClient.mockResolvedValue({
-                client_id: 'twd_dynamic_client_id',
-                client_secret: 'dynamic_client_secret',
-            })
-
-            // Mock PKCE parameters
-            mockGenerateCodeVerifier.mockReturnValue('test_code_verifier')
-            mockGenerateCodeChallenge.mockReturnValue('test_code_challenge')
-            mockGenerateState.mockReturnValue('test_state')
-
-            // Mock authorization URL
-            mockBuildAuthorizationUrl.mockReturnValue('https://twist.com/oauth/authorize?...')
-
-            // Mock callback server that resolves immediately
-            const mockCleanup = vi.fn()
-            mockStartCallbackServer.mockImplementation(async (expectedState) => {
-                // Simulate the browser opening behavior by calling our mocks
-                mockBuildAuthorizationUrl(
-                    'twd_dynamic_client_id',
-                    'test_code_challenge',
-                    expectedState,
-                )
-                await mockOpen('https://twist.com/oauth/authorize?...')
-
-                return Promise.resolve({
-                    code: 'auth_code_123',
-                    cleanup: mockCleanup,
-                })
-            })
-
-            // Mock token exchange
-            mockExchangeCodeForToken.mockResolvedValue('access_token_123')
-
-            // Mock browser opening
-            mockOpen.mockResolvedValue({} as Awaited<ReturnType<typeof open>>)
-
-            // Mock token saving
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'login'])
-
-            // Verify dynamic client registration
-            expect(mockRegisterDynamicClient).toHaveBeenCalled()
-
-            // Verify PKCE parameters were generated
-            expect(mockGenerateCodeVerifier).toHaveBeenCalled()
-            expect(mockGenerateCodeChallenge).toHaveBeenCalledWith('test_code_verifier')
-            expect(mockGenerateState).toHaveBeenCalled()
-
-            // Verify authorization URL was built with dynamic client ID
-            // Note: the actual buildAuthorizationUrl call happens inside a setTimeout,
-            // so we verify the mock's simulation call from startCallbackServer instead
-            expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
-                'twd_dynamic_client_id',
-                'test_code_challenge',
-                'test_state',
-            )
-
-            // Verify callback server was started
-            expect(mockStartCallbackServer).toHaveBeenCalledWith('test_state')
-
-            // Verify browser was opened
-            expect(mockOpen).toHaveBeenCalledWith('https://twist.com/oauth/authorize?...')
-
-            // Verify token exchange with client credentials
-            expect(mockExchangeCodeForToken).toHaveBeenCalledWith(
-                'auth_code_123',
-                'test_code_verifier',
-                {
-                    client_id: 'twd_dynamic_client_id',
-                    client_secret: 'dynamic_client_secret',
-                },
-            )
-
-            // Verify token was saved with read-write auth metadata
-            expect(mockSaveApiToken).toHaveBeenCalledWith('access_token_123', {
-                authMode: 'read-write',
-                authScope: expect.any(String),
-            })
-
-            // Verify cleanup was called
-            expect(mockCleanup).toHaveBeenCalled()
-
-            // Verify success messages
-            expect(consoleSpy).toHaveBeenCalledWith('Starting OAuth authentication (read-write)...')
-            expect(consoleSpy).toHaveBeenCalledWith('✓', 'OAuth authentication successful!')
-        })
-
-        it('handles callback server errors', async () => {
-            const program = createProgram()
-
-            // Mock dynamic client registration
-            mockRegisterDynamicClient.mockResolvedValue({
-                client_id: 'twd_dynamic_client_id',
-                client_secret: 'dynamic_client_secret',
-            })
-
-            // Mock PKCE parameters
-            mockGenerateCodeVerifier.mockReturnValue('test_code_verifier')
-            mockGenerateCodeChallenge.mockReturnValue('test_code_challenge')
-            mockGenerateState.mockReturnValue('test_state')
-
-            // Mock callback server error
-            mockStartCallbackServer.mockRejectedValue(new Error('Port 8766 is already in use'))
-
-            const result = program.parseAsync(['node', 'tw', 'auth', 'login'])
-            await expect(result).rejects.toHaveProperty('code', 'AUTH_FAILED')
-            await expect(result).rejects.toHaveProperty('hints')
-        })
-
-        it('handles token exchange errors', async () => {
-            const program = createProgram()
-
-            // Mock dynamic client registration
-            mockRegisterDynamicClient.mockResolvedValue({
-                client_id: 'twd_dynamic_client_id',
-                client_secret: 'dynamic_client_secret',
-            })
-
-            // Mock PKCE parameters
-            mockGenerateCodeVerifier.mockReturnValue('test_code_verifier')
-            mockGenerateCodeChallenge.mockReturnValue('test_code_challenge')
-            mockGenerateState.mockReturnValue('test_state')
-
-            // Mock successful callback
-            const mockCleanup = vi.fn()
-            mockStartCallbackServer.mockResolvedValue({
-                code: 'auth_code_123',
-                cleanup: mockCleanup,
-            })
-
-            // Mock token exchange error
-            mockExchangeCodeForToken.mockRejectedValue(new Error('Invalid authorization code'))
-
-            const result = program.parseAsync(['node', 'tw', 'auth', 'login'])
-            await expect(result).rejects.toHaveProperty('code', 'AUTH_FAILED')
-            await expect(result).rejects.toHaveProperty('hints')
-            expect(mockCleanup).toHaveBeenCalled()
-        })
-
-        it('handles browser opening errors gracefully', async () => {
-            const program = createProgram()
-
-            // Mock dynamic client registration
-            mockRegisterDynamicClient.mockResolvedValue({
-                client_id: 'twd_dynamic_client_id',
-                client_secret: 'dynamic_client_secret',
-            })
-
-            // Mock PKCE parameters
-            mockGenerateCodeVerifier.mockReturnValue('test_code_verifier')
-            mockGenerateCodeChallenge.mockReturnValue('test_code_challenge')
-            mockGenerateState.mockReturnValue('test_state')
-
-            // Mock callback server
-            const mockCleanup = vi.fn()
-            mockStartCallbackServer.mockResolvedValue({
-                code: 'auth_code_123',
-                cleanup: mockCleanup,
-            })
-
-            // Mock browser opening error
-            mockOpen.mockRejectedValue(new Error('No browser available'))
-
-            // Mock successful token exchange (flow should still continue)
-            mockExchangeCodeForToken.mockResolvedValue('access_token_123')
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'login'])
-
-            // Should still complete successfully despite browser error
-            expect(consoleSpy).toHaveBeenCalledWith('✓', 'OAuth authentication successful!')
-        })
-
-        it('calls cleanup when OAuth server throws', async () => {
-            const program = createProgram()
-
-            // Mock dynamic client registration
-            mockRegisterDynamicClient.mockResolvedValue({
-                client_id: 'twd_dynamic_client_id',
-                client_secret: 'dynamic_client_secret',
-            })
-
-            // Mock PKCE parameters
-            mockGenerateCodeVerifier.mockReturnValue('test_code_verifier')
-            mockGenerateCodeChallenge.mockReturnValue('test_code_challenge')
-            mockGenerateState.mockReturnValue('test_state')
-
-            // Mock server that throws an error
-            mockStartCallbackServer.mockRejectedValue(new Error('Server failed to start'))
-
-            const result = program.parseAsync(['node', 'tw', 'auth', 'login'])
-            await expect(result).rejects.toHaveProperty('code', 'AUTH_FAILED')
-            await expect(result).rejects.toHaveProperty('hints')
-        })
-    })
-
-    describe('login subcommand with unconfigured client ID', () => {
-        // Note: Testing the unconfigured client ID scenario is complex with the current mock setup
-        // In practice, users would need to configure their client ID before OAuth works
-        it('would show error when client ID is not configured', () => {
-            // This test documents the expected behavior when TWIST_CLIENT_ID === 'YOUR_CLIENT_ID'
-            // The actual implementation checks this condition and shows an error message
-            expect(true).toBe(true) // Placeholder for documentation purposes
         })
     })
 
@@ -571,9 +421,6 @@ describe('auth command', () => {
 
             expect(mockClearApiToken).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'Logged out')
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'Stored token removed from the system credential manager',
-            )
         })
     })
 })

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -329,6 +329,22 @@ describe('auth command', () => {
             ).rejects.toHaveProperty('code', 'AUTH_FAILED')
             expect(mockUpsertAccount).not.toHaveBeenCalled()
         })
+
+        it('cleanup still runs when a post-callback step fails (regression: server must close on upsert error)', async () => {
+            const program = createProgram()
+            const cleanup = setupOAuthMocks()
+            mockUpsertAccount.mockRejectedValueOnce(new Error('config write failed'))
+
+            await expect(
+                program.parseAsync(['node', 'tw', 'auth', 'login']),
+            ).rejects.toHaveProperty('code', 'AUTH_FAILED')
+
+            // The callback server resolved successfully, so the returned
+            // cleanup MUST still run via the `finally` block — otherwise the
+            // OAuth listener is left dangling and the next login fails with
+            // EADDRINUSE.
+            expect(cleanup).toHaveBeenCalled()
+        })
     })
 
     describe('status subcommand', () => {
@@ -368,10 +384,13 @@ describe('auth command', () => {
                 authMode: 'read-write',
                 source: 'secure-store',
             })
-            mockListStoredAccounts.mockResolvedValue([
-                { id: '12345', email: 'scott@example.com' },
-                { id: '67890', email: 'other@example.com' },
-            ])
+            mockGetConfig.mockResolvedValue({
+                configVersion: 2,
+                accounts: [
+                    { id: '12345', email: 'scott@example.com' },
+                    { id: '67890', email: 'other@example.com' },
+                ],
+            })
 
             await program.parseAsync(['node', 'tw', 'auth', 'status'])
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
-import { saveApiToken } from '../../lib/auth.js'
+import { createWrappedTwistClient } from '../../lib/api.js'
+import { upsertAccount } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
 import { startCallbackServer } from '../../lib/oauth-server.js'
 import {
@@ -54,11 +55,22 @@ export async function loginWithOAuth(options: { readOnly?: boolean }): Promise<v
             console.log(chalk.dim('Exchanging authorization code for token...'))
             const accessToken = await exchangeCodeForToken(result.code, codeVerifier, client)
 
-            const saveResult = await saveApiToken(accessToken, {
+            // Identify the Twist user behind the new token before persisting.
+            const probeApi = createWrappedTwistClient(accessToken)
+            const sessionUser = await probeApi.users.getSessionUser()
+            const userId = String(sessionUser.id)
+
+            const saveResult = await upsertAccount({
+                id: userId,
+                email: sessionUser.email,
+                name: sessionUser.name,
+                token: accessToken,
                 authMode: options.readOnly ? 'read-only' : 'read-write',
                 authScope: options.readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES,
             })
-            console.log(chalk.green('✓'), 'OAuth authentication successful!')
+
+            const verb = saveResult.replaced ? 'Updated credentials for' : 'Logged in as'
+            console.log(chalk.green('✓'), `${verb} ${sessionUser.email}`)
             logTokenStorageResult(
                 saveResult,
                 'Token stored securely in the system credential manager',

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk'
 import { clearApiToken } from '../../lib/auth.js'
+import { getRequestedUserRef } from '../../lib/global-args.js'
 import { logTokenStorageResult } from './helpers.js'
 
 export async function logout(): Promise<void> {
-    const clearResult = await clearApiToken()
+    const clearResult = await clearApiToken({ ref: getRequestedUserRef() })
     console.log(chalk.green('✓'), 'Logged out')
     logTokenStorageResult(clearResult, 'Stored token removed from the system credential manager')
 }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,8 +1,8 @@
 import { TwistRequestError } from '@doist/twist-sdk'
 import chalk from 'chalk'
-import { getDefaultAccountId } from '../../lib/accounts.js'
+import { getDefaultAccountId, getStoredAccounts } from '../../lib/accounts.js'
 import { getSessionUser } from '../../lib/api.js'
-import { getAuthMetadata, listStoredAccounts, NoTokenError } from '../../lib/auth.js'
+import { getAuthMetadata, NoTokenError } from '../../lib/auth.js'
 import { getConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { formatJson } from '../../lib/output.js'
@@ -21,9 +21,11 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
         throw error
     }
 
-    const metadata = await getAuthMetadata()
-    const config = await getConfig()
-    const storedAccounts = await listStoredAccounts()
+    // One config read covers both the stored-accounts list and the
+    // default-id lookup; metadata fetch runs in parallel so cold status
+    // doesn't pay for sequential FS hops.
+    const [metadata, config] = await Promise.all([getAuthMetadata(), getConfig()])
+    const storedAccounts = getStoredAccounts(config)
     const defaultAccountId = getDefaultAccountId(config)
     const userIdStr = String(user.id)
 

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,7 +1,9 @@
 import { TwistRequestError } from '@doist/twist-sdk'
 import chalk from 'chalk'
+import { getDefaultAccountId } from '../../lib/accounts.js'
 import { getSessionUser } from '../../lib/api.js'
-import { NoTokenError, getAuthMetadata } from '../../lib/auth.js'
+import { getAuthMetadata, listStoredAccounts, NoTokenError } from '../../lib/auth.js'
+import { getConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { formatJson } from '../../lib/output.js'
 
@@ -19,12 +21,32 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
         throw error
     }
 
+    const metadata = await getAuthMetadata()
+    const config = await getConfig()
+    const storedAccounts = await listStoredAccounts()
+    const defaultAccountId = getDefaultAccountId(config)
+    const userIdStr = String(user.id)
+
     if (options.json) {
-        console.log(formatJson({ id: user.id, email: user.email, name: user.name }))
+        console.log(
+            formatJson({
+                id: user.id,
+                email: user.email,
+                name: user.name,
+                authMode: metadata.authMode,
+                authScope: metadata.authScope,
+                source: metadata.source,
+                isDefault: defaultAccountId === userIdStr,
+                storedAccounts: storedAccounts.map((a) => ({
+                    id: a.id,
+                    email: a.email,
+                    isDefault: defaultAccountId === a.id,
+                })),
+            }),
+        )
         return
     }
 
-    const metadata = await getAuthMetadata()
     const modeLabel =
         metadata.authMode === 'read-only'
             ? `read-only (scope: ${metadata.authScope ?? 'unknown'})`
@@ -32,8 +54,33 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
               ? 'read-write'
               : 'unknown (manual token or env var; assuming write access)'
 
-    console.log(chalk.green('✓'), 'Authenticated')
+    // env source wins over default: when running with TWIST_API_TOKEN, hiding
+    // the env override behind a (default) marker would obscure important
+    // debugging context.
+    const marker =
+        metadata.source === 'env'
+            ? ' (TWIST_API_TOKEN)'
+            : defaultAccountId === userIdStr
+              ? ' (default)'
+              : ''
+
+    console.log(chalk.green('✓'), `Authenticated${marker}`)
     console.log(`  Email: ${user.email}`)
     console.log(`  Name:  ${user.name}`)
     console.log(`  Mode:  ${modeLabel}`)
+
+    const others = storedAccounts.filter((a) => a.id !== userIdStr)
+    if (others.length > 0) {
+        console.log()
+        console.log(chalk.dim(`Other stored accounts (${others.length}):`))
+        for (const other of others) {
+            const otherMarker = other.id === defaultAccountId ? chalk.dim(' (default)') : ''
+            console.log(`  ${other.email} ${chalk.dim(`(id:${other.id})`)}${otherMarker}`)
+        }
+        console.log(
+            chalk.dim(
+                'Use `tw account use <id|email>` to switch default, or `--user <ref>` per command.',
+            ),
+        )
+    }
 }

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,4 +1,5 @@
 import { createInterface } from 'node:readline'
+import { TwistRequestError } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { createWrappedTwistClient } from '../../lib/api.js'
 import { upsertAccount } from '../../lib/auth.js'
@@ -48,8 +49,25 @@ export async function loginWithToken(token?: string): Promise<void> {
     const trimmed = token.trim()
 
     // Identify the Twist user behind the token so it lands in the right slot.
+    // Wrap probe failures so a bad/expired token or transient network error
+    // surfaces as a structured CliError rather than a raw stack trace.
     const probeApi = createWrappedTwistClient(trimmed)
-    const sessionUser = await probeApi.users.getSessionUser()
+    let sessionUser: Awaited<ReturnType<typeof probeApi.users.getSessionUser>>
+    try {
+        sessionUser = await probeApi.users.getSessionUser()
+    } catch (error) {
+        if (error instanceof TwistRequestError && error.httpStatusCode === 401) {
+            throw new CliError(
+                'INVALID_TOKEN',
+                'Token rejected by Twist (401). The token is invalid or expired.',
+                ['Get a fresh token via `tw auth login`, or pass a valid one to `tw auth token`'],
+            )
+        }
+        const detail = error instanceof Error && error.message ? `: ${error.message}` : ''
+        throw new CliError('AUTH_FAILED', `Could not verify token with Twist${detail}`, [
+            'Check your network connection, then re-run `tw auth token`',
+        ])
+    }
     const userId = String(sessionUser.id)
 
     const saveResult = await upsertAccount({

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,6 +1,7 @@
 import { createInterface } from 'node:readline'
 import chalk from 'chalk'
-import { saveApiToken } from '../../lib/auth.js'
+import { createWrappedTwistClient } from '../../lib/api.js'
+import { upsertAccount } from '../../lib/auth.js'
 import { CliError } from '../../lib/errors.js'
 import { isNonInteractive } from '../../lib/global-args.js'
 import { logTokenStorageResult } from './helpers.js'
@@ -44,7 +45,22 @@ export async function loginWithToken(token?: string): Promise<void> {
             ])
         }
     }
-    const saveResult = await saveApiToken(token.trim(), { authMode: 'unknown' })
-    console.log(chalk.green('✓'), 'API token saved successfully!')
+    const trimmed = token.trim()
+
+    // Identify the Twist user behind the token so it lands in the right slot.
+    const probeApi = createWrappedTwistClient(trimmed)
+    const sessionUser = await probeApi.users.getSessionUser()
+    const userId = String(sessionUser.id)
+
+    const saveResult = await upsertAccount({
+        id: userId,
+        email: sessionUser.email,
+        name: sessionUser.name,
+        token: trimmed,
+        authMode: 'unknown',
+    })
+
+    const verb = saveResult.replaced ? 'Updated stored token for' : 'Saved token for'
+    console.log(chalk.green('✓'), `${verb} ${sessionUser.email}`)
     logTokenStorageResult(saveResult, 'Token stored securely in the system credential manager')
 }

--- a/src/commands/channel/threads.test.ts
+++ b/src/commands/channel/threads.test.ts
@@ -11,7 +11,8 @@ const refsMocks = vi.hoisted(() => ({
     resolveChannelRef: vi.fn(),
 }))
 
-vi.mock('../../lib/api.js', () => ({
+vi.mock('../../lib/api.js', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../lib/api.js')>()),
     getTwistClient: apiMocks.getTwistClient,
     getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
 }))

--- a/src/commands/channel/threads.ts
+++ b/src/commands/channel/threads.ts
@@ -1,6 +1,6 @@
 import type { ArchiveFilter, Thread } from '@doist/twist-sdk'
 import chalk from 'chalk'
-import { getCurrentWorkspaceId, getTwistClient } from '../../lib/api.js'
+import { assertBatchData, getCurrentWorkspaceId, getTwistClient } from '../../lib/api.js'
 import { formatRelativeDate } from '../../lib/dates.js'
 import { CliError } from '../../lib/errors.js'
 import { isAccessible } from '../../lib/global-args.js'
@@ -86,8 +86,10 @@ export async function showChannelThreads(
         client.threads.getUnread(workspaceId, { batch: true }),
     )
 
-    const unreadThreadIds = new Set(unreadResp.data.map((u) => u.threadId))
-    let threads: DecoratedThread[] = threadsResp.data.map((t) => ({
+    const threadsList = assertBatchData(threadsResp, `threads in #${channel.name}`)
+    const unreadList = assertBatchData(unreadResp, 'unread threads')
+    const unreadThreadIds = new Set(unreadList.map((u) => u.threadId))
+    let threads: DecoratedThread[] = threadsList.map((t) => ({
         ...t,
         isUnread: unreadThreadIds.has(t.id),
     }))

--- a/src/commands/config/view.ts
+++ b/src/commands/config/view.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import { getDefaultAccount, getStoredAccounts } from '../../lib/accounts.js'
 import {
     type AuthProbeMetadata,
     NoTokenError,
@@ -104,7 +105,13 @@ function formatConfigView(
     lines.push('')
 
     lines.push(chalk.bold('Workspace'))
-    lines.push(`  Current:       ${formatValue(config.currentWorkspace)}`)
+    const accounts = getStoredAccounts(config)
+    const activeAccount = getDefaultAccount(config) ?? (accounts.length === 1 ? accounts[0] : null)
+    // currentWorkspace lives per-account on v2+ configs; fall back to the
+    // legacy top-level field so the view stays useful during the lazy
+    // migration window (cleared on the next workspace lookup).
+    const currentWorkspace = activeAccount?.currentWorkspace ?? config.currentWorkspace
+    lines.push(`  Current:       ${formatValue(currentWorkspace)}`)
     lines.push('')
 
     lines.push(chalk.bold('Updates'))

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -7,7 +7,8 @@ const apiMocks = vi.hoisted(() => ({
     getCurrentWorkspaceId: vi.fn(),
 }))
 
-vi.mock('../lib/api.js', () => ({
+vi.mock('../lib/api.js', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../lib/api.js')>()),
     getTwistClient: apiMocks.getTwistClient,
     getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
 }))

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,7 +1,7 @@
 import type { ArchiveFilter } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { Command, Option } from 'commander'
-import { getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
+import { assertBatchData, getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
 import { withCaseInsensitiveChoices } from '../lib/completion.js'
 import { formatRelativeDate } from '../lib/dates.js'
 import { CliError } from '../lib/errors.js'
@@ -53,8 +53,10 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         client.threads.getUnread(workspaceId, { batch: true }),
     )
 
-    const unreadThreadIds = new Set(unreadData.data.map((u) => u.threadId))
-    let inboxThreads = threads.data.map((t) => ({
+    const inboxData = assertBatchData(threads, 'inbox threads')
+    const unreadList = assertBatchData(unreadData, 'unread threads')
+    const unreadThreadIds = new Set(unreadList.map((u) => u.threadId))
+    let inboxThreads = inboxData.map((t) => ({
         ...t,
         isUnread: unreadThreadIds.has(t.id),
     }))

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import { Command } from 'commander'
-import { fetchWorkspaces, getCurrentWorkspaceId } from '../lib/api.js'
-import { updateConfig } from '../lib/config.js'
+import { fetchWorkspaces, getCurrentWorkspaceId, setActiveAccountWorkspace } from '../lib/api.js'
 import type { ViewOptions } from '../lib/options.js'
 import { colors, formatJson, formatNdjson, printEmpty } from '../lib/output.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
@@ -39,7 +38,7 @@ async function listWorkspaces(options: ListOptions): Promise<void> {
 
 async function useWorkspace(ref: string): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)
-    await updateConfig({ currentWorkspace: workspace.id })
+    await setActiveAccountWorkspace(workspace.id)
     console.log(`Switched to workspace: ${workspace.name}`)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { type Command, program } from 'commander'
 import pkg from '../package.json' with { type: 'json' }
 import { CliError } from './lib/errors.js'
-import { isJsonMode } from './lib/global-args.js'
+import { getRequestedUserRef, isJsonMode, stripUserFlag } from './lib/global-args.js'
 import { formatError, formatErrorJson } from './lib/output.js'
 import { startEarlySpinner, stopEarlySpinner } from './lib/spinner.js'
 
@@ -25,6 +25,8 @@ const loadMentionsCommand = async () =>
     (await import('./commands/mentions.js')).registerMentionsCommand
 const loadReactCommand = async () => (await import('./commands/react.js')).registerReactCommand
 const loadAuthCommand = async () => (await import('./commands/auth/index.js')).registerAuthCommand
+const loadAccountCommand = async () =>
+    (await import('./commands/account/index.js')).registerAccountCommand
 const loadSkillCommand = async () =>
     (await import('./commands/skill/index.js')).registerSkillCommand
 const loadViewCommand = async () => (await import('./commands/view.js')).registerViewCommand
@@ -58,6 +60,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
     react: ['Add an emoji reaction (target-type: thread, comment, message)', loadReactCommand],
     unreact: ['Remove an emoji reaction (target-type: thread, comment, message)', loadReactCommand],
     auth: ['Manage authentication', loadAuthCommand],
+    account: ['Manage stored Twist accounts (multi-user)', loadAccountCommand],
     skill: ['Manage agent skill integrations', loadSkillCommand],
     view: ['View a Twist entity by URL', loadViewCommand],
     completion: ['Manage shell completions', loadCompletionCommand],
@@ -93,12 +96,17 @@ program
         'Disable interactive prompts (auto-detected when stdin is not a TTY)',
     )
     .option('--interactive', 'Force interactive mode even when stdin is not a TTY')
+    .option(
+        '--user <ref>',
+        'Run as a specific stored Twist account (id or email). See `tw account list`.',
+    )
     .addHelpText(
         'after',
         `
 Note for AI/LLM agents:
   Use --json or --ndjson flags for unambiguous, parseable output.
-  Default JSON shows essential fields; use --full for all fields.`,
+  Default JSON shows essential fields; use --full for all fields.
+  Use --user <id|email> on any command to act as a specific stored account.`,
     )
 
 // Register lightweight placeholders so --help lists all commands
@@ -109,6 +117,38 @@ for (const [name, [description]] of Object.entries(commands)) {
     if (alias) {
         cmd.alias(alias)
     }
+}
+
+// Validate `--user` and strip it from argv before commander parses.
+//
+// Commander has no global-option attachment, so leaving `--user` in argv
+// would make every subcommand error on it. We capture the value via
+// `parseGlobalArgs` first and remove it here. Before stripping we surface
+// usage errors that the parser can detect now but commander never will
+// because it never sees the flag — bare `--user`, `--user=` (empty), and
+// `--user <known-subcommand>` (almost always a forgotten value).
+{
+    const originalArgs = process.argv.slice(2)
+    const sawUserFlag = originalArgs.some((a) => a === '--user' || a.startsWith('--user='))
+    if (sawUserFlag) {
+        const ref = getRequestedUserRef()
+        const reportUserFlagError = (message: string, hints: string[]): never => {
+            const err = new CliError('USER_FLAG_INVALID', message, hints)
+            console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
+            process.exit(1)
+        }
+        if (!ref) {
+            reportUserFlagError('--user requires a value: <id|email>.', [
+                'Example: tw --user me@example.com inbox',
+            ])
+        } else if (Object.hasOwn(commands, ref) || Object.hasOwn(commandAliases, ref)) {
+            reportUserFlagError(
+                `--user requires a value: <id|email>. Got "${ref}", which looks like a subcommand — did you forget the value?`,
+                [`Example: tw --user me@example.com ${ref}`],
+            )
+        }
+    }
+    process.argv = [process.argv[0], process.argv[1], ...stripUserFlag(originalArgs)]
 }
 
 // completion-server needs the command tree to walk for completions.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { type Command, program } from 'commander'
 import pkg from '../package.json' with { type: 'json' }
 import { CliError } from './lib/errors.js'
-import { getRequestedUserRef, isJsonMode, stripUserFlag } from './lib/global-args.js'
+import { isJsonMode, stripUserFlag, validateUserFlag } from './lib/global-args.js'
 import { formatError, formatErrorJson } from './lib/output.js'
 import { startEarlySpinner, stopEarlySpinner } from './lib/spinner.js'
 
@@ -119,34 +119,37 @@ for (const [name, [description]] of Object.entries(commands)) {
     }
 }
 
+function reportError(err: Error): void {
+    stopEarlySpinner()
+    if (err instanceof CliError) {
+        console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
+    } else {
+        console.error(
+            isJsonMode()
+                ? formatErrorJson('INTERNAL_ERROR', err.message)
+                : err.stack || err.message,
+        )
+    }
+    process.exitCode = 1
+}
+
 // Validate `--user` and strip it from argv before commander parses.
 //
 // Commander has no global-option attachment, so leaving `--user` in argv
-// would make every subcommand error on it. We capture the value via
-// `parseGlobalArgs` first and remove it here. Before stripping we surface
-// usage errors that the parser can detect now but commander never will
-// because it never sees the flag — bare `--user`, `--user=` (empty), and
-// `--user <known-subcommand>` (almost always a forgotten value).
+// would make every subcommand error on it. The validator (single source of
+// truth in `global-args.ts`) catches bare `--user`, `--user=` (empty), and
+// `--user <known-subcommand>` (almost always a forgotten value) — commander
+// would never see these because we strip the flag before parsing.
 {
     const originalArgs = process.argv.slice(2)
-    const sawUserFlag = originalArgs.some((a) => a === '--user' || a.startsWith('--user='))
-    if (sawUserFlag) {
-        const ref = getRequestedUserRef()
-        const reportUserFlagError = (message: string, hints: string[]): never => {
-            const err = new CliError('USER_FLAG_INVALID', message, hints)
-            console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
-            process.exit(1)
-        }
-        if (!ref) {
-            reportUserFlagError('--user requires a value: <id|email>.', [
-                'Example: tw --user me@example.com inbox',
-            ])
-        } else if (Object.hasOwn(commands, ref) || Object.hasOwn(commandAliases, ref)) {
-            reportUserFlagError(
-                `--user requires a value: <id|email>. Got "${ref}", which looks like a subcommand — did you forget the value?`,
-                [`Example: tw --user me@example.com ${ref}`],
-            )
-        }
+    const knownCommands = new Set([...Object.keys(commands), ...Object.keys(commandAliases)])
+    const validation = validateUserFlag(originalArgs, knownCommands)
+    if (!validation.ok) {
+        // Pre-parse failure runs synchronously here, before commander
+        // registers anything — the bottom `.catch(reportError)` can't see
+        // it. Route through the shared formatter, then exit explicitly.
+        reportError(new CliError('USER_FLAG_INVALID', validation.message, validation.hints))
+        process.exit(process.exitCode ?? 1)
     }
     process.argv = [process.argv[0], process.argv[1], ...stripUserFlag(originalArgs)]
 }
@@ -216,19 +219,7 @@ if (process.argv[2] === 'completion-server') {
 
 await program
     .parseAsync()
-    .catch((err: Error) => {
-        stopEarlySpinner()
-        if (err instanceof CliError) {
-            console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
-        } else {
-            console.error(
-                isJsonMode()
-                    ? formatErrorJson('INTERNAL_ERROR', err.message)
-                    : err.stack || err.message,
-            )
-        }
-        process.exitCode = 1
-    })
+    .catch(reportError)
     .finally(() => {
         stopEarlySpinner()
     })

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -1,0 +1,117 @@
+import type { Config, StoredAccount } from './config.js'
+import { CliError } from './errors.js'
+
+/**
+ * Reference shape accepted by `--user` and `tw account` subcommands: an
+ * exact Twist user id, or a Twist account email (case-insensitive).
+ */
+export type AccountRef = string
+
+export interface FindAccountResult {
+    account: StoredAccount
+    index: number
+}
+
+export class AccountNotFoundError extends CliError {
+    constructor(ref: AccountRef) {
+        super(
+            'ACCOUNT_NOT_FOUND',
+            `No stored account matches "${ref}". Use \`tw account list\` to see authenticated accounts.`,
+            [
+                'Run `tw auth login` to add an account, or `tw account list` to inspect existing ones',
+            ],
+            'info',
+        )
+        this.name = 'AccountNotFoundError'
+    }
+}
+
+export class NoAccountSelectedError extends CliError {
+    constructor() {
+        super(
+            'NO_ACCOUNT_SELECTED',
+            'Multiple Twist accounts are stored. Specify which one to use.',
+            [
+                'Pass `--user <id|email>` on the command, or',
+                'Set a default with `tw account use <id|email>`',
+            ],
+            'info',
+        )
+        this.name = 'NoAccountSelectedError'
+    }
+}
+
+export function getStoredAccounts(config: Config): StoredAccount[] {
+    return Array.isArray(config.accounts) ? config.accounts : []
+}
+
+export function findAccountByRef(config: Config, ref: AccountRef): FindAccountResult | null {
+    const accounts = getStoredAccounts(config)
+    const trimmed = ref.trim()
+    if (!trimmed) return null
+
+    // Exact id match first (Twist user ids are numeric strings; case-sensitive)
+    const byId = accounts.findIndex((a) => a.id === trimmed)
+    if (byId !== -1) return { account: accounts[byId], index: byId }
+
+    // Email match — case-insensitive
+    const lower = trimmed.toLowerCase()
+    const byEmail = accounts.findIndex((a) => a.email.toLowerCase() === lower)
+    if (byEmail !== -1) return { account: accounts[byEmail], index: byEmail }
+
+    return null
+}
+
+export function requireAccountByRef(config: Config, ref: AccountRef): FindAccountResult {
+    const found = findAccountByRef(config, ref)
+    if (!found) throw new AccountNotFoundError(ref)
+    return found
+}
+
+export function getDefaultAccountId(config: Config): string | undefined {
+    return config.account?.defaultAccount
+}
+
+export function getDefaultAccount(config: Config): StoredAccount | null {
+    const id = getDefaultAccountId(config)
+    if (!id) return null
+    return getStoredAccounts(config).find((a) => a.id === id) ?? null
+}
+
+/**
+ * Replace or append an account record. Returns a new config and whether the
+ * account was already present (so callers can distinguish "added" from
+ * "updated").
+ */
+export function upsertStoredAccount(
+    config: Config,
+    next: StoredAccount,
+): { config: Config; replaced: boolean } {
+    const accounts = getStoredAccounts(config).slice()
+    const idx = accounts.findIndex((a) => a.id === next.id)
+    const replaced = idx !== -1
+    if (replaced) {
+        accounts[idx] = next
+    } else {
+        accounts.push(next)
+    }
+    return { config: { ...config, accounts }, replaced }
+}
+
+export function removeStoredAccount(config: Config, id: string): Config {
+    const accounts = getStoredAccounts(config).filter((a) => a.id !== id)
+    const next: Config = { ...config, accounts }
+    if (next.account?.defaultAccount === id) {
+        const { defaultAccount: _, ...restAccount } = next.account
+        next.account = Object.keys(restAccount).length === 0 ? undefined : restAccount
+        if (next.account === undefined) {
+            const { account: _a, ...rest } = next
+            return rest
+        }
+    }
+    return next
+}
+
+export function setDefaultAccount(config: Config, id: string): Config {
+    return { ...config, account: { ...config.account, defaultAccount: id } }
+}

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -115,3 +115,15 @@ export function removeStoredAccount(config: Config, id: string): Config {
 export function setDefaultAccount(config: Config, id: string): Config {
     return { ...config, account: { ...config.account, defaultAccount: id } }
 }
+
+/**
+ * Patch a single stored account in-place. No-op if no account matches `id`.
+ */
+export function updateStoredAccount(
+    config: Config,
+    id: string,
+    patch: Partial<StoredAccount>,
+): Config {
+    const accounts = getStoredAccounts(config).map((a) => (a.id === id ? { ...a, ...patch } : a))
+    return { ...config, accounts }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,8 +5,9 @@ import {
     type Workspace,
     type WorkspaceUser,
 } from '@doist/twist-sdk'
+import { getStoredAccounts, updateStoredAccount } from './accounts.js'
 import { resolveActiveAccount } from './auth.js'
-import { getConfig, updateConfig } from './config.js'
+import { type Config, getConfig, setConfig } from './config.js'
 import { CliError, isInsufficientScope } from './errors.js'
 import { ensureWriteAllowed, isMutatingMethod } from './permissions.js'
 import { getProgressTracker } from './progress.js'
@@ -264,27 +265,92 @@ export async function getCurrentWorkspaceId(flagValue?: number): Promise<number>
         return flagValue
     }
 
-    const config = await getConfig()
-    if (config.currentWorkspace) {
-        return config.currentWorkspace
+    const resolved = await resolveActiveAccount()
+
+    // Env-token flow has no persistent slot to write into; resolve the
+    // workspace freshly from the API each call.
+    if (resolved.id === 'env') {
+        const sessionUser = await getSessionUser()
+        if (sessionUser.defaultWorkspace) return sessionUser.defaultWorkspace
+        return firstWorkspaceId()
+    }
+
+    let config = await getConfig()
+
+    // One-shot migration: legacy installs stored a single `currentWorkspace`
+    // at the top level. Move it onto the default-or-only account so that
+    // `tw --user <other>` doesn't try to use someone else's workspace.
+    const migrated = migrateLegacyCurrentWorkspace(config)
+    if (migrated !== config) {
+        await setConfig(migrated)
+        config = migrated
+    }
+
+    const account = getStoredAccounts(config).find((a) => a.id === resolved.id)
+    if (account?.currentWorkspace) {
+        return account.currentWorkspace
     }
 
     const sessionUser = await getSessionUser()
     if (sessionUser.defaultWorkspace) {
-        await updateConfig({ currentWorkspace: sessionUser.defaultWorkspace })
+        await persistAccountWorkspace(resolved.id, sessionUser.defaultWorkspace)
         return sessionUser.defaultWorkspace
     }
 
+    const id = await firstWorkspaceId()
+    await persistAccountWorkspace(resolved.id, id)
+    return id
+}
+
+async function firstWorkspaceId(): Promise<number> {
     const workspaces = await fetchWorkspaces()
     if (workspaces.length === 0) {
         throw new CliError('NOT_FOUND', 'No workspaces found for this user', [
             'Ensure your account has been added to a workspace',
         ])
     }
+    return workspaces[0].id
+}
 
-    const defaultWorkspace = workspaces[0]
-    await updateConfig({ currentWorkspace: defaultWorkspace.id })
-    return defaultWorkspace.id
+async function persistAccountWorkspace(accountId: string, workspaceId: number): Promise<void> {
+    const config = await getConfig()
+    await setConfig(updateStoredAccount(config, accountId, { currentWorkspace: workspaceId }))
+}
+
+function migrateLegacyCurrentWorkspace(config: Config): Config {
+    if (typeof config.currentWorkspace !== 'number') return config
+    const accounts = getStoredAccounts(config)
+    if (accounts.length === 0) {
+        // No accounts to attach to yet — strip the orphan so it stops being
+        // surfaced by `tw doctor` and friends.
+        const { currentWorkspace: _drop, ...rest } = config
+        return rest
+    }
+    const targetId =
+        config.account?.defaultAccount ?? (accounts.length === 1 ? accounts[0].id : undefined)
+    if (!targetId) {
+        // Multiple accounts and no default — we can't guess whose workspace
+        // this was. Drop it; `getCurrentWorkspaceId` will re-derive per
+        // account on next call.
+        const { currentWorkspace: _drop, ...rest } = config
+        return rest
+    }
+    const next = accounts.map((a) =>
+        a.id === targetId && a.currentWorkspace === undefined
+            ? { ...a, currentWorkspace: config.currentWorkspace }
+            : a,
+    )
+    const { currentWorkspace: _drop, ...rest } = config
+    return { ...rest, accounts: next }
+}
+
+/**
+ * Persist the active account's workspace selection. Used by `tw workspace use`.
+ */
+export async function setActiveAccountWorkspace(workspaceId: number): Promise<void> {
+    const resolved = await resolveActiveAccount()
+    if (resolved.id === 'env') return
+    await persistAccountWorkspace(resolved.id, workspaceId)
 }
 
 export async function getSessionUser(): Promise<User> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,7 +5,7 @@ import {
     type Workspace,
     type WorkspaceUser,
 } from '@doist/twist-sdk'
-import { getApiToken } from './auth.js'
+import { resolveActiveAccount } from './auth.js'
 import { getConfig, updateConfig } from './config.js'
 import { CliError, isInsufficientScope } from './errors.js'
 import { ensureWriteAllowed, isMutatingMethod } from './permissions.js'
@@ -237,8 +237,8 @@ export function createWrappedTwistClient(token: string): TwistApi {
 
 export async function getTwistClient(): Promise<TwistApi> {
     if (!apiClient) {
-        const token = await getApiToken()
-        apiClient = createWrappedTwistClient(token)
+        const resolved = await resolveActiveAccount()
+        apiClient = createWrappedTwistClient(resolved.token)
     }
     return apiClient
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ import { getStoredAccounts, updateStoredAccount } from './accounts.js'
 import { resolveActiveAccount } from './auth.js'
 import { type Config, getConfig, setConfig } from './config.js'
 import { CliError, isInsufficientScope } from './errors.js'
+import { getRequestedUserRef } from './global-args.js'
 import { ensureWriteAllowed, isMutatingMethod } from './permissions.js'
 import { getProgressTracker } from './progress.js'
 import { withSpinner } from './spinner.js'
@@ -238,7 +239,7 @@ export function createWrappedTwistClient(token: string): TwistApi {
 
 export async function getTwistClient(): Promise<TwistApi> {
     if (!apiClient) {
-        const resolved = await resolveActiveAccount()
+        const resolved = await resolveActiveAccount({ ref: getRequestedUserRef() })
         apiClient = createWrappedTwistClient(resolved.token)
     }
     return apiClient
@@ -265,11 +266,11 @@ export async function getCurrentWorkspaceId(flagValue?: number): Promise<number>
         return flagValue
     }
 
-    const resolved = await resolveActiveAccount()
+    const resolved = await resolveActiveAccount({ ref: getRequestedUserRef() })
 
-    // Env-token flow has no persistent slot to write into; resolve the
-    // workspace freshly from the API each call.
-    if (resolved.id === 'env') {
+    // Env-token / legacy-fallback flows have no persistent slot to write
+    // into; resolve the workspace freshly from the API each call.
+    if (!resolved.id) {
         const sessionUser = await getSessionUser()
         if (sessionUser.defaultWorkspace) return sessionUser.defaultWorkspace
         return firstWorkspaceId()
@@ -286,19 +287,20 @@ export async function getCurrentWorkspaceId(flagValue?: number): Promise<number>
         config = migrated
     }
 
-    const account = getStoredAccounts(config).find((a) => a.id === resolved.id)
+    const accountId = resolved.id
+    const account = getStoredAccounts(config).find((a) => a.id === accountId)
     if (account?.currentWorkspace) {
         return account.currentWorkspace
     }
 
     const sessionUser = await getSessionUser()
     if (sessionUser.defaultWorkspace) {
-        await persistAccountWorkspace(resolved.id, sessionUser.defaultWorkspace)
+        await persistAccountWorkspace(accountId, sessionUser.defaultWorkspace)
         return sessionUser.defaultWorkspace
     }
 
     const id = await firstWorkspaceId()
-    await persistAccountWorkspace(resolved.id, id)
+    await persistAccountWorkspace(accountId, id)
     return id
 }
 
@@ -348,8 +350,8 @@ function migrateLegacyCurrentWorkspace(config: Config): Config {
  * Persist the active account's workspace selection. Used by `tw workspace use`.
  */
 export async function setActiveAccountWorkspace(workspaceId: number): Promise<void> {
-    const resolved = await resolveActiveAccount()
-    if (resolved.id === 'env') return
+    const resolved = await resolveActiveAccount({ ref: getRequestedUserRef() })
+    if (!resolved.id) return
     await persistAccountWorkspace(resolved.id, workspaceId)
 }
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -95,10 +95,10 @@ describe('auth multi-account storage', () => {
         const { getApiToken, resolveActiveAccount } = await import('./auth.js')
 
         await expect(getApiToken()).resolves.toBe('env_token_123456')
-        await expect(resolveActiveAccount()).resolves.toMatchObject({
-            id: 'env',
-            source: 'env',
-        })
+        const resolved = await resolveActiveAccount()
+        expect(resolved.source).toBe('env')
+        expect(resolved.id).toBeUndefined()
+        expect(resolved.email).toBeUndefined()
         expect(mocks.getConfig).not.toHaveBeenCalled()
     })
 
@@ -306,7 +306,8 @@ describe('auth multi-account storage', () => {
         const { resolveActiveAccount } = await import('./auth.js')
 
         const resolved = await resolveActiveAccount()
-        expect(resolved.id).toBe('legacy')
+        expect(resolved.legacy).toBe(true)
+        expect(resolved.id).toBeUndefined()
         expect(resolved.token).toBe('legacy-token-1234567')
         expect(resolved.authMode).toBe('read-write')
         // does NOT auto-migrate at runtime — postinstall's job
@@ -320,7 +321,8 @@ describe('auth multi-account storage', () => {
         const { resolveActiveAccount } = await import('./auth.js')
 
         const resolved = await resolveActiveAccount()
-        expect(resolved.id).toBe('legacy')
+        expect(resolved.legacy).toBe(true)
+        expect(resolved.id).toBeUndefined()
         expect(resolved.token).toBe('legacy-secure-1234567')
         expect(resolved.source).toBe('secure-store')
     })

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -3,49 +3,83 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => {
     class MockSecureStoreUnavailableError extends Error {}
 
+    interface KeyringEntry {
+        token: string | null
+    }
+    const keyringEntries = new Map<string, KeyringEntry>()
+    function entry(account: string): KeyringEntry {
+        let e = keyringEntries.get(account)
+        if (!e) {
+            e = { token: null }
+            keyringEntries.set(account, e)
+        }
+        return e
+    }
+
     return {
         MockSecureStoreUnavailableError,
+        keyringEntries,
+        entry,
         getConfig: vi.fn(),
         getConfigPath: vi.fn(() => '/home/user/.config/twist-cli/config.json'),
-        secureTokenStore: {
-            getSecret: vi.fn(),
-            setSecret: vi.fn(),
-            deleteSecret: vi.fn(),
-        },
         setConfig: vi.fn(),
         unlink: vi.fn(),
-        updateConfig: vi.fn(),
+        // tracks the account name passed to createSecureStore
+        secureStoreFactory: vi.fn(),
+        secureStoreError: null as Error | null,
     }
 })
 
-vi.mock('./config.js', () => ({
-    getConfig: mocks.getConfig,
-    getConfigPath: mocks.getConfigPath,
-    setConfig: mocks.setConfig,
-    updateConfig: mocks.updateConfig,
-}))
+vi.mock('./config.js', async () => {
+    const actual = await vi.importActual<typeof import('./config.js')>('./config.js')
+    return {
+        ...actual,
+        getConfig: mocks.getConfig,
+        getConfigPath: mocks.getConfigPath,
+        setConfig: mocks.setConfig,
+    }
+})
 
 vi.mock('./secure-store.js', () => ({
-    createSecureStore: () => mocks.secureTokenStore,
     SECURE_STORE_DESCRIPTION: 'system credential manager',
     SecureStoreUnavailableError: mocks.MockSecureStoreUnavailableError,
+    LEGACY_ACCOUNT_NAME: 'api-token',
+    accountForUser: (id: string) => `user-${id}`,
+    createSecureStore: (account = 'api-token') => {
+        mocks.secureStoreFactory(account)
+        return {
+            async getSecret(): Promise<string | null> {
+                if (mocks.secureStoreError) throw mocks.secureStoreError
+                return mocks.entry(account).token
+            },
+            async setSecret(secret: string): Promise<void> {
+                if (mocks.secureStoreError) throw mocks.secureStoreError
+                mocks.entry(account).token = secret
+            },
+            async deleteSecret(): Promise<boolean> {
+                if (mocks.secureStoreError) throw mocks.secureStoreError
+                const e = mocks.entry(account)
+                const had = e.token !== null
+                e.token = null
+                return had
+            },
+        }
+    },
 }))
 
 vi.mock('node:fs/promises', () => ({
     unlink: mocks.unlink,
 }))
 
-describe('auth token storage', () => {
+describe('auth multi-account storage', () => {
     beforeEach(() => {
         vi.resetModules()
         vi.clearAllMocks()
         mocks.getConfig.mockReset()
         mocks.setConfig.mockReset()
-        mocks.updateConfig.mockReset()
         mocks.unlink.mockReset()
-        mocks.secureTokenStore.getSecret.mockReset()
-        mocks.secureTokenStore.setSecret.mockReset()
-        mocks.secureTokenStore.deleteSecret.mockReset()
+        mocks.keyringEntries.clear()
+        mocks.secureStoreError = null
         delete process.env.TWIST_API_TOKEN
     })
 
@@ -53,221 +87,379 @@ describe('auth token storage', () => {
         delete process.env.TWIST_API_TOKEN
     })
 
-    it('prefers TWIST_API_TOKEN over stored credentials', async () => {
+    // --- env var --------------------------------------------------------------
+
+    it('TWIST_API_TOKEN bypasses stored accounts', async () => {
         process.env.TWIST_API_TOKEN = 'env_token_123456'
 
-        const { getApiToken } = await import('./auth.js')
+        const { getApiToken, resolveActiveAccount } = await import('./auth.js')
 
         await expect(getApiToken()).resolves.toBe('env_token_123456')
-        expect(mocks.secureTokenStore.getSecret).not.toHaveBeenCalled()
+        await expect(resolveActiveAccount()).resolves.toMatchObject({
+            id: 'env',
+            source: 'env',
+        })
         expect(mocks.getConfig).not.toHaveBeenCalled()
     })
 
-    it('migrates a legacy plaintext config token into the secure store', async () => {
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 42,
-        })
+    // --- upsertAccount --------------------------------------------------------
 
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(mocks.secureTokenStore.setSecret).toHaveBeenCalledWith('legacy_token_123456')
-        expect(mocks.setConfig).toHaveBeenCalledWith({ currentWorkspace: 42 })
-        expect(mocks.unlink).not.toHaveBeenCalled()
-    })
-
-    it('prefers the fallback config token over a stale secure-store token', async () => {
-        mocks.secureTokenStore.getSecret.mockResolvedValue('stale_secure_token_123456')
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'fresh_config_token_123456',
-            currentWorkspace: 42,
-        })
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('fresh_config_token_123456')
-        expect(mocks.secureTokenStore.setSecret).toHaveBeenCalledWith('fresh_config_token_123456')
-        expect(mocks.secureTokenStore.getSecret).not.toHaveBeenCalled()
-    })
-
-    it('returns the migrated token even when config cleanup fails', async () => {
-        mocks.secureTokenStore.getSecret.mockResolvedValue(null)
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 42,
-        })
-        mocks.setConfig.mockRejectedValue(new Error('EACCES'))
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(errorSpy).toHaveBeenCalledWith(
-            'Warning: Token was migrated to secure storage, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-        )
-
-        errorSpy.mockRestore()
-    })
-
-    it('writes tokens to the secure store by default', async () => {
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
+    it('upsertAccount stores token in per-account keyring slot and writes v2 config', async () => {
         mocks.getConfig.mockResolvedValue({})
 
-        const { saveApiToken } = await import('./auth.js')
+        const { upsertAccount } = await import('./auth.js')
 
-        await expect(saveApiToken(' secure_token_123456 ')).resolves.toEqual({
-            storage: 'secure-store',
-        })
-        expect(mocks.secureTokenStore.setSecret).toHaveBeenCalledWith('secure_token_123456')
-    })
-
-    it('keeps secure-store success when plaintext cleanup fails after saving', async () => {
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 42,
-        })
-        mocks.setConfig.mockRejectedValue(new Error('EACCES'))
-
-        const { saveApiToken } = await import('./auth.js')
-
-        await expect(saveApiToken('secure_token_123456')).resolves.toEqual({
-            storage: 'secure-store',
-            warning:
-                'Token was stored securely, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-        })
-    })
-
-    it('deletes tokens from the secure store and removes any legacy config token', async () => {
-        mocks.secureTokenStore.deleteSecret.mockResolvedValue(true)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 7,
-        })
-
-        const { clearApiToken } = await import('./auth.js')
-
-        await expect(clearApiToken()).resolves.toEqual({ storage: 'secure-store' })
-        expect(mocks.secureTokenStore.deleteSecret).toHaveBeenCalled()
-        expect(mocks.setConfig).toHaveBeenCalledWith({ currentWorkspace: 7 })
-    })
-
-    it('persists pending secure-store clear state when logout falls back to config', async () => {
-        mocks.secureTokenStore.deleteSecret.mockRejectedValue(
-            new mocks.MockSecureStoreUnavailableError('No keychain access'),
-        )
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 7,
-        })
-
-        const { clearApiToken } = await import('./auth.js')
-
-        await expect(clearApiToken()).resolves.toEqual({
-            storage: 'config-file',
-            warning:
-                'system credential manager unavailable; local auth state cleared in /home/user/.config/twist-cli/config.json',
-        })
-        expect(mocks.setConfig).toHaveBeenCalledWith({
-            currentWorkspace: 7,
-            pendingSecureStoreClear: true,
-        })
-    })
-
-    it('falls back to plaintext config storage when the secure store is unavailable', async () => {
-        mocks.secureTokenStore.setSecret.mockRejectedValue(
-            new mocks.MockSecureStoreUnavailableError('No keychain access'),
-        )
-        mocks.getConfig.mockResolvedValue({})
-
-        const { saveApiToken } = await import('./auth.js')
-
-        await expect(saveApiToken('fallback_token_123456')).resolves.toEqual({
-            storage: 'config-file',
-            warning:
-                'system credential manager unavailable; token saved as plaintext in /home/user/.config/twist-cli/config.json',
-        })
-        expect(mocks.setConfig).toHaveBeenCalledWith({
-            token: 'fallback_token_123456',
-            authMode: 'unknown',
-            authScope: undefined,
-        })
-    })
-
-    it('reads from plaintext config silently when the secure store is unavailable', async () => {
-        mocks.secureTokenStore.setSecret.mockRejectedValue(
-            new mocks.MockSecureStoreUnavailableError('No keychain access'),
-        )
-        mocks.getConfig.mockResolvedValue({ token: 'legacy_token_123456' })
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(errorSpy).not.toHaveBeenCalled()
-
-        errorSpy.mockRestore()
-    })
-
-    it('probes a legacy config token without migrating it', async () => {
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            authMode: 'read-write',
-            currentWorkspace: 42,
-        })
-
-        const { probeApiToken } = await import('./auth.js')
-
-        await expect(probeApiToken()).resolves.toEqual({
-            token: 'legacy_token_123456',
-            metadata: {
+        await expect(
+            upsertAccount({
+                id: '12345',
+                email: 'me@example.com',
+                name: 'Scott',
+                token: 'oauth-token-1234567',
                 authMode: 'read-write',
-                source: 'config-file',
-            },
+                authScope: 'user:read user:write',
+            }),
+        ).resolves.toEqual({ storage: 'secure-store', replaced: false })
+
+        expect(mocks.entry('user-12345').token).toBe('oauth-token-1234567')
+        expect(mocks.setConfig).toHaveBeenCalledWith({
+            configVersion: 2,
+            account: { defaultAccount: '12345' },
+            accounts: [
+                {
+                    id: '12345',
+                    email: 'me@example.com',
+                    name: 'Scott',
+                    authMode: 'read-write',
+                    authScope: 'user:read user:write',
+                },
+            ],
         })
-        expect(mocks.secureTokenStore.setSecret).not.toHaveBeenCalled()
+    })
+
+    it('upsertAccount sets the new account as default even when an orphaned defaultAccount points elsewhere', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: 'orphan' },
+            accounts: [],
+        })
+
+        const { upsertAccount } = await import('./auth.js')
+
+        await upsertAccount({
+            id: '111',
+            email: 'a@b.c',
+            token: 'first-token-1234567',
+        })
+
+        expect(mocks.setConfig).toHaveBeenCalledWith(
+            expect.objectContaining({
+                account: { defaultAccount: '111' },
+                accounts: [expect.objectContaining({ id: '111' })],
+            }),
+        )
+    })
+
+    it('upsertAccount does NOT overwrite an existing default when adding a second account', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: '111' },
+            accounts: [{ id: '111', email: 'first@example.com' }],
+        })
+
+        const { upsertAccount } = await import('./auth.js')
+
+        await upsertAccount({
+            id: '222',
+            email: 'second@example.com',
+            token: 'second-token-1234567',
+        })
+
+        const written = mocks.setConfig.mock.calls.at(-1)?.[0]
+        expect(written.account).toEqual({ defaultAccount: '111' })
+        expect(written.accounts.map((a: { id: string }) => a.id)).toEqual(['111', '222'])
+    })
+
+    it('upsertAccount falls back to per-account plaintext when keyring unavailable', async () => {
+        mocks.getConfig.mockResolvedValue({})
+        mocks.secureStoreError = new mocks.MockSecureStoreUnavailableError('no keychain')
+
+        const { upsertAccount } = await import('./auth.js')
+
+        const result = await upsertAccount({
+            id: '12345',
+            email: 'me@example.com',
+            token: 'fallback-token-1234567',
+        })
+
+        expect(result.storage).toBe('config-file')
+        expect(result.warning).toContain('plaintext')
+        const written = mocks.setConfig.mock.calls.at(-1)?.[0]
+        expect(written.accounts[0].token).toBe('fallback-token-1234567')
+    })
+
+    it('upsertAccount rolls back the keyring write when the config write fails', async () => {
+        mocks.getConfig.mockResolvedValue({})
+        mocks.setConfig.mockRejectedValue(new Error('EACCES'))
+
+        const { upsertAccount } = await import('./auth.js')
+
+        await expect(
+            upsertAccount({ id: '12345', email: 'me@example.com', token: 'rollback-1234567' }),
+        ).rejects.toMatchObject({ code: 'CONFIG_WRITE_FAILED' })
+        expect(mocks.entry('user-12345').token).toBeNull()
+    })
+
+    // --- resolveActiveAccount -------------------------------------------------
+
+    it('resolves single stored account implicitly', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            accounts: [{ id: '111', email: 'a@b.c' }],
+        })
+        mocks.entry('user-111').token = 'stored-token'
+
+        const { resolveActiveAccount } = await import('./auth.js')
+
+        await expect(resolveActiveAccount()).resolves.toMatchObject({
+            id: '111',
+            email: 'a@b.c',
+            token: 'stored-token',
+            source: 'secure-store',
+        })
+    })
+
+    it('resolves the configured default when multiple accounts are stored', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: '222' },
+            accounts: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        mocks.entry('user-222').token = 'token-222'
+
+        const { resolveActiveAccount } = await import('./auth.js')
+
+        await expect(resolveActiveAccount()).resolves.toMatchObject({
+            id: '222',
+            token: 'token-222',
+        })
+    })
+
+    it('errors when multiple accounts are stored without a default and no --user', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            accounts: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+
+        const { resolveActiveAccount } = await import('./auth.js')
+        const { NoAccountSelectedError } = await import('./accounts.js')
+
+        await expect(resolveActiveAccount()).rejects.toBeInstanceOf(NoAccountSelectedError)
+    })
+
+    it('honors an explicit ref override (case-insensitive email)', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: '111' },
+            accounts: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'D@E.F' },
+            ],
+        })
+        mocks.entry('user-222').token = 'token-222'
+
+        const { resolveActiveAccount } = await import('./auth.js')
+
+        await expect(resolveActiveAccount({ ref: 'd@e.f' })).resolves.toMatchObject({
+            id: '222',
+        })
+        await expect(resolveActiveAccount({ ref: '222' })).resolves.toMatchObject({ id: '222' })
+    })
+
+    it('throws AccountNotFoundError when ref does not match', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            accounts: [{ id: '111', email: 'a@b.c' }],
+        })
+
+        const { resolveActiveAccount } = await import('./auth.js')
+        const { AccountNotFoundError } = await import('./accounts.js')
+
+        await expect(resolveActiveAccount({ ref: 'nope' })).rejects.toBeInstanceOf(
+            AccountNotFoundError,
+        )
+    })
+
+    // --- legacy fallback ------------------------------------------------------
+
+    it('serves a legacy config token when no v2 accounts exist', async () => {
+        mocks.getConfig.mockResolvedValue({
+            token: 'legacy-token-1234567',
+            authMode: 'read-write',
+        })
+
+        const { resolveActiveAccount } = await import('./auth.js')
+
+        const resolved = await resolveActiveAccount()
+        expect(resolved.id).toBe('legacy')
+        expect(resolved.token).toBe('legacy-token-1234567')
+        expect(resolved.authMode).toBe('read-write')
+        // does NOT auto-migrate at runtime — postinstall's job
         expect(mocks.setConfig).not.toHaveBeenCalled()
     })
 
-    it('probes a secure-store token without mutating config', async () => {
-        mocks.secureTokenStore.getSecret.mockResolvedValue('secure_token_123456')
+    it('serves a legacy keyring token when no v2 accounts and no plaintext', async () => {
+        mocks.getConfig.mockResolvedValue({})
+        mocks.entry('api-token').token = 'legacy-secure-1234567'
+
+        const { resolveActiveAccount } = await import('./auth.js')
+
+        const resolved = await resolveActiveAccount()
+        expect(resolved.id).toBe('legacy')
+        expect(resolved.token).toBe('legacy-secure-1234567')
+        expect(resolved.source).toBe('secure-store')
+    })
+
+    it('does not reauth from legacy keyring when v2 accounts[] is explicitly empty', async () => {
+        // Logged-out v2 install — leftover api-token must NOT be picked up.
+        mocks.getConfig.mockResolvedValue({ configVersion: 2, accounts: [] })
+        mocks.entry('api-token').token = 'leftover-from-v1'
+
+        const { resolveActiveAccount, NoTokenError } = await import('./auth.js')
+
+        await expect(resolveActiveAccount()).rejects.toBeInstanceOf(NoTokenError)
+    })
+
+    it('treats v1 pendingSecureStoreClear as logged out', async () => {
+        mocks.getConfig.mockResolvedValue({ pendingSecureStoreClear: true })
+        mocks.entry('api-token').token = 'stale-1234567'
+
+        const { resolveActiveAccount, NoTokenError } = await import('./auth.js')
+
+        await expect(resolveActiveAccount()).rejects.toBeInstanceOf(NoTokenError)
+    })
+
+    it('probeApiToken surfaces SecureStoreUnavailableError instead of NoTokenError', async () => {
         mocks.getConfig.mockResolvedValue({
-            authMode: 'read-only',
-            authScope: 'user:read',
-            currentWorkspace: 42,
+            configVersion: 2,
+            accounts: [{ id: '111', email: 'a@b.c' }],
         })
+        mocks.secureStoreError = new mocks.MockSecureStoreUnavailableError('keychain locked')
 
         const { probeApiToken } = await import('./auth.js')
 
-        await expect(probeApiToken()).resolves.toEqual({
-            token: 'secure_token_123456',
-            metadata: {
-                authMode: 'read-only',
-                authScope: 'user:read',
-                source: 'secure-store',
-            },
-        })
-        expect(mocks.secureTokenStore.getSecret).toHaveBeenCalled()
-        expect(mocks.setConfig).not.toHaveBeenCalled()
+        await expect(probeApiToken()).rejects.toBeInstanceOf(mocks.MockSecureStoreUnavailableError)
     })
 
-    it('treats pending secure-store clear as logged out and does not reuse stale secure tokens', async () => {
-        mocks.secureTokenStore.deleteSecret.mockResolvedValue(true)
-        mocks.secureTokenStore.getSecret.mockResolvedValue('stale_secure_token_123456')
+    it('getAuthMetadata degrades to unknown when the keyring is offline', async () => {
         mocks.getConfig.mockResolvedValue({
-            pendingSecureStoreClear: true,
-            currentWorkspace: 7,
+            configVersion: 2,
+            accounts: [{ id: '111', email: 'a@b.c' }],
+        })
+        mocks.secureStoreError = new mocks.MockSecureStoreUnavailableError('keychain locked')
+
+        const { getAuthMetadata } = await import('./auth.js')
+
+        await expect(getAuthMetadata()).resolves.toEqual({
+            authMode: 'unknown',
+            source: 'secure-store',
+        })
+    })
+
+    // --- removeAccountById / clearApiToken -----------------------------------
+
+    it('removeAccountById writes config first then deletes secret', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: '111' },
+            accounts: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        mocks.entry('user-111').token = 't1'
+        mocks.entry('user-222').token = 't2'
+
+        const { removeAccountById } = await import('./auth.js')
+
+        await expect(removeAccountById('111')).resolves.toEqual({ storage: 'secure-store' })
+
+        expect(mocks.entry('user-111').token).toBeNull()
+        const written = mocks.setConfig.mock.calls.at(-1)?.[0]
+        expect(written.accounts.map((a: { id: string }) => a.id)).toEqual(['222'])
+        expect(written.account).toBeUndefined()
+    })
+
+    it('removeAccountById fails hard when config write fails — keyring untouched', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: '111' },
+            accounts: [{ id: '111', email: 'a@b.c' }],
+        })
+        mocks.entry('user-111').token = 'preserved'
+        mocks.setConfig.mockRejectedValue(new Error('EACCES'))
+
+        const { removeAccountById } = await import('./auth.js')
+
+        await expect(removeAccountById('111')).rejects.toMatchObject({
+            code: 'CONFIG_WRITE_FAILED',
+        })
+        expect(mocks.entry('user-111').token).toBe('preserved')
+    })
+
+    it('clearApiToken errors when multiple accounts stored and no --user', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            accounts: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
         })
 
-        const { getApiToken } = await import('./auth.js')
+        const { clearApiToken } = await import('./auth.js')
+        const { NoAccountSelectedError } = await import('./accounts.js')
 
-        await expect(getApiToken()).rejects.toThrow('No API token found')
-        expect(mocks.secureTokenStore.deleteSecret).toHaveBeenCalled()
-        expect(mocks.secureTokenStore.getSecret).not.toHaveBeenCalled()
-        expect(mocks.setConfig).toHaveBeenCalledWith({ currentWorkspace: 7 })
+        await expect(clearApiToken()).rejects.toBeInstanceOf(NoAccountSelectedError)
+    })
+
+    it('clearApiToken targets the default account when one is set', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            account: { defaultAccount: '222' },
+            accounts: [
+                { id: '111', email: 'a@b.c' },
+                { id: '222', email: 'd@e.f' },
+            ],
+        })
+        mocks.entry('user-222').token = 't2'
+
+        const { clearApiToken } = await import('./auth.js')
+        await clearApiToken()
+
+        expect(mocks.entry('user-222').token).toBeNull()
+        const written = mocks.setConfig.mock.calls.at(-1)?.[0]
+        expect(written.accounts).toEqual([{ id: '111', email: 'a@b.c' }])
+    })
+
+    // --- setDefaultAccountId --------------------------------------------------
+
+    it('setDefaultAccountId only accepts a stored account', async () => {
+        mocks.getConfig.mockResolvedValue({
+            configVersion: 2,
+            accounts: [{ id: '111', email: 'a@b.c' }],
+        })
+
+        const { setDefaultAccountId } = await import('./auth.js')
+        const { AccountNotFoundError } = await import('./accounts.js')
+
+        await expect(setDefaultAccountId('999')).rejects.toBeInstanceOf(AccountNotFoundError)
+        await setDefaultAccountId('111')
+        const written = mocks.setConfig.mock.calls.at(-1)?.[0]
+        expect(written.account).toEqual({ defaultAccount: '111' })
     })
 })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,11 +1,34 @@
 import { unlink } from 'node:fs/promises'
-import { type AuthMode, type Config, getConfig, getConfigPath, setConfig } from './config.js'
-import { CliError } from './errors.js'
 import {
+    AccountNotFoundError,
+    findAccountByRef,
+    getDefaultAccount,
+    getStoredAccounts,
+    NoAccountSelectedError,
+    removeStoredAccount,
+    setDefaultAccount as setDefaultAccountInConfig,
+    upsertStoredAccount,
+} from './accounts.js'
+import {
+    type AuthMode,
+    type Config,
+    CONFIG_VERSION,
+    getConfig,
+    getConfigPath,
+    setConfig,
+    type StoredAccount,
+} from './config.js'
+import { CliError } from './errors.js'
+import { getRequestedUserRef } from './global-args.js'
+import {
+    accountForUser,
     createSecureStore,
+    LEGACY_ACCOUNT_NAME,
     SECURE_STORE_DESCRIPTION,
     SecureStoreUnavailableError,
 } from './secure-store.js'
+
+export const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
 export class NoTokenError extends CliError {
     constructor() {
@@ -19,7 +42,6 @@ export class NoTokenError extends CliError {
     }
 }
 
-export const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 export type TokenStorageLocation = 'secure-store' | 'config-file'
 
 export interface TokenStorageResult {
@@ -27,21 +49,39 @@ export interface TokenStorageResult {
     warning?: string
 }
 
-export interface SaveApiTokenOptions {
-    authMode?: AuthMode
-    authScope?: string
-}
-
 export interface AuthMetadata {
     authMode: AuthMode
     authScope?: string
-    source: 'env' | 'config'
+    source: 'env' | 'secure-store' | 'config-file'
+    accountId?: string
+    email?: string
+}
+
+export interface ResolvedAccount {
+    id: string
+    email: string
+    name?: string
+    token: string
+    authMode: AuthMode
+    authScope?: string
+    source: AuthMetadata['source']
+}
+
+export interface UpsertAccountInput {
+    id: string
+    email: string
+    name?: string
+    token: string
+    authMode?: AuthMode
+    authScope?: string
 }
 
 export interface AuthProbeMetadata {
     authMode: AuthMode
     authScope?: string
-    source: 'env' | 'config-file' | 'secure-store'
+    source: 'env' | 'secure-store' | 'config-file'
+    accountId?: string
+    email?: string
 }
 
 export interface AuthProbeResult {
@@ -49,212 +89,405 @@ export interface AuthProbeResult {
     metadata: AuthProbeMetadata
 }
 
-export async function getApiToken(): Promise<string> {
-    // Priority 1: Environment variable
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve which stored account this invocation should act as, and load its
+ * token. Honors `--user <ref>`, then `account.defaultAccount`, then a single
+ * stored account.
+ *
+ * Throws `NoAccountSelectedError` when multiple accounts are stored without
+ * a default and no `--user` was passed; `AccountNotFoundError` when `--user`
+ * does not match; `NoTokenError` when no accounts are stored.
+ *
+ * `TWIST_API_TOKEN` short-circuits the resolver entirely — env tokens act as
+ * an anonymous identity for the duration of the command.
+ */
+export async function resolveActiveAccount(opts: { ref?: string } = {}): Promise<ResolvedAccount> {
     const envToken = process.env[TOKEN_ENV_VAR]
     if (envToken) {
-        return envToken
+        return {
+            id: 'env',
+            email: '',
+            token: envToken,
+            authMode: 'unknown',
+            source: 'env',
+        }
     }
 
     const config = await getConfig()
-    const configToken = getConfigToken(config)
-    const secureStore = createSecureStore()
+    const accounts = getStoredAccounts(config)
+    const requestedRef = opts.ref ?? getRequestedUserRef()
 
-    if (configToken) {
-        try {
-            await secureStore.setSecret(configToken)
-            const cleanupWarning = await cleanupAuthFallbackState(
-                config,
-                'Token was migrated to secure storage,',
-            )
-            if (cleanupWarning) {
-                warn(cleanupWarning)
-            }
-        } catch (error) {
-            if (!(error instanceof SecureStoreUnavailableError)) {
-                throw error
-            }
+    // Gate the legacy fallback on the *absence* of `config.accounts` rather
+    // than an empty array. A v2 config that has been logged out
+    // (`accounts: []`) must not silently fall back to a stale `api-token`
+    // keyring entry — that would let a forgotten v1 credential
+    // reauthenticate the next command.
+    const isLegacyShape = !Array.isArray(config.accounts)
+    if (accounts.length === 0) {
+        if (requestedRef) {
+            throw new AccountNotFoundError(requestedRef)
         }
-
-        return configToken
-    }
-
-    if (config.pendingSecureStoreClear) {
-        try {
-            await secureStore.deleteSecret()
-            const cleanupWarning = await cleanupAuthFallbackState(
-                config,
-                'Secure-store token was removed,',
-            )
-            if (cleanupWarning) {
-                warn(cleanupWarning)
-            }
-        } catch (error) {
-            if (!(error instanceof SecureStoreUnavailableError)) {
-                throw error
-            }
+        if (isLegacyShape) {
+            return resolveLegacyToken(config)
         }
-
         throw new NoTokenError()
     }
 
-    try {
-        const storedToken = await secureStore.getSecret()
-        if (storedToken?.trim()) {
-            return storedToken
+    let target: StoredAccount
+    if (requestedRef) {
+        const found = findAccountByRef(config, requestedRef)
+        if (!found) throw new AccountNotFoundError(requestedRef)
+        target = found.account
+    } else if (config.account?.defaultAccount) {
+        const found = findAccountByRef(config, config.account.defaultAccount)
+        if (!found) {
+            // Default points at a missing account — treat like no default.
+            if (accounts.length === 1) {
+                target = accounts[0]
+            } else {
+                throw new NoAccountSelectedError()
+            }
+        } else {
+            target = found.account
         }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
+    } else if (accounts.length === 1) {
+        target = accounts[0]
+    } else {
+        throw new NoAccountSelectedError()
     }
 
-    throw new NoTokenError()
+    const { token, source } = await loadTokenForStoredAccount(target)
+    return {
+        id: target.id,
+        email: target.email,
+        name: target.name,
+        token,
+        authMode: target.authMode ?? 'unknown',
+        authScope: target.authScope,
+        source,
+    }
 }
 
+/**
+ * Backwards-compatible no-arg accessor for the active account's token.
+ * Most call sites only need the bearer string.
+ */
+export async function getApiToken(): Promise<string> {
+    const resolved = await resolveActiveAccount()
+    return resolved.token
+}
+
+/**
+ * Like `resolveActiveAccount` but returns whichever credentials are at hand
+ * without mutating storage. Useful for `tw doctor` / `tw config view` where
+ * we want to inspect (and report on) what would be used. Lets
+ * `SecureStoreUnavailableError` propagate so diagnostics can render the
+ * keyring-broken case distinctly from "no credentials".
+ */
 export async function probeApiToken(): Promise<AuthProbeResult> {
-    const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) {
-        return {
-            token: envToken,
-            metadata: { authMode: 'unknown', source: 'env' },
-        }
-    }
-
-    const config = await getConfig()
-    const configToken = getConfigToken(config)
-    if (configToken) {
-        return {
-            token: configToken,
-            metadata: {
-                authMode: config.authMode ?? 'unknown',
-                authScope: config.authScope,
-                source: 'config-file',
-            },
-        }
-    }
-
-    if (config.pendingSecureStoreClear) {
-        throw new NoTokenError()
-    }
-
-    const secureStore = createSecureStore()
-    try {
-        const storedToken = await secureStore.getSecret()
-        if (storedToken?.trim()) {
-            return {
-                token: storedToken.trim(),
-                metadata: {
-                    authMode: config.authMode ?? 'unknown',
-                    authScope: config.authScope,
-                    source: 'secure-store',
-                },
-            }
-        }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
-        throw error
-    }
-
-    throw new NoTokenError()
+    const resolved = await resolveActiveAccount()
+    return { token: resolved.token, metadata: resolvedToMetadata(resolved) }
 }
 
 export async function getAuthMetadata(): Promise<AuthMetadata> {
-    const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) {
-        return { authMode: 'unknown', source: 'env' }
-    }
-
-    const config = await getConfig()
-    return {
-        authMode: config.authMode ?? 'unknown',
-        authScope: config.authScope,
-        source: 'config',
+    try {
+        const resolved = await resolveActiveAccount()
+        return resolvedToMetadata(resolved)
+    } catch (error) {
+        // Metadata callers (e.g. permission checks) need a sensible default
+        // rather than a hard failure when credentials are missing or the
+        // keyring is offline. Diagnostic commands use `probeApiToken` for
+        // that — it intentionally lets `SecureStoreUnavailableError`
+        // propagate so it can be reported.
+        if (error instanceof NoTokenError || error instanceof SecureStoreUnavailableError) {
+            return { authMode: 'unknown', source: 'secure-store' }
+        }
+        throw error
     }
 }
 
-export async function saveApiToken(
-    token: string,
-    options: SaveApiTokenOptions = {},
-): Promise<TokenStorageResult> {
-    // Validate token (non-empty, reasonable length)
-    if (!token || token.trim().length < 10) {
+/**
+ * Add or update a stored account. Stores the token in the OS credential
+ * manager under `user-<id>` when available, falls back to per-account
+ * plaintext in config. Sets `defaultAccount` automatically when this is the
+ * first account being stored.
+ */
+export async function upsertAccount(
+    input: UpsertAccountInput,
+): Promise<TokenStorageResult & { replaced: boolean }> {
+    if (!input.token || input.token.trim().length < 10) {
         throw new CliError('INVALID_TOKEN', 'Invalid token: Token must be at least 10 characters', [
             'Run: tw auth login',
             'Or set TWIST_API_TOKEN environment variable',
         ])
     }
-
-    const trimmedToken = token.trim()
-    const secureStore = createSecureStore()
-
-    try {
-        await secureStore.setSecret(trimmedToken)
-        const existingConfig = await getConfig()
-        const warning = await cleanupAuthFallbackState(existingConfig, 'Token was stored securely,')
-        // Persist auth metadata to config — needed for ensureWriteAllowed() enforcement
-        try {
-            await saveAuthMetadata(options)
-        } catch {
-            if (options.authMode && options.authMode !== 'unknown') {
-                warn(
-                    `Could not persist auth mode '${options.authMode}' to config. CLI-side write protection may not work in future sessions.`,
-                )
-            }
-        }
-        return warning ? { storage: 'secure-store', warning } : { storage: 'secure-store' }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
+    if (!input.id) {
+        throw new CliError('INVALID_ACCOUNT', 'Cannot store account record: missing id')
+    }
+    if (!input.email) {
+        throw new CliError('INVALID_ACCOUNT', 'Cannot store account record: missing email')
     }
 
+    const trimmedToken = input.token.trim()
     const config = await getConfig()
-    config.token = trimmedToken
-    delete config.pendingSecureStoreClear
-    config.authMode = options.authMode ?? 'unknown'
-    config.authScope = options.authScope
-    await writeConfig(config)
+    const previouslyExisted = getStoredAccounts(config).some((a) => a.id === input.id)
+    // Always default the first stored account, even if `account.defaultAccount`
+    // points at an orphaned id, so a stale pointer can't wedge resolution.
+    const shouldSetDefault = getStoredAccounts(config).length === 0
+
+    const baseRecord: StoredAccount = {
+        id: input.id,
+        email: input.email,
+        name: input.name,
+        authMode: input.authMode,
+        authScope: input.authScope,
+    }
+
+    const secureStore = createSecureStore(accountForUser(input.id))
+    let storedSecurely = false
+    try {
+        await secureStore.setSecret(trimmedToken)
+        storedSecurely = true
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) throw error
+    }
+
+    const accountRecord: StoredAccount = storedSecurely
+        ? baseRecord
+        : { ...baseRecord, token: trimmedToken }
+
+    let next = ensureV2Shape(config)
+    next = upsertStoredAccount(next, accountRecord).config
+    if (shouldSetDefault) {
+        next = setDefaultAccountInConfig(next, input.id)
+    }
+    next = stripLegacyAuthFields(next)
+
+    try {
+        await setConfig(next)
+    } catch (error) {
+        // Config write is the source of truth — without it, later commands
+        // can't resolve the account even though the keyring holds the
+        // secret. Roll back the keyring so we don't leak a credential for
+        // a non-stored account, then surface the failure.
+        if (storedSecurely) {
+            try {
+                await secureStore.deleteSecret()
+            } catch {
+                // best effort — original error is what the user needs
+            }
+        }
+        const detail = error instanceof Error && error.message ? `: ${error.message}` : ''
+        throw new CliError(
+            'CONFIG_WRITE_FAILED',
+            `Could not persist account record to ${getConfigPath()}${detail}`,
+            ['Check file permissions on ~/.config/twist-cli/, then re-run the command'],
+        )
+    }
+
     return {
-        storage: 'config-file',
-        warning: buildFallbackWarning('token saved as plaintext in'),
+        storage: storedSecurely ? 'secure-store' : 'config-file',
+        warning: storedSecurely ? undefined : buildFallbackWarning('token saved as plaintext in'),
+        replaced: previouslyExisted,
     }
 }
 
-export async function clearApiToken(): Promise<TokenStorageResult> {
+/**
+ * Remove the active account (resolved via `--user` or default). For multi-
+ * account installs without a default, callers must pass `--user <ref>` to
+ * disambiguate.
+ */
+export async function clearApiToken(opts: { ref?: string } = {}): Promise<TokenStorageResult> {
     const config = await getConfig()
-    const secureStore = createSecureStore()
+    const accounts = getStoredAccounts(config)
+    const requestedRef = opts.ref ?? getRequestedUserRef()
 
-    // Clear auth metadata from the in-memory config object so all subsequent
-    // writes (cleanupAuthFallbackState, withPendingSecureStoreClear) persist
-    // the removal atomically alongside other state changes.
-    delete config.authMode
-    delete config.authScope
+    // No accounts stored yet — fall through to legacy logout only on a
+    // v1-shaped config (no `accounts` key at all). Empty `accounts: []` is
+    // an already-clean v2 install; treat as a no-op rather than poking the
+    // legacy keyring.
+    if (accounts.length === 0) {
+        if (!Array.isArray(config.accounts)) {
+            return clearLegacyToken(config)
+        }
+        if (requestedRef) {
+            throw new AccountNotFoundError(requestedRef)
+        }
+        throw new NoTokenError()
+    }
 
-    try {
-        await secureStore.deleteSecret()
-        const warning = await cleanupAuthFallbackState(config, 'Secure-store token was removed,')
-        return warning ? { storage: 'secure-store', warning } : { storage: 'secure-store' }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
+    let target: StoredAccount
+    if (requestedRef) {
+        const found = findAccountByRef(config, requestedRef)
+        if (!found) throw new AccountNotFoundError(requestedRef)
+        target = found.account
+    } else {
+        const def = getDefaultAccount(config)
+        if (def) {
+            target = def
+        } else if (accounts.length === 1) {
+            target = accounts[0]
+        } else {
+            throw new NoAccountSelectedError()
         }
     }
 
-    await writeConfig(withPendingSecureStoreClear(config))
+    return removeAccountById(target.id)
+}
+
+/**
+ * Remove a specific account by id. Used by `tw account remove` and as the
+ * primitive for `clearApiToken`.
+ *
+ * Order matters: write the new config first (the source of truth) and only
+ * then delete the secret. If the config update fails the keyring is
+ * untouched, so the account remains fully functional and a retry will
+ * simply re-attempt the same operation. A keyring delete failure after a
+ * successful config update leaves an orphan secret that the keyring's own
+ * service can clean up later — the CLI no longer references it.
+ */
+export async function removeAccountById(id: string): Promise<TokenStorageResult> {
+    const config = await getConfig()
+    const next = stripLegacyAuthFields(removeStoredAccount(ensureV2Shape(config), id))
+
+    try {
+        await setConfig(next)
+    } catch (error) {
+        const detail = error instanceof Error && error.message ? `: ${error.message}` : ''
+        throw new CliError('CONFIG_WRITE_FAILED', `Could not update ${getConfigPath()}${detail}`, [
+            'Check file permissions on ~/.config/twist-cli/, then re-run the command',
+        ])
+    }
+
+    const secureStore = createSecureStore(accountForUser(id))
+    try {
+        await secureStore.deleteSecret()
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) throw error
+        return {
+            storage: 'config-file',
+            warning: buildFallbackWarning('local auth state cleared in'),
+        }
+    }
+
+    return { storage: 'secure-store' }
+}
+
+export async function setDefaultAccountId(id: string): Promise<void> {
+    const config = ensureV2Shape(await getConfig())
+    const found = findAccountByRef(config, id)
+    if (!found) throw new AccountNotFoundError(id)
+    await setConfig(stripLegacyAuthFields(setDefaultAccountInConfig(config, found.account.id)))
+}
+
+export async function listStoredAccounts(): Promise<StoredAccount[]> {
+    const config = await getConfig()
+    return getStoredAccounts(config)
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function loadTokenForStoredAccount(
+    account: StoredAccount,
+): Promise<{ token: string; source: 'secure-store' | 'config-file' }> {
+    if (account.token?.trim()) {
+        return { token: account.token.trim(), source: 'config-file' }
+    }
+    const secureStore = createSecureStore(accountForUser(account.id))
+    // Re-throw `SecureStoreUnavailableError` rather than collapsing it into
+    // `NoTokenError`. A stored v2 account with the keyring offline is *not*
+    // the same situation as no credentials at all — diagnostic commands
+    // should report the keyring failure rather than say the account has no
+    // saved credentials.
+    const stored = await secureStore.getSecret()
+    if (stored?.trim()) {
+        return { token: stored.trim(), source: 'secure-store' }
+    }
+    throw new NoTokenError()
+}
+
+/**
+ * v1 fallback: when there are no v2 accounts in the config, see if a legacy
+ * single-user token is present (config plaintext or legacy `api-token`
+ * keyring entry). Returns it as a synthetic ResolvedAccount so the CLI
+ * keeps working until postinstall (or `tw auth login`) migrates the install.
+ */
+async function resolveLegacyToken(config: Config): Promise<ResolvedAccount> {
+    const legacyToken = typeof config.token === 'string' ? config.token.trim() : ''
+    if (legacyToken) {
+        return {
+            id: 'legacy',
+            email: '',
+            token: legacyToken,
+            authMode: config.authMode ?? 'unknown',
+            authScope: config.authScope,
+            source: 'config-file',
+        }
+    }
+
+    if (config.pendingSecureStoreClear) {
+        // v1 logout state: nothing to restore.
+        throw new NoTokenError()
+    }
+
+    const secureStore = createSecureStore(LEGACY_ACCOUNT_NAME)
+    try {
+        const stored = await secureStore.getSecret()
+        if (stored?.trim()) {
+            return {
+                id: 'legacy',
+                email: '',
+                token: stored.trim(),
+                authMode: config.authMode ?? 'unknown',
+                authScope: config.authScope,
+                source: 'secure-store',
+            }
+        }
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) throw error
+    }
+
+    throw new NoTokenError()
+}
+
+async function clearLegacyToken(config: Config): Promise<TokenStorageResult> {
+    const secureStore = createSecureStore(LEGACY_ACCOUNT_NAME)
+
+    try {
+        await secureStore.deleteSecret()
+        const cleaned = stripLegacyAuthFields(config)
+        try {
+            await writeConfig(cleaned)
+        } catch (error) {
+            return {
+                storage: 'secure-store',
+                warning: buildConfigCleanupWarning('Secure-store token was removed,', error),
+            }
+        }
+        return { storage: 'secure-store' }
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) throw error
+    }
+
+    const cleared: Config = {
+        ...stripLegacyAuthFields(config),
+        pendingSecureStoreClear: true,
+    }
+    try {
+        await writeConfig(cleared)
+    } catch {
+        // best effort
+    }
     return {
         storage: 'config-file',
         warning: buildFallbackWarning('local auth state cleared in'),
     }
-}
-
-async function saveAuthMetadata(options: SaveApiTokenOptions): Promise<void> {
-    const config = await getConfig()
-    config.authMode = options.authMode ?? 'unknown'
-    config.authScope = options.authScope
-    await setConfig(config)
 }
 
 async function writeConfig(config: Config): Promise<void> {
@@ -262,39 +495,34 @@ async function writeConfig(config: Config): Promise<void> {
         try {
             await unlink(getConfigPath())
         } catch (error) {
-            if (!isMissingFileError(error)) {
-                throw error
-            }
+            if (!isMissingFileError(error)) throw error
         }
         return
     }
-
     await setConfig(config)
 }
 
-async function cleanupAuthFallbackState(
-    config: Config,
-    warningPrefix: string,
-): Promise<string | undefined> {
-    try {
-        await writeConfig(withoutAuthFallbackState(config))
-        return undefined
-    } catch (error) {
-        return buildConfigCleanupWarning(warningPrefix, error)
+function ensureV2Shape(config: Config): Config {
+    const next: Config = { ...config, configVersion: CONFIG_VERSION }
+    if (!Array.isArray(next.accounts)) {
+        next.accounts = []
     }
+    return next
 }
 
-function getConfigToken(config: Config): string | null {
-    return typeof config.token === 'string' && config.token.trim() ? config.token.trim() : null
-}
-
-function withoutAuthFallbackState(config: Config): Config {
-    const { token: _token, pendingSecureStoreClear: _pending, ...rest } = config
+function stripLegacyAuthFields(config: Config): Config {
+    const { token: _t, authMode: _m, authScope: _s, pendingSecureStoreClear: _p, ...rest } = config
     return rest
 }
 
-function withPendingSecureStoreClear(config: Config): Config {
-    return { ...withoutAuthFallbackState(config), pendingSecureStoreClear: true }
+function resolvedToMetadata(resolved: ResolvedAccount): AuthMetadata {
+    return {
+        authMode: resolved.authMode,
+        authScope: resolved.authScope,
+        source: resolved.source,
+        accountId: resolved.id === 'env' || resolved.id === 'legacy' ? undefined : resolved.id,
+        email: resolved.email || undefined,
+    }
 }
 
 function buildFallbackWarning(action: string): string {
@@ -303,13 +531,9 @@ function buildFallbackWarning(action: string): string {
 
 function buildConfigCleanupWarning(prefix: string, error: unknown): string {
     const detail = error instanceof Error && error.message ? ` (${error.message})` : ''
-    return `${prefix} but could not remove legacy plaintext token from ${getConfigPath()}${detail}`
+    return `${prefix} but could not update ${getConfigPath()}${detail}`
 }
 
 function isMissingFileError(error: unknown): boolean {
     return error instanceof Error && 'code' in error && error.code === 'ENOENT'
-}
-
-function warn(message: string): void {
-    console.error(`Warning: ${message}`)
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,7 +19,6 @@ import {
     type StoredAccount,
 } from './config.js'
 import { CliError } from './errors.js'
-import { getRequestedUserRef } from './global-args.js'
 import {
     accountForUser,
     createSecureStore,
@@ -57,14 +56,25 @@ export interface AuthMetadata {
     email?: string
 }
 
+/**
+ * The account whose token will be used for the current command.
+ *
+ * `id` and `email` are present only for stored v2 accounts. Env-token and
+ * legacy v1 fallback flows leave them unset (they don't represent a real
+ * account record). Use `source` / the `legacy` flag to distinguish:
+ *  - `source: 'env'` — `TWIST_API_TOKEN` is in scope
+ *  - `legacy: true` — v1 single-user fallback (no v2 record yet)
+ *  - otherwise — a stored v2 account (`id` and `email` are guaranteed)
+ */
 export interface ResolvedAccount {
-    id: string
-    email: string
+    id?: string
+    email?: string
     name?: string
     token: string
     authMode: AuthMode
     authScope?: string
     source: AuthMetadata['source']
+    legacy?: boolean
 }
 
 export interface UpsertAccountInput {
@@ -109,8 +119,6 @@ export async function resolveActiveAccount(opts: { ref?: string } = {}): Promise
     const envToken = process.env[TOKEN_ENV_VAR]
     if (envToken) {
         return {
-            id: 'env',
-            email: '',
             token: envToken,
             authMode: 'unknown',
             source: 'env',
@@ -118,58 +126,56 @@ export async function resolveActiveAccount(opts: { ref?: string } = {}): Promise
     }
 
     const config = await getConfig()
-    const accounts = getStoredAccounts(config)
-    const requestedRef = opts.ref ?? getRequestedUserRef()
+    const target = resolveTargetAccount(config, opts.ref)
+    if (target.kind === 'legacy') {
+        return resolveLegacyToken(config)
+    }
 
-    // Gate the legacy fallback on the *absence* of `config.accounts` rather
-    // than an empty array. A v2 config that has been logged out
-    // (`accounts: []`) must not silently fall back to a stale `api-token`
-    // keyring entry — that would let a forgotten v1 credential
-    // reauthenticate the next command.
+    const { token, source } = await loadTokenForStoredAccount(target.account)
+    return {
+        id: target.account.id,
+        email: target.account.email,
+        name: target.account.name,
+        token,
+        authMode: target.account.authMode ?? 'unknown',
+        authScope: target.account.authScope,
+        source,
+    }
+}
+
+type TargetAccountResult = { kind: 'stored'; account: StoredAccount } | { kind: 'legacy' }
+
+/**
+ * Pick the account record this invocation should act on. Shared between
+ * `resolveActiveAccount` (read path) and `clearApiToken` (write path) so the
+ * `--user` / default / single-account / legacy fallback rules stay in lockstep.
+ *
+ * Returns `{ kind: 'legacy' }` only when the config has no `accounts` key at
+ * all (a v1-shaped install). An empty `accounts: []` is treated as a clean v2
+ * state; callers should surface `NoTokenError` rather than poking the legacy
+ * keyring.
+ */
+function resolveTargetAccount(config: Config, requestedRef?: string): TargetAccountResult {
+    const accounts = getStoredAccounts(config)
     const isLegacyShape = !Array.isArray(config.accounts)
+
     if (accounts.length === 0) {
-        if (requestedRef) {
-            throw new AccountNotFoundError(requestedRef)
-        }
-        if (isLegacyShape) {
-            return resolveLegacyToken(config)
-        }
+        if (requestedRef) throw new AccountNotFoundError(requestedRef)
+        if (isLegacyShape) return { kind: 'legacy' }
         throw new NoTokenError()
     }
 
-    let target: StoredAccount
     if (requestedRef) {
         const found = findAccountByRef(config, requestedRef)
         if (!found) throw new AccountNotFoundError(requestedRef)
-        target = found.account
-    } else if (config.account?.defaultAccount) {
-        const found = findAccountByRef(config, config.account.defaultAccount)
-        if (!found) {
-            // Default points at a missing account — treat like no default.
-            if (accounts.length === 1) {
-                target = accounts[0]
-            } else {
-                throw new NoAccountSelectedError()
-            }
-        } else {
-            target = found.account
-        }
-    } else if (accounts.length === 1) {
-        target = accounts[0]
-    } else {
-        throw new NoAccountSelectedError()
+        return { kind: 'stored', account: found.account }
     }
 
-    const { token, source } = await loadTokenForStoredAccount(target)
-    return {
-        id: target.id,
-        email: target.email,
-        name: target.name,
-        token,
-        authMode: target.authMode ?? 'unknown',
-        authScope: target.authScope,
-        source,
-    }
+    const def = getDefaultAccount(config)
+    if (def) return { kind: 'stored', account: def }
+
+    if (accounts.length === 1) return { kind: 'stored', account: accounts[0] }
+    throw new NoAccountSelectedError()
 }
 
 /**
@@ -271,10 +277,15 @@ export async function upsertAccount(
         await setConfig(next)
     } catch (error) {
         // Config write is the source of truth — without it, later commands
-        // can't resolve the account even though the keyring holds the
-        // secret. Roll back the keyring so we don't leak a credential for
-        // a non-stored account, then surface the failure.
-        if (storedSecurely) {
+        // can't resolve a brand-new account even though the keyring holds
+        // the secret. For *new* accounts, roll the keyring back so we don't
+        // leak a credential nothing references.
+        //
+        // For an existing account being re-authenticated, the unmodified
+        // config still points at the same `user-<id>` slot, so leaving the
+        // new token in place keeps the user authenticated — destroying it
+        // would be the more damaging outcome of a transient write failure.
+        if (storedSecurely && !previouslyExisted) {
             try {
                 await secureStore.deleteSecret()
             } catch {
@@ -303,40 +314,17 @@ export async function upsertAccount(
  */
 export async function clearApiToken(opts: { ref?: string } = {}): Promise<TokenStorageResult> {
     const config = await getConfig()
-    const accounts = getStoredAccounts(config)
-    const requestedRef = opts.ref ?? getRequestedUserRef()
+    const target = resolveTargetAccount(config, opts.ref)
 
-    // No accounts stored yet — fall through to legacy logout only on a
-    // v1-shaped config (no `accounts` key at all). Empty `accounts: []` is
-    // an already-clean v2 install; treat as a no-op rather than poking the
-    // legacy keyring.
-    if (accounts.length === 0) {
-        if (!Array.isArray(config.accounts)) {
-            return clearLegacyToken(config)
-        }
-        if (requestedRef) {
-            throw new AccountNotFoundError(requestedRef)
-        }
-        throw new NoTokenError()
+    if (target.kind === 'legacy') {
+        // `--user <ref>` against a v1-shaped install — we don't know what
+        // identity the legacy token represents, so refuse to log it out under
+        // the new exact-match contract.
+        if (opts.ref) throw new AccountNotFoundError(opts.ref)
+        return clearLegacyToken(config)
     }
 
-    let target: StoredAccount
-    if (requestedRef) {
-        const found = findAccountByRef(config, requestedRef)
-        if (!found) throw new AccountNotFoundError(requestedRef)
-        target = found.account
-    } else {
-        const def = getDefaultAccount(config)
-        if (def) {
-            target = def
-        } else if (accounts.length === 1) {
-            target = accounts[0]
-        } else {
-            throw new NoAccountSelectedError()
-        }
-    }
-
-    return removeAccountById(target.id)
+    return removeAccountById(target.account.id)
 }
 
 /**
@@ -377,11 +365,16 @@ export async function removeAccountById(id: string): Promise<TokenStorageResult>
     return { storage: 'secure-store' }
 }
 
-export async function setDefaultAccountId(id: string): Promise<void> {
+/**
+ * Set the default account, looked up by id or email. Returns the resolved
+ * account so callers can show "switched to <email>" without re-resolving.
+ */
+export async function setDefaultAccountId(ref: string): Promise<StoredAccount> {
     const config = ensureV2Shape(await getConfig())
-    const found = findAccountByRef(config, id)
-    if (!found) throw new AccountNotFoundError(id)
+    const found = findAccountByRef(config, ref)
+    if (!found) throw new AccountNotFoundError(ref)
     await setConfig(stripLegacyAuthFields(setDefaultAccountInConfig(config, found.account.id)))
+    return found.account
 }
 
 export async function listStoredAccounts(): Promise<StoredAccount[]> {
@@ -422,12 +415,11 @@ async function resolveLegacyToken(config: Config): Promise<ResolvedAccount> {
     const legacyToken = typeof config.token === 'string' ? config.token.trim() : ''
     if (legacyToken) {
         return {
-            id: 'legacy',
-            email: '',
             token: legacyToken,
             authMode: config.authMode ?? 'unknown',
             authScope: config.authScope,
             source: 'config-file',
+            legacy: true,
         }
     }
 
@@ -441,12 +433,11 @@ async function resolveLegacyToken(config: Config): Promise<ResolvedAccount> {
         const stored = await secureStore.getSecret()
         if (stored?.trim()) {
             return {
-                id: 'legacy',
-                email: '',
                 token: stored.trim(),
                 authMode: config.authMode ?? 'unknown',
                 authScope: config.authScope,
                 source: 'secure-store',
+                legacy: true,
             }
         }
     } catch (error) {
@@ -520,8 +511,8 @@ function resolvedToMetadata(resolved: ResolvedAccount): AuthMetadata {
         authMode: resolved.authMode,
         authScope: resolved.authScope,
         source: resolved.source,
-        accountId: resolved.id === 'env' || resolved.id === 'legacy' ? undefined : resolved.id,
-        email: resolved.email || undefined,
+        accountId: resolved.id,
+        email: resolved.email,
     }
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,17 +8,33 @@ export const CONFIG_PATH = join(homedir(), '.config', 'twist-cli', 'config.json'
 export type AuthMode = 'read-only' | 'read-write' | 'unknown'
 export type UpdateChannel = 'stable' | 'pre-release'
 
+export const CONFIG_VERSION = 2 as const
+
 const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
-    'token',
-    'pendingSecureStoreClear',
+    'configVersion',
+    'account',
+    'accounts',
     'currentWorkspace',
-    'authMode',
-    'authScope',
     'updateChannel',
     'userSettings',
+    // Legacy v1 keys — tolerated until migration runs (postinstall + lazy fallback).
+    'token',
+    'pendingSecureStoreClear',
+    'authMode',
+    'authScope',
 ])
 
 const KNOWN_USER_SETTINGS_KEYS: ReadonlySet<string> = new Set(['unarchiveNewThreads'])
+const KNOWN_ACCOUNT_CONFIG_KEYS: ReadonlySet<string> = new Set(['defaultAccount'])
+const KNOWN_STORED_ACCOUNT_KEYS: ReadonlySet<string> = new Set([
+    'id',
+    'email',
+    'name',
+    'authMode',
+    'authScope',
+    'token',
+    'pendingSecureStoreClear',
+])
 
 const AUTH_MODES: ReadonlySet<AuthMode> = new Set(['read-only', 'read-write', 'unknown'])
 const UPDATE_CHANNELS: ReadonlySet<UpdateChannel> = new Set(['stable', 'pre-release'])
@@ -27,17 +43,44 @@ export interface UserSettings {
     unarchiveNewThreads?: boolean
 }
 
-export interface Config {
-    // Legacy plaintext token storage retained for migration and secure-store fallback only.
-    token?: string
-    // Non-secret state used to finish logout after transient secure-store failures.
-    pendingSecureStoreClear?: boolean
-    currentWorkspace?: number
-    // Auth metadata persisted alongside the token to track OAuth scope.
+export interface AccountConfig {
+    /** Twist user id of the default account, used when --user is not given. */
+    defaultAccount?: string
+}
+
+/**
+ * Per-account record stored in `config.accounts`. Each entry represents one
+ * authenticated Twist user identity. The token itself lives in the OS
+ * credential manager under account `user-<id>`; `token` only appears here
+ * when the credential manager was unavailable at save time (plaintext fallback).
+ */
+export interface StoredAccount {
+    id: string
+    email: string
+    name?: string
     authMode?: AuthMode
     authScope?: string
+    token?: string
+    pendingSecureStoreClear?: boolean
+}
+
+export interface Config {
+    /** Schema marker — present on v2+ configs. Absent on legacy v1 installs. */
+    configVersion?: number
+    /** Selection state — which stored account is the default. */
+    account?: AccountConfig
+    /** All authenticated Twist accounts. */
+    accounts?: StoredAccount[]
+
+    currentWorkspace?: number
     updateChannel?: UpdateChannel
     userSettings?: UserSettings
+
+    // ---- Legacy v1 fields, read for one-time migration ----
+    token?: string
+    pendingSecureStoreClear?: boolean
+    authMode?: AuthMode
+    authScope?: string
 }
 
 export async function getConfig(): Promise<Config> {
@@ -122,6 +165,77 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
         }
     }
 
+    if (
+        config.configVersion !== undefined &&
+        (typeof config.configVersion !== 'number' || config.configVersion < 1)
+    ) {
+        issues.push('configVersion must be a positive number')
+    }
+
+    if (config.account !== undefined) {
+        if (!isObject(config.account)) {
+            issues.push('account must be an object')
+        } else {
+            for (const key of Object.keys(config.account)) {
+                if (!KNOWN_ACCOUNT_CONFIG_KEYS.has(key)) {
+                    issues.push(`account contains unrecognized key "${key}"`)
+                }
+            }
+            const defaultAccount = (config.account as Record<string, unknown>).defaultAccount
+            if (defaultAccount !== undefined && typeof defaultAccount !== 'string') {
+                issues.push('account.defaultAccount must be a string')
+            }
+        }
+    }
+
+    if (config.accounts !== undefined) {
+        if (!Array.isArray(config.accounts)) {
+            issues.push('accounts must be an array')
+        } else {
+            for (const [i, entry] of config.accounts.entries()) {
+                if (!isObject(entry)) {
+                    issues.push(`accounts[${i}] must be an object`)
+                    continue
+                }
+                for (const key of Object.keys(entry)) {
+                    if (!KNOWN_STORED_ACCOUNT_KEYS.has(key)) {
+                        issues.push(`accounts[${i}] contains unrecognized key "${key}"`)
+                    }
+                }
+                if (typeof entry.id !== 'string' || !entry.id) {
+                    issues.push(`accounts[${i}].id must be a non-empty string`)
+                }
+                if (typeof entry.email !== 'string' || !entry.email) {
+                    issues.push(`accounts[${i}].email must be a non-empty string`)
+                }
+                if (entry.name !== undefined && typeof entry.name !== 'string') {
+                    issues.push(`accounts[${i}].name must be a string`)
+                }
+                if (
+                    entry.authMode !== undefined &&
+                    (typeof entry.authMode !== 'string' ||
+                        !AUTH_MODES.has(entry.authMode as AuthMode))
+                ) {
+                    issues.push(
+                        `accounts[${i}].authMode must be one of: read-only, read-write, unknown`,
+                    )
+                }
+                if (entry.authScope !== undefined && typeof entry.authScope !== 'string') {
+                    issues.push(`accounts[${i}].authScope must be a string`)
+                }
+                if (entry.token !== undefined && typeof entry.token !== 'string') {
+                    issues.push(`accounts[${i}].token must be a string`)
+                }
+                if (
+                    entry.pendingSecureStoreClear !== undefined &&
+                    typeof entry.pendingSecureStoreClear !== 'boolean'
+                ) {
+                    issues.push(`accounts[${i}].pendingSecureStoreClear must be a boolean`)
+                }
+            }
+        }
+    }
+
     if (config.token !== undefined && typeof config.token !== 'string') {
         issues.push('token must be a string')
     }
@@ -161,11 +275,7 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
 
     if (config.userSettings !== undefined) {
         const userSettings = config.userSettings
-        if (
-            userSettings === null ||
-            typeof userSettings !== 'object' ||
-            Array.isArray(userSettings)
-        ) {
+        if (!isObject(userSettings)) {
             issues.push('userSettings must be an object')
         } else {
             const settingsRecord = userSettings as Record<string, unknown>
@@ -184,6 +294,10 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
     }
 
     return issues
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
 export function getConfigPath(): string {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,7 +14,6 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     'configVersion',
     'account',
     'accounts',
-    'currentWorkspace',
     'updateChannel',
     'userSettings',
     // Legacy v1 keys — tolerated until migration runs (postinstall + lazy fallback).
@@ -22,6 +21,7 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     'pendingSecureStoreClear',
     'authMode',
     'authScope',
+    'currentWorkspace',
 ])
 
 const KNOWN_USER_SETTINGS_KEYS: ReadonlySet<string> = new Set(['unarchiveNewThreads'])
@@ -34,6 +34,7 @@ const KNOWN_STORED_ACCOUNT_KEYS: ReadonlySet<string> = new Set([
     'authScope',
     'token',
     'pendingSecureStoreClear',
+    'currentWorkspace',
 ])
 
 const AUTH_MODES: ReadonlySet<AuthMode> = new Set(['read-only', 'read-write', 'unknown'])
@@ -62,6 +63,12 @@ export interface StoredAccount {
     authScope?: string
     token?: string
     pendingSecureStoreClear?: boolean
+    /**
+     * Twist workspace id this account is currently scoped to. Per-account so
+     * that `tw --user <other> ...` doesn't try to use the previous account's
+     * workspace (which the other account may not be a member of).
+     */
+    currentWorkspace?: number
 }
 
 export interface Config {
@@ -72,7 +79,6 @@ export interface Config {
     /** All authenticated Twist accounts. */
     accounts?: StoredAccount[]
 
-    currentWorkspace?: number
     updateChannel?: UpdateChannel
     userSettings?: UserSettings
 
@@ -81,6 +87,12 @@ export interface Config {
     pendingSecureStoreClear?: boolean
     authMode?: AuthMode
     authScope?: string
+    /**
+     * Legacy: pre-multi-account installs stored a single workspace id at the
+     * top level. Migrated onto the default account on first read; never
+     * written by current code.
+     */
+    currentWorkspace?: number
 }
 
 export async function getConfig(): Promise<Config> {
@@ -231,6 +243,13 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
                     typeof entry.pendingSecureStoreClear !== 'boolean'
                 ) {
                     issues.push(`accounts[${i}].pendingSecureStoreClear must be a boolean`)
+                }
+                if (
+                    entry.currentWorkspace !== undefined &&
+                    (!Number.isInteger(entry.currentWorkspace) ||
+                        Number(entry.currentWorkspace) <= 0)
+                ) {
+                    issues.push(`accounts[${i}].currentWorkspace must be a positive integer`)
                 }
             }
         }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -5,11 +5,16 @@
  */
 export type ErrorCode =
     // Auth & permissions
+    | 'ACCOUNT_NOT_FOUND'
     | 'AUTH_FAILED'
+    | 'CONFIG_WRITE_FAILED'
     | 'INSUFFICIENT_SCOPE'
+    | 'INVALID_ACCOUNT'
     | 'INVALID_TOKEN'
+    | 'NO_ACCOUNT_SELECTED'
     | 'NO_TOKEN'
     | 'READ_ONLY'
+    | 'USER_FLAG_INVALID'
     // Validation
     | 'CONFLICTING_OPTIONS'
     | 'INVALID_CURSOR'
@@ -17,6 +22,7 @@ export type ErrorCode =
     | 'INVALID_ID'
     | 'INVALID_MINUTES'
     | 'INVALID_REF'
+    | 'MISSING_REF'
     | 'INVALID_SCOPE'
     | 'INVALID_STATE'
     | 'INVALID_TYPE'

--- a/src/lib/global-args.test.ts
+++ b/src/lib/global-args.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+    getRequestedUserRef,
     includePrivateChannels,
     isAccessible,
     isNonInteractive,
@@ -7,6 +8,7 @@ import {
     parseGlobalArgs,
     resetGlobalArgs,
     shouldDisableSpinner,
+    stripUserFlag,
 } from './global-args.js'
 
 describe('parseGlobalArgs', () => {
@@ -53,7 +55,55 @@ describe('parseGlobalArgs', () => {
                 accessible: false,
                 nonInteractive: false,
                 interactive: false,
+                user: undefined,
             })
+        })
+    })
+
+    describe('--user', () => {
+        it('parses --user <ref>', () => {
+            expect(parseGlobalArgs(['--user', 'me@example.com']).user).toBe('me@example.com')
+        })
+        it('parses --user=<ref>', () => {
+            expect(parseGlobalArgs(['--user=12345']).user).toBe('12345')
+        })
+        it('handles --user mid-argv', () => {
+            const result = parseGlobalArgs(['inbox', '--user', 'a@b.c', '--json'])
+            expect(result.user).toBe('a@b.c')
+            expect(result.json).toBe(true)
+        })
+        it('does not consume the next arg as a value when it looks like a flag', () => {
+            // `tw --user --json …` should leave `result.user` undefined and
+            // keep --json intact, so commander surfaces a usage error.
+            const result = parseGlobalArgs(['--user', '--json', 'inbox'])
+            expect(result.user).toBeUndefined()
+            expect(result.json).toBe(true)
+        })
+        it('leaves --user at end of argv as undefined', () => {
+            expect(parseGlobalArgs(['inbox', '--user']).user).toBeUndefined()
+        })
+    })
+
+    describe('stripUserFlag', () => {
+        it('removes --user <value>', () => {
+            expect(stripUserFlag(['inbox', '--user', 'a@b.c', '--json'])).toEqual([
+                'inbox',
+                '--json',
+            ])
+        })
+        it('removes --user=<value>', () => {
+            expect(stripUserFlag(['--user=12345', 'inbox'])).toEqual(['inbox'])
+        })
+        it('does not strip the next arg when it looks like a flag', () => {
+            expect(stripUserFlag(['--user', '--json', 'inbox'])).toEqual(['--json', 'inbox'])
+        })
+        it('preserves args after --', () => {
+            expect(stripUserFlag(['inbox', '--', '--user', 'x'])).toEqual([
+                'inbox',
+                '--',
+                '--user',
+                'x',
+            ])
         })
     })
 
@@ -122,6 +172,12 @@ describe('cached singleton', () => {
         resetGlobalArgs()
         process.argv = ['node', 'tw', '--progress-jsonl']
         expect(isProgressJsonlEnabled()).toBe(true)
+    })
+
+    it('getRequestedUserRef returns the parsed --user value', () => {
+        resetGlobalArgs()
+        process.argv = ['node', 'tw', 'inbox', '--user', 'me@example.com']
+        expect(getRequestedUserRef()).toBe('me@example.com')
     })
 })
 

--- a/src/lib/global-args.test.ts
+++ b/src/lib/global-args.test.ts
@@ -9,6 +9,7 @@ import {
     resetGlobalArgs,
     shouldDisableSpinner,
     stripUserFlag,
+    validateUserFlag,
 } from './global-args.js'
 
 describe('parseGlobalArgs', () => {
@@ -81,6 +82,66 @@ describe('parseGlobalArgs', () => {
         })
         it('leaves --user at end of argv as undefined', () => {
             expect(parseGlobalArgs(['inbox', '--user']).user).toBeUndefined()
+        })
+    })
+
+    describe('validateUserFlag', () => {
+        const known = new Set(['inbox', 'thread', 'channel', 'account'])
+
+        it('returns ok with undefined ref when --user is not present', () => {
+            expect(validateUserFlag(['inbox'], known)).toEqual({ ok: true, ref: undefined })
+        })
+
+        it('returns ok with the ref for --user <ref>', () => {
+            expect(validateUserFlag(['--user', 'me@example.com', 'inbox'], known)).toEqual({
+                ok: true,
+                ref: 'me@example.com',
+            })
+        })
+
+        it('returns ok with the ref for --user=<ref>', () => {
+            expect(validateUserFlag(['--user=12345', 'inbox'], known)).toEqual({
+                ok: true,
+                ref: '12345',
+            })
+        })
+
+        it('rejects bare --user with no value', () => {
+            const result = validateUserFlag(['--user'], known)
+            expect(result.ok).toBe(false)
+            if (result.ok) throw new Error('expected failure')
+            expect(result.message).toContain('--user requires a value')
+        })
+
+        it('rejects --user= with empty value', () => {
+            const result = validateUserFlag(['--user=', 'inbox'], known)
+            expect(result.ok).toBe(false)
+            if (result.ok) throw new Error('expected failure')
+            expect(result.message).toContain('--user requires a value')
+        })
+
+        it('rejects --user followed by another flag (--user --json)', () => {
+            const result = validateUserFlag(['--user', '--json', 'inbox'], known)
+            expect(result.ok).toBe(false)
+            if (result.ok) throw new Error('expected failure')
+            expect(result.message).toContain('--user requires a value')
+        })
+
+        it('rejects --user followed by a known subcommand and hints with the subcommand name', () => {
+            const result = validateUserFlag(['--user', 'inbox'], known)
+            expect(result.ok).toBe(false)
+            if (result.ok) throw new Error('expected failure')
+            expect(result.message).toContain('looks like a subcommand')
+            expect(result.hints[0]).toContain('inbox')
+        })
+
+        it('ignores --user tokens after the -- terminator', () => {
+            // `tw msg send -- --user=bot` is positional content, not a global
+            // flag. Verifies the bug fix.
+            expect(validateUserFlag(['msg', 'send', '--', '--user=bot'], known)).toEqual({
+                ok: true,
+                ref: undefined,
+            })
         })
     })
 

--- a/src/lib/global-args.ts
+++ b/src/lib/global-args.ts
@@ -28,9 +28,15 @@ export interface GlobalArgs {
  *
  * Pure function — pass an explicit array for testing, or omit to use
  * `process.argv`.
+ *
+ * Honors the `--` terminator: anything after it is treated as positional and
+ * ignored by global-flag detection (so `tw msg send -- --user=bot` does not
+ * misroute as account selection).
  */
 export function parseGlobalArgs(argv?: string[]): GlobalArgs {
-    const args = argv ?? process.argv
+    const fullArgs = argv ?? process.argv
+    const terminatorIndex = fullArgs.indexOf('--')
+    const args = terminatorIndex === -1 ? fullArgs : fullArgs.slice(0, terminatorIndex)
 
     const has = (flag: string) =>
         args.includes(flag) || args.some((arg) => arg.startsWith(`${flag}=`))
@@ -51,8 +57,9 @@ export function parseGlobalArgs(argv?: string[]): GlobalArgs {
         }
     }
 
-    // --user <ref> | --user=<ref> | --user (no value — left undefined so
-    // index.ts can surface a clear usage error before commander runs).
+    // --user <ref> | --user=<ref> | --user (no value — left undefined so the
+    // pre-parse validator can surface a clear usage error before commander
+    // runs).
     let user: string | undefined
     const userIndices = args
         .map((arg, index) => ({ arg, index }))
@@ -81,6 +88,49 @@ export function parseGlobalArgs(argv?: string[]): GlobalArgs {
         interactive: has('--interactive'),
         user,
     }
+}
+
+/**
+ * Validate the `--user` flag from an argv slice. Single source of truth for
+ * the pre-Commander validation in `src/index.ts`.
+ *
+ * Returns:
+ *  - `{ ok: true, ref }` — valid value (possibly undefined when --user wasn't passed)
+ *  - `{ ok: false, message, hints }` — invalid; caller should raise CliError
+ *
+ * `knownCommands` lets the validator catch the common typo
+ * `tw --user list` (forgot the value, list looks like a subcommand). Pass the
+ * full set of subcommand names + aliases.
+ */
+export type UserFlagValidation =
+    | { ok: true; ref: string | undefined }
+    | { ok: false; message: string; hints: string[] }
+
+export function validateUserFlag(
+    argv: string[],
+    knownCommands: ReadonlySet<string>,
+): UserFlagValidation {
+    const terminatorIndex = argv.indexOf('--')
+    const scanRange = terminatorIndex === -1 ? argv : argv.slice(0, terminatorIndex)
+    const sawUserFlag = scanRange.some((a) => a === '--user' || a.startsWith('--user='))
+    if (!sawUserFlag) return { ok: true, ref: undefined }
+
+    const ref = parseGlobalArgs(argv).user
+    if (!ref) {
+        return {
+            ok: false,
+            message: '--user requires a value: <id|email>.',
+            hints: ['Example: tw --user me@example.com inbox'],
+        }
+    }
+    if (knownCommands.has(ref)) {
+        return {
+            ok: false,
+            message: `--user requires a value: <id|email>. Got "${ref}", which looks like a subcommand — did you forget the value?`,
+            hints: [`Example: tw --user me@example.com ${ref}`],
+        }
+    }
+    return { ok: true, ref }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/global-args.ts
+++ b/src/lib/global-args.ts
@@ -19,6 +19,8 @@ export interface GlobalArgs {
     accessible: boolean
     nonInteractive: boolean
     interactive: boolean
+    /** --user <ref> — selects which stored Twist account to use. */
+    user: string | undefined
 }
 
 /**
@@ -33,9 +35,8 @@ export function parseGlobalArgs(argv?: string[]): GlobalArgs {
     const has = (flag: string) =>
         args.includes(flag) || args.some((arg) => arg.startsWith(`${flag}=`))
 
-    // Parse --progress-jsonl with optional path value.
-    // Supports: --progress-jsonl, --progress-jsonl=path, --progress-jsonl path
-    // "Last one wins" when specified multiple times.
+    // --progress-jsonl supports --progress-jsonl, --progress-jsonl=path, and
+    // --progress-jsonl path. "Last one wins" when specified multiple times.
     const progressIndices = args
         .map((arg, index) => ({ arg, index }))
         .filter(({ arg }) => arg === '--progress-jsonl' || arg.startsWith('--progress-jsonl='))
@@ -50,6 +51,24 @@ export function parseGlobalArgs(argv?: string[]): GlobalArgs {
         }
     }
 
+    // --user <ref> | --user=<ref> | --user (no value — left undefined so
+    // index.ts can surface a clear usage error before commander runs).
+    let user: string | undefined
+    const userIndices = args
+        .map((arg, index) => ({ arg, index }))
+        .filter(({ arg }) => arg === '--user' || arg.startsWith('--user='))
+    if (userIndices.length > 0) {
+        const { arg, index } = userIndices[userIndices.length - 1]
+        if (arg.includes('=')) {
+            user = arg.slice(arg.indexOf('=') + 1)
+        } else if (index + 1 < args.length && !args[index + 1].startsWith('-')) {
+            // Only consume the next arg as the value when it doesn't look
+            // like another flag — keeps `tw --user --json …` from silently
+            // swallowing `--json`.
+            user = args[index + 1]
+        }
+    }
+
     return {
         json: has('--json'),
         ndjson: has('--ndjson'),
@@ -60,6 +79,7 @@ export function parseGlobalArgs(argv?: string[]): GlobalArgs {
         accessible: has('--accessible'),
         nonInteractive: has('--non-interactive'),
         interactive: has('--interactive'),
+        user,
     }
 }
 
@@ -122,4 +142,44 @@ export function isProgressJsonlEnabled(): boolean {
 
 export function getProgressJsonlPath(): string | undefined {
     return getGlobalArgs().progressJsonlPath
+}
+
+export function getRequestedUserRef(): string | undefined {
+    return getGlobalArgs().user
+}
+
+/**
+ * Remove `--user <ref>` / `--user=<ref>` from an argv array so commander —
+ * which has no global-option attachment — never sees the flag at subcommand
+ * level. Returns a new array; the original is not mutated. Stops at the `--`
+ * terminator so positional args after it are preserved verbatim.
+ *
+ * Mirrors `parseGlobalArgs`: refuses to consume the next arg as the value
+ * when it looks like another flag, so commander gets a chance to surface a
+ * usage error on a malformed `--user`.
+ */
+export function stripUserFlag(argv: string[]): string[] {
+    const out: string[] = []
+    let stopped = false
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i]
+        if (stopped) {
+            out.push(arg)
+            continue
+        }
+        if (arg === '--') {
+            stopped = true
+            out.push(arg)
+            continue
+        }
+        if (arg === '--user') {
+            if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) i++
+            continue
+        }
+        if (arg.startsWith('--user=')) {
+            continue
+        }
+        out.push(arg)
+    }
+    return out
 }

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+    class MockSecureStoreUnavailableError extends Error {}
+
+    interface KeyringEntry {
+        token: string | null
+    }
+    const keyringEntries = new Map<string, KeyringEntry>()
+    function entry(account: string): KeyringEntry {
+        let e = keyringEntries.get(account)
+        if (!e) {
+            e = { token: null }
+            keyringEntries.set(account, e)
+        }
+        return e
+    }
+
+    return {
+        MockSecureStoreUnavailableError,
+        keyringEntries,
+        entry,
+        getConfig: vi.fn(),
+        setConfig: vi.fn(),
+        secureStoreError: null as Error | null,
+    }
+})
+
+vi.mock('./config.js', async () => {
+    const actual = await vi.importActual<typeof import('./config.js')>('./config.js')
+    return {
+        ...actual,
+        getConfig: mocks.getConfig,
+        setConfig: mocks.setConfig,
+    }
+})
+
+vi.mock('./secure-store.js', () => ({
+    SECURE_STORE_DESCRIPTION: 'system credential manager',
+    SecureStoreUnavailableError: mocks.MockSecureStoreUnavailableError,
+    LEGACY_ACCOUNT_NAME: 'api-token',
+    accountForUser: (id: string) => `user-${id}`,
+    createSecureStore: (account = 'api-token') => ({
+        async getSecret(): Promise<string | null> {
+            if (mocks.secureStoreError) throw mocks.secureStoreError
+            return mocks.entry(account).token
+        },
+        async setSecret(secret: string): Promise<void> {
+            if (mocks.secureStoreError) throw mocks.secureStoreError
+            mocks.entry(account).token = secret
+        },
+        async deleteSecret(): Promise<boolean> {
+            if (mocks.secureStoreError) throw mocks.secureStoreError
+            const e = mocks.entry(account)
+            const had = e.token !== null
+            e.token = null
+            return had
+        },
+    }),
+}))
+
+describe('migrateLegacyAuth', () => {
+    beforeEach(() => {
+        vi.resetModules()
+        vi.clearAllMocks()
+        mocks.getConfig.mockReset()
+        mocks.setConfig.mockReset()
+        mocks.keyringEntries.clear()
+        mocks.secureStoreError = null
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('reports already-migrated when accounts array exists', async () => {
+        mocks.getConfig.mockResolvedValue({ configVersion: 2, accounts: [] })
+
+        const { migrateLegacyAuth } = await import('./migrate-auth.js')
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl: failingFetch })
+
+        expect(result.status).toBe('already-migrated')
+        expect(mocks.setConfig).not.toHaveBeenCalled()
+    })
+
+    it('reports no-legacy-state when config has no auth-related fields', async () => {
+        mocks.getConfig.mockResolvedValue({})
+
+        const { migrateLegacyAuth } = await import('./migrate-auth.js')
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl: failingFetch })
+
+        expect(result.status).toBe('no-legacy-state')
+        expect(mocks.setConfig).not.toHaveBeenCalled()
+    })
+
+    it('migrates a v1 plaintext token via REST session-user fetch', async () => {
+        mocks.getConfig.mockResolvedValue({
+            token: 'legacy-1234567',
+            authMode: 'read-write',
+            authScope: 'user:read user:write',
+            currentWorkspace: 42,
+        })
+
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ id: 999, email: 'me@example.com', name: 'Scott' }), {
+                    status: 200,
+                }),
+        )
+
+        const { migrateLegacyAuth } = await import('./migrate-auth.js')
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl })
+
+        expect(result).toMatchObject({
+            status: 'migrated',
+            migratedUserId: '999',
+            migratedEmail: 'me@example.com',
+        })
+        expect(mocks.entry('user-999').token).toBe('legacy-1234567')
+        expect(mocks.setConfig).toHaveBeenCalledWith({
+            configVersion: 2,
+            currentWorkspace: 42,
+            account: { defaultAccount: '999' },
+            accounts: [
+                {
+                    id: '999',
+                    email: 'me@example.com',
+                    name: 'Scott',
+                    authMode: 'read-write',
+                    authScope: 'user:read user:write',
+                },
+            ],
+        })
+    })
+
+    it('migrates a legacy keyring token (api-token account)', async () => {
+        mocks.getConfig.mockResolvedValue({})
+        mocks.entry('api-token').token = 'legacy-secure-1234567'
+
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify({ id: 42, email: 'k@e.y' }), { status: 200 }),
+        )
+
+        const { migrateLegacyAuth } = await import('./migrate-auth.js')
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl })
+
+        expect(result.status).toBe('migrated')
+        expect(mocks.entry('user-42').token).toBe('legacy-secure-1234567')
+        // legacy slot cleared
+        expect(mocks.entry('api-token').token).toBeNull()
+    })
+
+    it('skips and leaves config untouched when fetch fails', async () => {
+        mocks.getConfig.mockResolvedValue({ token: 'legacy-1234567' })
+
+        const fetchImpl = vi.fn(async () => new Response('boom', { status: 500 }))
+
+        const { migrateLegacyAuth } = await import('./migrate-auth.js')
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl })
+
+        expect(result.status).toBe('skipped')
+        expect(mocks.setConfig).not.toHaveBeenCalled()
+    })
+})
+
+const failingFetch: typeof fetch = async () => {
+    throw new Error('fetch should not be called')
+}

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -1,0 +1,184 @@
+/**
+ * One-time migration of v1 single-user auth state into the v2 multi-account
+ * shape. Invoked from `src/postinstall.ts` so existing installs upgrade
+ * transparently. Best-effort: any failure (offline, invalid token, keyring
+ * unavailable) leaves the v1 state untouched so the runtime fallback in
+ * `resolveActiveAccount` can keep serving the legacy token until the next
+ * upgrade attempt or `tw auth login`.
+ */
+
+import { type Config, CONFIG_VERSION, getConfig, setConfig, type StoredAccount } from './config.js'
+import {
+    accountForUser,
+    createSecureStore,
+    LEGACY_ACCOUNT_NAME,
+    SecureStoreUnavailableError,
+} from './secure-store.js'
+
+export interface MigrateAuthResult {
+    status: 'already-migrated' | 'no-legacy-state' | 'migrated' | 'skipped'
+    reason?: string
+    migratedUserId?: string
+    migratedEmail?: string
+}
+
+interface MigrateOptions {
+    /** Suppress console output. Postinstall sets this; CLI surfaces use it via warn(). */
+    silent?: boolean
+    /** Override fetch (for tests). */
+    fetchImpl?: typeof fetch
+}
+
+interface SessionUser {
+    id: string
+    email: string
+    name?: string
+}
+
+const SESSION_ENDPOINT = 'https://api.twist.com/api/v3/users/get_session_user'
+
+export async function migrateLegacyAuth(opts: MigrateOptions = {}): Promise<MigrateAuthResult> {
+    const fetchImpl = opts.fetchImpl ?? fetch
+    const config = await getConfig()
+
+    // Already on v2 — the presence of `accounts` is the marker. Empty array
+    // still counts as migrated (clean slate after a logout).
+    if (Array.isArray(config.accounts)) {
+        return { status: 'already-migrated' }
+    }
+
+    const legacyToken = await loadLegacyToken(config)
+    if (!legacyToken) {
+        // No usable token to migrate. If there's nothing legacy at all, exit
+        // without writing the file. Otherwise clean up to v2 shape.
+        if (
+            config.token === undefined &&
+            config.authMode === undefined &&
+            config.authScope === undefined &&
+            !config.pendingSecureStoreClear
+        ) {
+            return { status: 'no-legacy-state' }
+        }
+
+        try {
+            await setConfig(toV2(stripLegacy(config), []))
+        } catch (error) {
+            return skipped(opts, `failed to clean up legacy config (${describe(error)})`)
+        }
+        return { status: 'migrated' }
+    }
+
+    // Identify the user behind the legacy token via a one-shot REST call —
+    // no SDK import to keep postinstall lightweight.
+    let user: SessionUser
+    try {
+        user = await fetchSessionUser(legacyToken, fetchImpl)
+    } catch (error) {
+        return skipped(opts, `could not identify Twist user (${describe(error)})`)
+    }
+
+    const record: StoredAccount = {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        authMode: config.authMode,
+        authScope: config.authScope,
+    }
+
+    // Move the token into the per-account keyring slot.
+    let storedSecurely = false
+    try {
+        const accountStore = createSecureStore(accountForUser(user.id))
+        await accountStore.setSecret(legacyToken)
+        storedSecurely = true
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) {
+            return skipped(opts, `failed to write account-scoped credential (${describe(error)})`)
+        }
+    }
+
+    if (!storedSecurely) {
+        record.token = legacyToken
+    }
+
+    const next = toV2(stripLegacy(config), [record], user.id)
+
+    try {
+        await setConfig(next)
+    } catch (error) {
+        return skipped(opts, `failed to update config (${describe(error)})`)
+    }
+
+    // Clean up the legacy keyring entry — best effort, never fatal.
+    try {
+        const legacyStore = createSecureStore(LEGACY_ACCOUNT_NAME)
+        await legacyStore.deleteSecret()
+    } catch {
+        // ignore
+    }
+
+    if (!opts.silent) {
+        console.error(`twist-cli: migrated existing token to multi-account store (${user.email}).`)
+    }
+
+    return { status: 'migrated', migratedUserId: user.id, migratedEmail: user.email }
+}
+
+async function loadLegacyToken(config: Config): Promise<string | null> {
+    if (typeof config.token === 'string' && config.token.trim()) {
+        return config.token.trim()
+    }
+    try {
+        const legacyStore = createSecureStore(LEGACY_ACCOUNT_NAME)
+        const stored = await legacyStore.getSecret()
+        if (stored?.trim()) return stored.trim()
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) throw error
+    }
+    return null
+}
+
+async function fetchSessionUser(token: string, fetchImpl: typeof fetch): Promise<SessionUser> {
+    const response = await fetchImpl(SESSION_ENDPOINT, {
+        headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`)
+    }
+    const data = (await response.json()) as { id?: unknown; email?: unknown; name?: unknown }
+    if (data.id === undefined || data.id === null) {
+        throw new Error('response missing user id')
+    }
+    if (typeof data.email !== 'string' || !data.email) {
+        throw new Error('response missing user email')
+    }
+    return {
+        id: String(data.id),
+        email: data.email,
+        name: typeof data.name === 'string' ? data.name : undefined,
+    }
+}
+
+function toV2(config: Config, accounts: StoredAccount[], defaultAccountId?: string): Config {
+    const next: Config = { ...config, configVersion: CONFIG_VERSION, accounts }
+    if (defaultAccountId) {
+        next.account = { ...next.account, defaultAccount: defaultAccountId }
+    }
+    return next
+}
+
+function stripLegacy(config: Config): Config {
+    const { token: _t, authMode: _m, authScope: _s, pendingSecureStoreClear: _p, ...rest } = config
+    return rest
+}
+
+function describe(error: unknown): string {
+    return error instanceof Error && error.message ? error.message : String(error)
+}
+
+function skipped(opts: MigrateOptions, reason: string): MigrateAuthResult {
+    if (!opts.silent) {
+        console.error(`twist-cli: skipped legacy auth migration — ${reason}.`)
+    }
+    return { status: 'skipped', reason }
+}

--- a/src/lib/oauth-server.ts
+++ b/src/lib/oauth-server.ts
@@ -32,6 +32,12 @@ export async function startCallbackServer(expectedState: string): Promise<Callba
             }
 
             if (server) {
+                // server.close() only stops accepting new connections — it
+                // waits for keep-alive sockets to drain before resolving,
+                // which can hang the CLI for ~60s after a successful login
+                // because the browser keeps the response socket alive.
+                // closeAllConnections (Node 18.2+) force-terminates them.
+                server.closeAllConnections()
                 server.close()
                 server = null
             }
@@ -51,7 +57,10 @@ export async function startCallbackServer(expectedState: string): Promise<Callba
                 handleCallback(req, res, expectedState, resolve, reject, cleanup)
             } else {
                 // Handle other paths
-                res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' })
+                res.writeHead(404, {
+                    'Content-Type': 'text/html; charset=utf-8',
+                    Connection: 'close',
+                })
                 res.end(getNotFoundPage())
             }
         })
@@ -91,7 +100,7 @@ function handleCallback(
     // Check for OAuth errors first
     if (error) {
         const errorMsg = error_description ? String(error_description) : String(error)
-        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' })
         res.end(getErrorPage(`OAuth Error: ${errorMsg}`))
         cleanup()
         reject(new Error(`OAuth authorization failed: ${errorMsg}`))
@@ -100,7 +109,7 @@ function handleCallback(
 
     // Validate state parameter (CSRF protection)
     if (!state || String(state) !== expectedState) {
-        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' })
         res.end(getErrorPage('Invalid state parameter. This may be a security issue.'))
         cleanup()
         reject(new Error('Invalid state parameter received. Possible CSRF attack.'))
@@ -109,7 +118,7 @@ function handleCallback(
 
     // Validate authorization code
     if (!code || typeof code !== 'string') {
-        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8' })
+        res.writeHead(400, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' })
         res.end(getErrorPage('No authorization code received.'))
         cleanup()
         reject(new Error('No authorization code received from OAuth server'))
@@ -117,7 +126,7 @@ function handleCallback(
     }
 
     // Success!
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' })
     res.end(getSuccessPage())
 
     resolve({

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -14,7 +14,7 @@ describe('permissions', () => {
         mockGetAuthMetadata.mockResolvedValue({
             authMode: 'read-only',
             authScope: 'user:read workspaces:read',
-            source: 'config',
+            source: 'config-file',
         })
 
         await expect(ensureWriteAllowed()).rejects.toThrow(READ_ONLY_ERROR_MESSAGE)
@@ -23,7 +23,7 @@ describe('permissions', () => {
     it('allows writes in read-write mode', async () => {
         mockGetAuthMetadata.mockResolvedValue({
             authMode: 'read-write',
-            source: 'config',
+            source: 'config-file',
         })
 
         await expect(ensureWriteAllowed()).resolves.toBeUndefined()

--- a/src/lib/secure-store.ts
+++ b/src/lib/secure-store.ts
@@ -1,5 +1,10 @@
 const SERVICE_NAME = 'twist-cli'
-const ACCOUNT_NAME = 'api-token'
+
+/**
+ * Legacy single-user account name. Read once during migration to v2 storage,
+ * then deleted. New code should always pass an explicit `user-<id>` account.
+ */
+export const LEGACY_ACCOUNT_NAME = 'api-token'
 
 export const SECURE_STORE_DESCRIPTION = 'system credential manager'
 
@@ -16,10 +21,22 @@ export interface SecureStore {
     deleteSecret(): Promise<boolean>
 }
 
-export function createSecureStore(): SecureStore {
+/**
+ * Build the keyring account name for a given Twist user id.
+ */
+export function accountForUser(userId: string): string {
+    return `user-${userId}`
+}
+
+/**
+ * Create a secure-store handle for a specific keyring account. Pass the result
+ * of `accountForUser(id)` for per-account tokens, or `LEGACY_ACCOUNT_NAME`
+ * when reading/cleaning up the v1 single-user entry.
+ */
+export function createSecureStore(account: string = LEGACY_ACCOUNT_NAME): SecureStore {
     return {
         async getSecret(): Promise<string | null> {
-            const entry = await getEntry()
+            const entry = await getEntry(account)
             try {
                 return (await entry.getPassword()) ?? null
             } catch (error) {
@@ -28,7 +45,7 @@ export function createSecureStore(): SecureStore {
         },
 
         async setSecret(secret: string): Promise<void> {
-            const entry = await getEntry()
+            const entry = await getEntry(account)
             try {
                 await entry.setPassword(secret)
             } catch (error) {
@@ -37,7 +54,7 @@ export function createSecureStore(): SecureStore {
         },
 
         async deleteSecret(): Promise<boolean> {
-            const entry = await getEntry()
+            const entry = await getEntry(account)
             try {
                 return await entry.deleteCredential()
             } catch (error) {
@@ -47,10 +64,10 @@ export function createSecureStore(): SecureStore {
     }
 }
 
-async function getEntry(): Promise<import('@napi-rs/keyring').AsyncEntry> {
+async function getEntry(account: string): Promise<import('@napi-rs/keyring').AsyncEntry> {
     try {
         const { AsyncEntry } = await import('@napi-rs/keyring')
-        return new AsyncEntry(SERVICE_NAME, ACCOUNT_NAME)
+        return new AsyncEntry(SERVICE_NAME, account)
     } catch (error) {
         throw toUnavailableError(error)
     }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -38,6 +38,20 @@ Stored auth uses the system credential manager when available. If secure storage
 
 In read-only mode (\`tw auth login --read-only\`), commands that modify Twist data (reply, archive, react, delete, etc.) are blocked by the CLI. Externally provided tokens (\`TWIST_API_TOKEN\` or \`tw auth token\`) are treated as unknown scope and assumed write-capable.
 
+## Multi-account
+
+The CLI can hold credentials for multiple Twist accounts at once.
+
+\`\`\`bash
+tw auth login                       # adds the account; first one becomes default
+tw account list                     # all stored accounts (with default marker)
+tw account use <id|email>           # set the default account
+tw --user <id|email> inbox          # one-off override for any command
+tw auth logout --user <id|email>    # log out a specific account
+\`\`\`
+
+Resolution order: \`--user <ref>\` > \`account.defaultAccount\` from config > the only stored account. With multiple accounts and no default, commands error and ask for \`--user\` (or \`tw account use\`). \`<ref>\` matches an exact id or email (case-insensitive on email). \`TWIST_API_TOKEN\` still bypasses the resolver entirely.
+
 ## View by URL
 
 \`\`\`bash

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,3 +1,5 @@
+import { migrateLegacyAuth } from './lib/migrate-auth.js'
 import { updateAllInstalledSkills } from './lib/skills/update-installed.js'
 
 updateAllInstalledSkills({ local: false }).catch(() => {})
+migrateLegacyAuth({ silent: true }).catch(() => {})


### PR DESCRIPTION
## Summary

Adds multi-account support to twist-cli, mirroring [todoist-cli #300](https://github.com/Doist/todoist-cli/pull/300). The CLI can now hold credentials for multiple Twist accounts and target a specific one per command via `--user <id|email>`.

```bash
tw auth login                       # adds the account; first becomes default
tw account list                     # all stored accounts (with default marker)
tw account use <id|email>           # set the default account
tw --user <id|email> inbox          # one-off override for any command
tw auth logout --user <id|email>    # log out a specific account
```

Resolution order: `--user <ref>` > `account.defaultAccount` from config > the only stored account. Multiple accounts with no default makes commands error and ask for `--user` (or `tw account use`). `TWIST_API_TOKEN` still bypasses the resolver entirely.

## What's in here

- **Config schema v2** — `accounts: StoredAccount[]` + `account.defaultAccount`. `StoredAccount` carries `id`, `email`, `name`, `authMode`, `authScope`, optional `token` (plaintext fallback). `validateConfigForDoctor` updated to match.
- **Per-account keyring slots** — `accountForUser(id) → 'user-<id>'`. Legacy `'api-token'` slot is read once during migration then deleted.
- **One-time v1→v2 migration** in `src/lib/migrate-auth.ts`, run from `postinstall.ts`. Probes the legacy token via REST (no SDK import) to identify the user, moves the token to a per-account keyring slot, writes the v2 config, cleans up legacy state. Best-effort: any failure leaves v1 state untouched so the runtime fallback in `resolveActiveAccount` keeps serving the legacy token.
- **`--user` global flag** parsed in `src/lib/global-args.ts` (with `stripUserFlag` to keep commander happy since it has no global-option attachment) and validated in `src/index.ts` (rejects bare/empty/looks-like-subcommand values).
- **`tw account` command group** (`list`, `use`) under `src/commands/account/`. Plain output shows `Name <email> (id:N) (default)`; `--json` includes `name`, `isDefault`, `authMode`, `authScope`, `storage`.
- **`tw auth status`** now shows the default marker for the active account, lists other stored accounts, and points at `tw account use` / `--user`. Same JSON shape (`isDefault`, `storedAccounts[]`).
- **`tw auth login`** identifies the user behind the new token before persisting (so it lands in the right slot).
- **`tw auth token`** also probes the API to identify the user before saving.
- **`tw auth logout`** accepts `--user <ref>` to target a specific account.
- **OAuth login hang fix** (`cbc9678`) — `server.close()` waits for keep-alive sockets to drain, which kept the CLI hung for ~60s after a successful login. Force-terminate via `server.closeAllConnections()` and send `Connection: close` on responses.

## What's deliberately not ported

The todoist `auth_flags` / `--additional-scopes` system (app-management, backups) doesn't apply here — Twist's OAuth model has fixed `READ_ONLY_SCOPES` / `READ_WRITE_SCOPES` with no opt-in add-on scopes.

## Test plan

- [x] `npm run type-check`
- [x] `npx vitest run` (622 tests pass)
- [x] Manual: `tw auth login` for a second account — switch via `tw account use`, override per-command via `tw --user <ref> inbox`, log out a specific account via `tw auth logout --user <ref>`
- [x] Manual: confirm OAuth login no longer hangs after success page
- [ ] Manual: `tw doctor` against a fresh v2 config and against a v1 config requiring migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)