### PR TITLE
feat(auth): [2/4] add global --user flag and tw account list/use commands

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -20,11 +20,15 @@ tw auth login --callback-port <n># Override the local OAuth callback port (defau
 tw auth login --json             # Emit a JSON envelope for scripted / agent use
 tw auth login --ndjson           # Emit an NDJSON envelope for scripted / agent use
 tw auth token                    # Save API token manually (prompts securely; scope unknown, assumed write-capable)
-tw auth status                   # Verify authentication + show mode
-tw auth status --json            # JSON output: { id, email, name }
-tw auth logout                   # Remove saved token and auth metadata
+tw auth status                   # Verify authentication + show mode (lists other stored accounts)
+tw auth status --json            # JSON output: { id, email, name, authMode, isDefault, storedAccounts }
+tw auth logout                   # Remove saved token and auth metadata (use --user to target a specific account)
+tw account list                  # List all authenticated Twist accounts
+tw account list --json           # JSON output for stored accounts
+tw account use <id|email>        # Set the default account (used when --user is not given)
+tw --user <id|email> <command>   # Run any command as a specific stored account
 tw workspaces                    # List available workspaces
-tw workspace use <ref>           # Set current workspace
+tw workspace use <ref>           # Set current workspace (per-account)
 tw completion install            # Install shell completions
 tw config view                   # Show the current CLI configuration file (token masked)
 tw config set <key> <value>      # Set a user preference (e.g. unarchive-new-threads true)
@@ -33,7 +37,9 @@ tw update                        # Update CLI to latest version
 tw changelog                     # Show recent changelog entries
 ```
 
-Stored auth uses the system credential manager when available. If secure storage is unavailable, `tw` warns and falls back to `~/.config/twist-cli/config.json`. `TWIST_API_TOKEN` always takes priority over the stored token, and legacy plaintext config tokens are migrated automatically when secure storage is available.
+Multiple Twist accounts can be authenticated simultaneously. Each account's token is stored in a per-account keyring slot (`user-<id>`), and per-account state (`current_workspace`) is tracked separately so `tw --user other@example.com inbox` doesn't reuse the previous account's workspace selection. Without `--user`, the default account is used; if only one account is stored, it's implicit.
+
+Stored auth uses the system credential manager when available. If secure storage is unavailable, `tw` warns and falls back to `~/.config/twist-cli/config.json`. `TWIST_API_TOKEN` always takes priority over stored accounts (anonymous identity), and legacy plaintext config tokens are migrated automatically on install when secure storage is available.
 
 In read-only mode (`tw auth login --read-only`), commands that modify Twist data (reply, archive, react, delete, etc.) are blocked by the CLI. Externally provided tokens (`TWIST_API_TOKEN` or `tw auth token`) are treated as unknown scope and assumed write-capable.
 

--- a/src/commands/account/index.ts
+++ b/src/commands/account/index.ts
@@ -1,0 +1,30 @@
+import { Command } from 'commander'
+import { listAccountsCommand } from './list.js'
+import { useAccountCommand } from './use.js'
+
+export function registerAccountCommand(program: Command): void {
+    const account = program
+        .command('account')
+        .description('Manage stored Twist accounts (multi-user)')
+
+    account
+        .command('list')
+        .description('List all stored Twist accounts')
+        .option('--json', 'Output as JSON')
+        .action(listAccountsCommand)
+
+    account
+        .command('use <ref>')
+        .description('Set the default account used when --user is not provided')
+        .action((ref: string) => useAccountCommand(ref))
+
+    account.addHelpText(
+        'after',
+        `
+Examples:
+  $ tw auth login                  # add an account (sets it as default if first)
+  $ tw account list                # see all stored accounts
+  $ tw account use me@example.com  # set default
+  $ tw --user other@example.com inbox   # one-off override`,
+    )
+}

