### PR TITLE
fix(deps): bump @doist/twist-sdk to 2.5.1 for Node 26 gzip fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "2.5.0",
+                "@doist/twist-sdk": "2.5.1",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -137,9 +137,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.5.0.tgz",
-            "integrity": "sha512-PBBYZ8dVdaO3DXdyNL0PFXBn0xIt9g+U4ANMT6rPknKMc1uMkgfI8CZ5EsU6Rj0sE0EVYnmrlLNPsj82JcM5pw==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.5.1.tgz",
+            "integrity": "sha512-e1DDJAPdIcqhpeZz1MB797S7suZW8rUurKxcpb4/oIYVaFzSllZw8EoFtyOlz6KcxWgcrtNECzIOmCwXhMfWXg==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "CHANGELOG.md"
     ],
     "dependencies": {
-        "@doist/twist-sdk": "2.5.0",
+        "@doist/twist-sdk": "2.5.1",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",


### PR DESCRIPTION
## Summary

Bumps `@doist/twist-sdk` from `2.5.0` to `2.5.1`, picking up [Doist/twist-sdk-typescript#128](https://github.com/Doist/twist-sdk-typescript/pull/128).

That SDK release composes undici's `interceptors.decompress()` onto its `EnvHttpProxyAgent` so gzipped response bodies are decoded before reaching the CLI. On Node 24+, attaching any custom dispatcher to global `fetch` strips `content-encoding` from the response but doesn't actually decompress the body — every `tw` command that hits a gzipped endpoint was failing with a Zod root-level `expected: object, received: string` error.

The CLI's customFetch wrapper reuses the SDK's dispatcher transparently, so no CLI code change is needed; only the version bump.

This is the twist-cli companion to the [todoist-cli equivalent](https://github.com/Doist/todoist-cli/pull/320).

## Test plan

- [x] `npm install` clean
- [x] `npm test` — 596/596 passing
- [x] `npm run lint:check` — clean
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)