### PR TITLE
fix(account): [3/4] scope current_workspace per-account

### DIFF
--- a/src/commands/channel/threads.test.ts
+++ b/src/commands/channel/threads.test.ts
@@ -14,6 +14,12 @@ const refsMocks = vi.hoisted(() => ({
 vi.mock('../../lib/api.js', () => ({
     getTwistClient: apiMocks.getTwistClient,
     getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
+    assertBatchData: <T>(response: { code?: number; data: T }, label: string): T => {
+        if ((response.code ?? 200) >= 400 || response.data == null) {
+            throw new Error(`Failed to fetch ${label}.`)
+        }
+        return response.data
+    },
 }))
 
 vi.mock('../../lib/refs.js', () => ({

--- a/src/commands/channel/threads.ts
+++ b/src/commands/channel/threads.ts
@@ -1,6 +1,6 @@
 import type { ArchiveFilter, Thread } from '@doist/twist-sdk'
 import chalk from 'chalk'
-import { getCurrentWorkspaceId, getTwistClient } from '../../lib/api.js'
+import { assertBatchData, getCurrentWorkspaceId, getTwistClient } from '../../lib/api.js'
 import { formatRelativeDate } from '../../lib/dates.js'
 import { CliError } from '../../lib/errors.js'
 import { isAccessible } from '../../lib/global-args.js'
@@ -86,8 +86,10 @@ export async function showChannelThreads(
         client.threads.getUnread(workspaceId, { batch: true }),
     )
 
-    const unreadThreadIds = new Set(unreadResp.data.map((u) => u.threadId))
-    let threads: DecoratedThread[] = threadsResp.data.map((t) => ({
+    const threadsList = assertBatchData(threadsResp, `threads in #${channel.name}`)
+    const unreadList = assertBatchData(unreadResp, 'unread threads')
+    const unreadThreadIds = new Set(unreadList.map((u) => u.threadId))
+    let threads: DecoratedThread[] = threadsList.map((t) => ({
         ...t,
         isUnread: unreadThreadIds.has(t.id),
     }))

--- a/src/commands/inbox.test.ts
+++ b/src/commands/inbox.test.ts
@@ -10,6 +10,12 @@ const apiMocks = vi.hoisted(() => ({
 vi.mock('../lib/api.js', () => ({
     getTwistClient: apiMocks.getTwistClient,
     getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
+    assertBatchData: <T>(response: { code?: number; data: T }, label: string): T => {
+        if ((response.code ?? 200) >= 400 || response.data == null) {
+            throw new Error(`Failed to fetch ${label}.`)
+        }
+        return response.data
+    },
 }))
 
 vi.mock('../lib/refs.js', () => ({

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,7 +1,7 @@
 import type { ArchiveFilter } from '@doist/twist-sdk'
 import chalk from 'chalk'
 import { Command, Option } from 'commander'
-import { getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
+import { assertBatchData, getCurrentWorkspaceId, getTwistClient } from '../lib/api.js'
 import { withCaseInsensitiveChoices } from '../lib/completion.js'
 import { formatRelativeDate } from '../lib/dates.js'
 import { CliError } from '../lib/errors.js'
@@ -53,8 +53,10 @@ async function showInbox(workspaceRef: string | undefined, options: InboxOptions
         client.threads.getUnread(workspaceId, { batch: true }),
     )
 
-    const unreadThreadIds = new Set(unreadData.data.map((u) => u.threadId))
-    let inboxThreads = threads.data.map((t) => ({
+    const inboxData = assertBatchData(threads, 'inbox threads')
+    const unreadList = assertBatchData(unreadData, 'unread threads')
+    const unreadThreadIds = new Set(unreadList.map((u) => u.threadId))
+    let inboxThreads = inboxData.map((t) => ({
         ...t,
         isUnread: unreadThreadIds.has(t.id),
     }))

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import { Command } from 'commander'
-import { fetchWorkspaces, getCurrentWorkspaceId } from '../lib/api.js'
-import { updateConfig } from '../lib/config.js'
+import { fetchWorkspaces, getCurrentWorkspaceId, setActiveAccountWorkspace } from '../lib/api.js'
 import type { ViewOptions } from '../lib/options.js'
 import { colors, formatJson, formatNdjson, printEmpty } from '../lib/output.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
@@ -39,7 +38,7 @@ async function listWorkspaces(options: ListOptions): Promise<void> {
 
 async function useWorkspace(ref: string): Promise<void> {
     const workspace = await resolveWorkspaceRef(ref)
-    await updateConfig({ currentWorkspace: workspace.id })
+    await setActiveAccountWorkspace(workspace.id)
     console.log(`Switched to workspace: ${workspace.name}`)
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,12 +5,14 @@ import {
     type Workspace,
     type WorkspaceUser,
 } from '@doist/twist-sdk'
-import { getApiToken } from './auth.js'
-import { getConfig, updateConfig } from './config.js'
+import { resolveActiveUser } from './auth.js'
+import { type Config, getConfig, setConfig, type StoredUser } from './config.js'
 import { CliError, isInsufficientScope } from './errors.js'
+import { getRequestedUserRef } from './global-args.js'
 import { ensureWriteAllowed, isMutatingMethod } from './permissions.js'
 import { getProgressTracker } from './progress.js'
 import { withSpinner } from './spinner.js'
+import { getStoredUsers, updateStoredUser } from './users.js'
 
 // Mapping of API method paths to user-friendly spinner messages
 const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'green' | 'yellow' }> =
@@ -237,8 +239,8 @@ export function createWrappedTwistClient(token: string): TwistApi {
 
 export async function getTwistClient(): Promise<TwistApi> {
     if (!apiClient) {
-        const token = await getApiToken()
-        apiClient = createWrappedTwistClient(token)
+        const resolved = await resolveActiveUser({ ref: getRequestedUserRef() })
+        apiClient = createWrappedTwistClient(resolved.token)
     }
     return apiClient
 }
@@ -264,27 +266,92 @@ export async function getCurrentWorkspaceId(flagValue?: number): Promise<number>
         return flagValue
     }
 
-    const config = await getConfig()
-    if (config.currentWorkspace) {
-        return config.currentWorkspace
+    const resolved = await resolveActiveUser({ ref: getRequestedUserRef() })
+
+    // Env-token / legacy-fallback flows have no persistent slot to write
+    // into; resolve the workspace freshly from the API each call.
+    if (!resolved.id) {
+        const sessionUser = await getSessionUser()
+        if (sessionUser.defaultWorkspace) return sessionUser.defaultWorkspace
+        return firstWorkspaceId()
+    }
+
+    let config = await getConfig()
+
+    // One-shot migration: legacy installs stored a single `currentWorkspace`
+    // at the top level. Move it onto the default-or-only user so that
+    // `tw --user <other>` doesn't try to use someone else's workspace.
+    const migrated = migrateLegacyCurrentWorkspace(config)
+    if (migrated !== config) {
+        await setConfig(migrated)
+        config = migrated
+    }
+
+    const userId = resolved.id
+    const user = getStoredUsers(config).find((u) => u.id === userId)
+    if (user?.current_workspace) {
+        return user.current_workspace
     }
 
     const sessionUser = await getSessionUser()
     if (sessionUser.defaultWorkspace) {
-        await updateConfig({ currentWorkspace: sessionUser.defaultWorkspace })
+        await persistUserWorkspace(userId, sessionUser.defaultWorkspace)
         return sessionUser.defaultWorkspace
     }
 
+    const id = await firstWorkspaceId()
+    await persistUserWorkspace(userId, id)
+    return id
+}
+
+async function firstWorkspaceId(): Promise<number> {
     const workspaces = await fetchWorkspaces()
     if (workspaces.length === 0) {
         throw new CliError('NOT_FOUND', 'No workspaces found for this user', [
             'Ensure your account has been added to a workspace',
         ])
     }
+    return workspaces[0].id
+}
 
-    const defaultWorkspace = workspaces[0]
-    await updateConfig({ currentWorkspace: defaultWorkspace.id })
-    return defaultWorkspace.id
+async function persistUserWorkspace(userId: string, workspaceId: number): Promise<void> {
+    const config = await getConfig()
+    await setConfig(updateStoredUser(config, userId, { current_workspace: workspaceId }))
+}
+
+function migrateLegacyCurrentWorkspace(config: Config): Config {
+    if (typeof config.currentWorkspace !== 'number') return config
+    const users = getStoredUsers(config)
+    if (users.length === 0) {
+        // No users to attach to yet — strip the orphan so it stops being
+        // surfaced by `tw doctor` and friends.
+        const { currentWorkspace: _drop, ...rest } = config
+        return rest
+    }
+    const targetId = config.user?.default_user ?? (users.length === 1 ? users[0].id : undefined)
+    if (!targetId) {
+        // Multiple users and no default — we can't guess whose workspace
+        // this was. Drop it; `getCurrentWorkspaceId` will re-derive per
+        // user on next call.
+        const { currentWorkspace: _drop, ...rest } = config
+        return rest
+    }
+    const next: StoredUser[] = users.map((u) =>
+        u.id === targetId && u.current_workspace === undefined
+            ? { ...u, current_workspace: config.currentWorkspace }
+            : u,
+    )
+    const { currentWorkspace: _drop, ...rest } = config
+    return { ...rest, users: next }
+}
+
+/**
+ * Persist the active user's workspace selection. Used by `tw workspace use`.
+ */
+export async function setActiveAccountWorkspace(workspaceId: number): Promise<void> {
+    const resolved = await resolveActiveUser({ ref: getRequestedUserRef() })
+    if (!resolved.id) return
+    await persistUserWorkspace(resolved.id, workspaceId)
 }
 
 export async function getSessionUser(): Promise<User> {


### PR DESCRIPTION
**Part 3 of 4 stacked PRs.** Builds on #218.

## Order

- #217 — refactor: foundation
- #218 — feat: `--user` flag and `tw account list/use`
- **#219 this PR** — fix: per-account `current_workspace`
- #220 — feat: postinstall v1 → v2 migration

## Summary

With multiple authenticated accounts in play (part 2 wired up `--user`), the active workspace id must travel with each account — previously it lived at the top level of the config file and was shared across every account. `tw --user other inbox` swapped the token correctly but kept the previous account's workspace id, which the other account may not be a member of (API returned a 4xx body in place of an array, downstream `.map` blew up).

### `api.ts`

- `getTwistClient` resolves the active account via `resolveActiveUser({ ref: getRequestedUserRef() })` so every API call honours `--user`.
- `getCurrentWorkspaceId` reads from the active `StoredUser.current_workspace` and persists fresh selections back onto the same record. Env-token / legacy fallback flows resolve freshly from the session user each call (no persistent slot).
- `setActiveAccountWorkspace` writes the workspace selection onto the active account record. Used by `tw workspace use`.
- A one-shot lazy migration moves any existing top-level `currentWorkspace` onto the default (or only) account on the next workspace lookup, and drops it otherwise.

### `workspace.ts`

- `tw workspace use <ref>` now calls `setActiveAccountWorkspace` instead of writing to the top-level config.

### `inbox.ts` and `channel/threads.ts` — defensive assertBatchData

Route batch responses through the existing `assertBatchData` so a future API error surfaces as `BATCH_FAILED` CliError instead of a `TypeError` on `.map`. Defensive against API changes that break the SDK's batch-response schema validation — and exactly what caused the original symptom on the multi-account branch.

### Tests

- `inbox.test.ts` and `channel/threads.test.ts` mocks updated to include `assertBatchData` (pass-through implementation matching the production guard).

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 556 pass