--- a/src/commands/account/list.ts
+++ b/src/commands/account/list.ts
@@ -1,0 +1,46 @@
+import chalk from 'chalk'
+import { getConfig } from '../../lib/config.js'
+import { isAccessible } from '../../lib/global-args.js'
+import { formatJson } from '../../lib/output.js'
+import { getDefaultUserId, getStoredUsers } from '../../lib/users.js'
+
+export type ListAccountsOptions = {
+    json?: boolean
+}
+
+export async function listAccountsCommand(options: ListAccountsOptions): Promise<void> {
+    // One config read drives both the account list and the default lookup.
+    const config = await getConfig()
+    const users = getStoredUsers(config)
+    const defaultId = getDefaultUserId(config)
+
+    if (options.json) {
+        console.log(
+            formatJson(
+                users.map((u) => ({
+                    id: u.id,
+                    email: u.email,
+                    name: u.name,
+                    isDefault: u.id === defaultId,
+                    authMode: u.auth_mode,
+                    authScope: u.auth_scope,
+                    storage: u.api_token ? 'config-file' : 'secure-store',
+                })),
+            ),
+        )
+        return
+    }
+
+    if (users.length === 0) {
+        console.log(chalk.dim('No stored Twist accounts. Run `tw auth login` to add one.'))
+        return
+    }
+
+    const accessible = isAccessible()
+    for (const u of users) {
+        const isDefault = u.id === defaultId
+        const marker = isDefault ? (accessible ? ' [default]' : chalk.green(' (default)')) : ''
+        const label = u.name ? `${u.name} <${u.email}>` : u.email
+        console.log(`${label} ${chalk.dim(`(id:${u.id})`)}${marker}`)
+    }
+}

--- a/src/commands/account/use.ts
+++ b/src/commands/account/use.ts
@@ -1,0 +1,15 @@
+import chalk from 'chalk'
+import { setDefaultUserId } from '../../lib/auth.js'
+import { CliError } from '../../lib/errors.js'
+
+export async function useAccountCommand(ref: string | undefined): Promise<void> {
+    if (!ref) {
+        throw new CliError(
+            'MISSING_REF',
+            'Please provide an account id or email: `tw account use <id|email>`',
+        )
+    }
+
+    const user = await setDefaultUserId(ref)
+    console.log(chalk.green('✓'), `Default account set to ${user.email} (id:${user.id})`)
+}

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk'
 import { clearApiToken } from '../../lib/auth.js'
+import { getRequestedUserRef } from '../../lib/global-args.js'
 import { logTokenStorageResult } from './helpers.js'
 
 export async function logout(): Promise<void> {
-    const clearResult = await clearApiToken()
+    const clearResult = await clearApiToken({ ref: getRequestedUserRef() })
     console.log(chalk.green('✓'), 'Logged out')
     logTokenStorageResult(clearResult, 'Stored token removed from the system credential manager')
 }

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -1,9 +1,11 @@
 import { TwistRequestError } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { getSessionUser } from '../../lib/api.js'
-import { NoTokenError, getAuthMetadata } from '../../lib/auth.js'
+import { getAuthMetadata, NoTokenError } from '../../lib/auth.js'
+import { getConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { formatJson } from '../../lib/output.js'
+import { getDefaultUserId, getStoredUsers } from '../../lib/users.js'
 
 export async function showStatus(options: { json?: boolean }): Promise<void> {
     let user
@@ -19,12 +21,34 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
         throw error
     }
 
+    // One config read covers both the stored-users list and the
+    // default-id lookup; metadata fetch runs in parallel so cold status
+    // doesn't pay for sequential FS hops.
+    const [metadata, config] = await Promise.all([getAuthMetadata(), getConfig()])
+    const storedUsers = getStoredUsers(config)
+    const defaultUserId = getDefaultUserId(config)
+    const userIdStr = String(user.id)
+
     if (options.json) {
-        console.log(formatJson({ id: user.id, email: user.email, name: user.name }))
+        console.log(
+            formatJson({
+                id: user.id,
+                email: user.email,
+                name: user.name,
+                authMode: metadata.authMode,
+                authScope: metadata.authScope,
+                source: metadata.source,
+                isDefault: defaultUserId === userIdStr,
+                storedAccounts: storedUsers.map((u) => ({
+                    id: u.id,
+                    email: u.email,
+                    isDefault: defaultUserId === u.id,
+                })),
+            }),
+        )
         return
     }
 
-    const metadata = await getAuthMetadata()
     const modeLabel =
         metadata.authMode === 'read-only'
             ? `read-only (scope: ${metadata.authScope ?? 'unknown'})`
@@ -32,8 +56,33 @@ export async function showStatus(options: { json?: boolean }): Promise<void> {
               ? 'read-write'
               : 'unknown (manual token or env var; assuming write access)'
 
-    console.log(chalk.green('✓'), 'Authenticated')
+    // env source wins over default: when running with TWIST_API_TOKEN, hiding
+    // the env override behind a (default) marker would obscure important
+    // debugging context.
+    const marker =
+        metadata.source === 'env'
+            ? ' (TWIST_API_TOKEN)'
+            : defaultUserId === userIdStr
+              ? ' (default)'
+              : ''
+
+    console.log(chalk.green('✓'), `Authenticated${marker}`)
     console.log(`  Email: ${user.email}`)
     console.log(`  Name:  ${user.name}`)
     console.log(`  Mode:  ${modeLabel}`)
+
+    const others = storedUsers.filter((u) => u.id !== userIdStr)
+    if (others.length > 0) {
+        console.log()
+        console.log(chalk.dim(`Other stored accounts (${others.length}):`))
+        for (const other of others) {
+            const otherMarker = other.id === defaultUserId ? chalk.dim(' (default)') : ''
+            console.log(`  ${other.email} ${chalk.dim(`(id:${other.id})`)}${otherMarker}`)
+        }
+        console.log(
+            chalk.dim(
+                'Use `tw account use <id|email>` to switch default, or `--user <ref>` per command.',
+            ),
+        )
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@
 
 import { type Command, program } from 'commander'
 import pkg from '../package.json' with { type: 'json' }
-import { BaseCliError } from './lib/errors.js'
-import { isJsonMode, isNdjsonMode } from './lib/global-args.js'
+import { BaseCliError, CliError } from './lib/errors.js'
+import { isJsonMode, isNdjsonMode, stripUserFlag, validateUserFlag } from './lib/global-args.js'
 import { preloadMarkdown } from './lib/markdown.js'
 import { formatError, formatErrorJson } from './lib/output.js'
 import { startEarlySpinner, stopEarlySpinner } from './lib/spinner.js'
@@ -41,6 +41,8 @@ const loadGroupsCommand = async () =>
 const loadDoctorCommand = async () => (await import('./commands/doctor.js')).registerDoctorCommand
 const loadConfigCommand = async () =>
     (await import('./commands/config/index.js')).registerConfigCommand
+const loadAccountCommand = async () =>
+    (await import('./commands/account/index.js')).registerAccountCommand
 
 const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = {
     workspaces: ['List all workspaces', loadWorkspaceCommand],
@@ -70,6 +72,7 @@ const commands: Record<string, [string, () => Promise<(p: Command) => void>]> = 
         loadGroupsCommand,
     ],
     config: ['Manage CLI configuration', loadConfigCommand],
+    account: ['Manage authenticated Twist accounts (list, use)', loadAccountCommand],
 }
 
 const commandAliases: Record<string, string> = {
@@ -82,6 +85,7 @@ program
     .name('tw')
     .description('Twist CLI')
     .version(pkg.version)
+    .option('--user <id|email>', 'Select which stored account to use for this command')
     .option('--no-spinner', 'Disable loading animations')
     .option('--progress-jsonl [path]', 'Output progress events as JSONL to stderr or file')
     .option(
@@ -199,21 +203,45 @@ if (process.argv[2] === 'completion-server') {
     }
 }
 
-await program
-    .parseAsync()
-    .catch((err: Error) => {
-        stopEarlySpinner()
-        if (err instanceof BaseCliError) {
-            console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
-        } else {
-            console.error(
-                isJsonMode()
-                    ? formatErrorJson('INTERNAL_ERROR', err.message)
-                    : err.stack || err.message,
-            )
-        }
+// Pre-Commander validation of the global `--user <ref>` flag. Caught here so
+// `--user --json`, `--user=`, and `--user inbox` (forgot the value) produce a
+// clear CliError with hints instead of Commander's terser usage message.
+{
+    const knownCommands = new Set<string>([
+        ...Object.keys(commands),
+        ...Object.keys(commandAliases),
+    ])
+    const userArgs = process.argv.slice(2)
+    const validation = validateUserFlag(userArgs, knownCommands)
+    if (!validation.ok) {
+        const err = new CliError('USER_FLAG_INVALID', validation.message, validation.hints, 'info')
+        console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
         process.exitCode = 1
-    })
-    .finally(() => {
-        stopEarlySpinner()
-    })
+    } else {
+        // Strip `--user <ref>` from argv before Commander sees it. The value
+        // is still available via `getRequestedUserRef()` (read from the
+        // cached parse of the *original* argv).
+        const cleaned = stripUserFlag(userArgs)
+        process.argv = [process.argv[0], process.argv[1], ...cleaned]
+    }
+}
+
+if (!process.exitCode)
+    await program
+        .parseAsync()
+        .catch((err: Error) => {
+            stopEarlySpinner()
+            if (err instanceof BaseCliError) {
+                console.error(isJsonMode() ? formatErrorJson(err) : formatError(err))
+            } else {
+                console.error(
+                    isJsonMode()
+                        ? formatErrorJson('INTERNAL_ERROR', err.message)
+                        : err.stack || err.message,
+                )
+            }
+            process.exitCode = 1
+        })
+        .finally(() => {
+            stopEarlySpinner()
+        })

--- a/src/lib/global-args.ts
+++ b/src/lib/global-args.ts
@@ -29,6 +29,12 @@ type TwSpecificFlags = {
     includePrivateChannels: boolean
     nonInteractive: boolean
     interactive: boolean
+    /**
+     * Value of the global `--user <id|email>` flag. Selects which stored
+     * account every command this invocation runs against. `undefined` when
+     * the flag wasn't passed (use default / single-stored).
+     */
+    user: string | undefined
 }
 
 /**
@@ -66,6 +72,7 @@ type TwLocalFlags = {
      * twist re-adds it because the flag is global, not subcommand-attached.
      */
     progressJsonl: string | true | false
+    user: string | undefined
 }
 
 function parseTwLocalFlags(argv: string[]): TwLocalFlags {
@@ -73,6 +80,7 @@ function parseTwLocalFlags(argv: string[]): TwLocalFlags {
     let nonInteractive = false
     let interactive = false
     let progressJsonl: string | true | false = false
+    let user: string | undefined
 
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i]
@@ -93,6 +101,18 @@ function parseTwLocalFlags(argv: string[]): TwLocalFlags {
             }
         } else if (arg.startsWith('--progress-jsonl=')) {
             progressJsonl = arg.slice('--progress-jsonl='.length)
+        } else if (arg === '--user') {
+            // Bare or space form. Refuses to consume the next arg when it
+            // looks like another flag — `tw --user --json ...` should leave
+            // `user` undefined so the validator can flag the missing value.
+            if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) {
+                user = argv[i + 1]
+                i++
+            } else {
+                user = ''
+            }
+        } else if (arg.startsWith('--user=')) {
+            user = arg.slice('--user='.length)
         }
     }
 
@@ -101,6 +121,7 @@ function parseTwLocalFlags(argv: string[]): TwLocalFlags {
         nonInteractive,
         interactive,
         progressJsonl,
+        user,
     }
 }
 
@@ -117,6 +138,7 @@ function parseFullArgs(argv?: string[]): FullArgs {
         includePrivateChannels: local.includePrivateChannels,
         nonInteractive: local.nonInteractive,
         interactive: local.interactive,
+        user: local.user || undefined,
     }
 }
 
@@ -181,3 +203,89 @@ export const shouldDisableSpinner = createSpinnerGate({
     getArgs: store.get,
     extraTriggers: () => store.get().nonInteractive,
 })
+
+// ---------------------------------------------------------------------------
+// `--user <ref>` global flag plumbing
+// ---------------------------------------------------------------------------
+
+export function getRequestedUserRef(): string | undefined {
+    return store.get().user
+}
+
+/**
+ * Remove `--user <ref>` / `--user=<ref>` from an argv array so commander —
+ * which has no global-option attachment — never sees the flag at the
+ * subcommand level. Returns a new array; the original is not mutated. Stops
+ * at the `--` terminator so positional args after it are preserved verbatim.
+ *
+ * Mirrors `parseTwLocalFlags`: refuses to consume the next arg as the value
+ * when it looks like another flag, so commander gets a chance to surface a
+ * usage error on a malformed `--user`.
+ */
+export function stripUserFlag(argv: string[]): string[] {
+    const out: string[] = []
+    let stopped = false
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i]
+        if (stopped) {
+            out.push(arg)
+            continue
+        }
+        if (arg === '--') {
+            stopped = true
+            out.push(arg)
+            continue
+        }
+        if (arg === '--user') {
+            if (i + 1 < argv.length && !argv[i + 1].startsWith('-')) i++
+            continue
+        }
+        if (arg.startsWith('--user=')) {
+            continue
+        }
+        out.push(arg)
+    }
+    return out
+}
+
+/**
+ * Pre-Commander validation grammar for the global `--user` flag. Catches
+ * bare `--user`, `--user=` (empty value), and `--user <subcommand>` (typo:
+ * forgot the value) before Commander sees the argv. Tokens after a `--`
+ * terminator are treated as positional content and don't count as a
+ * `--user` instance.
+ *
+ * Returns:
+ *  - `{ ok: true, ref }` — valid value (possibly undefined when --user wasn't passed)
+ *  - `{ ok: false, message, hints }` — invalid; caller should raise CliError
+ */
+export type UserFlagValidation =
+    | { ok: true; ref: string | undefined }
+    | { ok: false; message: string; hints: string[] }
+
+export function validateUserFlag(
+    argv: string[],
+    knownCommands: ReadonlySet<string>,
+): UserFlagValidation {
+    const terminatorIndex = argv.indexOf('--')
+    const scanRange = terminatorIndex === -1 ? argv : argv.slice(0, terminatorIndex)
+    const sawUserFlag = scanRange.some((a) => a === '--user' || a.startsWith('--user='))
+    if (!sawUserFlag) return { ok: true, ref: undefined }
+
+    const ref = parseGlobalArgs(argv).user
+    if (!ref) {
+        return {
+            ok: false,
+            message: '--user requires a value: <id|email>.',
+            hints: ['Example: tw --user me@example.com inbox'],
+        }
+    }
+    if (knownCommands.has(ref)) {
+        return {
+            ok: false,
+            message: `--user requires a value: <id|email>. Got "${ref}", which looks like a subcommand — did you forget the value?`,
+            hints: [`Example: tw --user me@example.com ${ref}`],
+        }
+    }
+    return { ok: true, ref }
+}

--- a/src/lib/global-args.user.test.ts
+++ b/src/lib/global-args.user.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { parseGlobalArgs, resetGlobalArgs, stripUserFlag, validateUserFlag } from './global-args.js'
+
+const KNOWN = new Set(['inbox', 'thread', 'auth', 'account', 'channel'])
+
+describe('--user flag parsing', () => {
+    afterEach(() => resetGlobalArgs())
+
+    it.each([
+        ['--user me@example.com', ['--user', 'me@example.com'], 'me@example.com'],
+        ['--user=me@example.com', ['--user=me@example.com'], 'me@example.com'],
+        ['--user 42', ['--user', '42'], '42'],
+        ['no flag', ['inbox'], undefined],
+    ])('%s', (_, argv, expected) => {
+        expect(parseGlobalArgs(argv).user).toBe(expected)
+    })
+
+    it('leaves user undefined when the next token is another flag', () => {
+        expect(parseGlobalArgs(['--user', '--json', 'inbox']).user).toBeUndefined()
+    })
+
+    it('treats tokens after `--` as positional', () => {
+        expect(parseGlobalArgs(['--', '--user', 'someone']).user).toBeUndefined()
+    })
+})
+
+describe('stripUserFlag', () => {
+    afterEach(() => resetGlobalArgs())
+
+    it('removes space form', () => {
+        expect(stripUserFlag(['--user', 'me@example.com', 'inbox'])).toEqual(['inbox'])
+    })
+
+    it('removes equals form', () => {
+        expect(stripUserFlag(['--user=me@example.com', 'inbox'])).toEqual(['inbox'])
+    })
+
+    it('preserves tokens after the terminator', () => {
+        expect(stripUserFlag(['inbox', '--', '--user', 'x'])).toEqual([
+            'inbox',
+            '--',
+            '--user',
+            'x',
+        ])
+    })
+
+    it('leaves the next flag intact when --user lacks a value', () => {
+        expect(stripUserFlag(['--user', '--json', 'inbox'])).toEqual(['--json', 'inbox'])
+    })
+})
+
+describe('validateUserFlag', () => {
+    afterEach(() => resetGlobalArgs())
+
+    it('returns ok: true with undefined ref when --user is absent', () => {
+        expect(validateUserFlag(['inbox'], KNOWN)).toEqual({ ok: true, ref: undefined })
+    })
+
+    it('returns ok: true with the value', () => {
+        expect(validateUserFlag(['--user', 'me@example.com', 'inbox'], KNOWN)).toEqual({
+            ok: true,
+            ref: 'me@example.com',
+        })
+    })
+
+    it('rejects bare --user', () => {
+        const result = validateUserFlag(['--user'], KNOWN)
+        expect(result.ok).toBe(false)
+    })
+
+    it('rejects --user= (empty value)', () => {
+        expect(validateUserFlag(['--user='], KNOWN).ok).toBe(false)
+    })
+
+    it('rejects --user <known-subcommand>', () => {
+        const result = validateUserFlag(['--user', 'inbox'], KNOWN)
+        expect(result.ok).toBe(false)
+        if (!result.ok) {
+            expect(result.message).toContain('looks like a subcommand')
+        }
+    })
+
+    it('--user-shaped tokens after `--` are positional, not flag instances', () => {
+        expect(validateUserFlag(['inbox', '--', '--user', 'x'], KNOWN)).toEqual({
+            ok: true,
+            ref: undefined,
+        })
+    })
+})

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -24,11 +24,15 @@ tw auth login --callback-port <n># Override the local OAuth callback port (defau
 tw auth login --json             # Emit a JSON envelope for scripted / agent use
 tw auth login --ndjson           # Emit an NDJSON envelope for scripted / agent use
 tw auth token                    # Save API token manually (prompts securely; scope unknown, assumed write-capable)
-tw auth status                   # Verify authentication + show mode
-tw auth status --json            # JSON output: { id, email, name }
-tw auth logout                   # Remove saved token and auth metadata
+tw auth status                   # Verify authentication + show mode (lists other stored accounts)
+tw auth status --json            # JSON output: { id, email, name, authMode, isDefault, storedAccounts }
+tw auth logout                   # Remove saved token and auth metadata (use --user to target a specific account)
+tw account list                  # List all authenticated Twist accounts
+tw account list --json           # JSON output for stored accounts
+tw account use <id|email>        # Set the default account (used when --user is not given)
+tw --user <id|email> <command>   # Run any command as a specific stored account
 tw workspaces                    # List available workspaces
-tw workspace use <ref>           # Set current workspace
+tw workspace use <ref>           # Set current workspace (per-account)
 tw completion install            # Install shell completions
 tw config view                   # Show the current CLI configuration file (token masked)
 tw config set <key> <value>      # Set a user preference (e.g. unarchive-new-threads true)
@@ -37,7 +41,9 @@ tw update                        # Update CLI to latest version
 tw changelog                     # Show recent changelog entries
 \`\`\`
 
-Stored auth uses the system credential manager when available. If secure storage is unavailable, \`tw\` warns and falls back to \`~/.config/twist-cli/config.json\`. \`TWIST_API_TOKEN\` always takes priority over the stored token, and legacy plaintext config tokens are migrated automatically when secure storage is available.
+Multiple Twist accounts can be authenticated simultaneously. Each account's token is stored in a per-account keyring slot (\`user-<id>\`), and per-account state (\`current_workspace\`) is tracked separately so \`tw --user other@example.com inbox\` doesn't reuse the previous account's workspace selection. Without \`--user\`, the default account is used; if only one account is stored, it's implicit.
+
+Stored auth uses the system credential manager when available. If secure storage is unavailable, \`tw\` warns and falls back to \`~/.config/twist-cli/config.json\`. \`TWIST_API_TOKEN\` always takes priority over stored accounts (anonymous identity), and legacy plaintext config tokens are migrated automatically on install when secure storage is available.
 
 In read-only mode (\`tw auth login --read-only\`), commands that modify Twist data (reply, archive, react, delete, etc.) are blocked by the CLI. Externally provided tokens (\`TWIST_API_TOKEN\` or \`tw auth token\`) are treated as unknown scope and assumed write-capable.
 


### PR DESCRIPTION
**Part 2 of 4 stacked PRs.** Builds on #217.

When all 4 land, the integration branch `scottl/multi-user-base` merges into `main` as one release.

## Order

- #217 — refactor: foundation
- **#218 this PR** — feat: `--user` flag and `tw account list/use`
- #219 — fix: per-account `current_workspace`
- #220 — feat: postinstall v1 → v2 migration

## Summary

Exposes the user-facing surface on top of part 1's storage layer.

### Global `--user <id|email>` (`lib/global-args.ts`, `src/index.ts`)

Selects which stored account this invocation runs against. `undefined` falls back to default / single-stored.

- `parseTwLocalFlags` extends with `user`. The flag honours `--` (tokens after the terminator are positional).
- `stripUserFlag` removes `--user <ref>` from argv before Commander sees it, since Commander has no global-option attachment.
- `validateUserFlag` runs pre-Commander to reject:
  - bare `--user` (no value)
  - `--user=` (empty value)
  - `--user <known-subcommand>` (typo: forgot the value)
  Index.ts surfaces the error as `USER_FLAG_INVALID` CliError.

### `tw account list / use` (`commands/account/`)

- `account list` shows all stored accounts with a default marker. `--json` emits the full record. Named `account` because `tw user` already shows current Twist API user info.
- `account use <ref>` calls `setDefaultUserId` and confirms.

### `tw auth status` (`commands/auth/status.ts`)

- Reads config + metadata in parallel; renders an env-source marker for `TWIST_API_TOKEN` and a default marker for the active user.
- Lists other stored accounts when more than one is present.
- `--json` envelope grows `source`, `isDefault`, and `storedAccounts[]`.

### `tw auth logout` (`commands/auth/logout.ts`)

- Now respects `--user <ref>` so multi-user installs can scope the logout. Passes the ref through to `clearApiToken`.

### SKILL_CONTENT

Documents `--user` + `tw account` subcommands. `skills/twist-cli/SKILL.md` regenerated via `npm run sync:skill`.

### Tests

- New `global-args.user.test.ts` covers `parseGlobalArgs` / `stripUserFlag` / `validateUserFlag` for the bare / empty / subcommand-lookalike / terminator cases.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 556 pass
- [x] `tw --user inbox` → `USER_FLAG_INVALID` with hint
- [x] `tw --user` → `USER_FLAG_INVALID` with hint
- [x] `tw account --help` lists `list` and `use`
