### PR TITLE
feat(auth): [4/4] postinstall v1 → v2 migration

### DIFF
--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const configState: { current: import('./config.js').Config } = { current: {} }
+
+vi.mock('./config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./config.js')>()
+    return {
+        ...actual,
+        getConfig: vi.fn(async () => configState.current),
+        setConfig: vi.fn(async (next: import('./config.js').Config) => {
+            configState.current = next
+        }),
+    }
+})
+
+vi.mock('./secure-store.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./secure-store.js')>()
+    return {
+        ...actual,
+        createSecureStore: vi.fn(),
+    }
+})
+
+import type { Config } from './config.js'
+import { migrateLegacyAuth } from './migrate-auth.js'
+import { createSecureStore } from './secure-store.js'
+
+const mockCreateSecureStore = vi.mocked(createSecureStore)
+
+function memorySecureStore(initial: string | null = null) {
+    let secret = initial
+    return {
+        getSecret: vi.fn(async () => secret),
+        setSecret: vi.fn(async (v: string) => {
+            secret = v
+        }),
+        deleteSecret: vi.fn(async () => {
+            const had = secret !== null
+            secret = null
+            return had
+        }),
+    }
+}
+
+function fetchOk(body: object) {
+    return vi.fn(async () => new Response(JSON.stringify(body), { status: 200 }))
+}
+
+function setConfigState(next: Config) {
+    configState.current = next
+}
+
+describe('migrateLegacyAuth', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        setConfigState({})
+        mockCreateSecureStore.mockImplementation(() => memorySecureStore())
+        consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+        consoleSpy.mockRestore()
+    })
+
+    it('returns already-migrated when users key is present (even if empty)', async () => {
+        setConfigState({ users: [] })
+        expect(await migrateLegacyAuth({ silent: true })).toEqual({ status: 'already-migrated' })
+    })
+
+    it('returns no-legacy-state when config is completely empty', async () => {
+        setConfigState({})
+        expect(await migrateLegacyAuth({ silent: true })).toEqual({ status: 'no-legacy-state' })
+    })
+
+    it('migrates legacy plaintext token into a per-user record', async () => {
+        const legacyStore = memorySecureStore()
+        const userStore = memorySecureStore()
+        mockCreateSecureStore.mockImplementation((slot?: string) =>
+            slot === 'user-42' ? userStore : legacyStore,
+        )
+        setConfigState({
+            token: 'legacy-token',
+            authMode: 'read-write',
+            authScope: 'user:read threads:read',
+        })
+
+        const fetchImpl = fetchOk({ id: 42, email: 'ada@example.com', name: 'Ada' })
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl })
+
+        expect(result).toMatchObject({
+            status: 'migrated',
+            migratedUserId: '42',
+            migratedEmail: 'ada@example.com',
+        })
+        expect(configState.current.users).toEqual([
+            {
+                id: '42',
+                email: 'ada@example.com',
+                name: 'Ada',
+                auth_mode: 'read-write',
+                auth_scope: 'user:read threads:read',
+            },
+        ])
+        expect(configState.current.user?.default_user).toBe('42')
+        expect(configState.current.token).toBeUndefined()
+        expect(configState.current.authMode).toBeUndefined()
+        expect(configState.current.config_version).toBe(2)
+        expect(userStore.setSecret).toHaveBeenCalledWith('legacy-token')
+    })
+
+    it('migrates legacy keyring token (no plaintext) via the api-token slot', async () => {
+        const legacyStore = memorySecureStore('keyring-token')
+        const userStore = memorySecureStore()
+        mockCreateSecureStore.mockImplementation((slot?: string) =>
+            slot === 'user-7' ? userStore : legacyStore,
+        )
+        setConfigState({})
+        // Make config look v1 by NOT having `users` key, but with no plaintext
+        // token. The keyring read happens via createSecureStore(LEGACY_*).
+        const fetchImpl = fetchOk({ id: 7, email: 'k@example.com' })
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl })
+        expect(result.status).toBe('migrated')
+        expect(configState.current.users?.[0].id).toBe('7')
+    })
+
+    it('skips and leaves v1 state untouched when getSessionUser fails', async () => {
+        setConfigState({ token: 'bad-token' })
+        const failingFetch = vi.fn(async () => new Response('nope', { status: 401 }))
+        const result = await migrateLegacyAuth({ silent: true, fetchImpl: failingFetch })
+        expect(result.status).toBe('skipped')
+        expect(configState.current.token).toBe('bad-token')
+        expect(configState.current.users).toBeUndefined()
+    })
+})

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -1,0 +1,184 @@
+/**
+ * One-time migration of v1 single-user auth state into the v2 multi-user
+ * shape. Invoked from `src/postinstall.ts` so existing installs upgrade
+ * transparently. Best-effort: any failure (offline, invalid token, keyring
+ * unavailable) leaves the v1 state untouched so the runtime fallback in
+ * `resolveActiveUser` can keep serving the legacy token until the next
+ * upgrade attempt or `tw auth login`.
+ */
+
+import { type Config, CONFIG_VERSION, getConfig, setConfig, type StoredUser } from './config.js'
+import {
+    accountForUser,
+    createSecureStore,
+    LEGACY_ACCOUNT_NAME,
+    SecureStoreUnavailableError,
+} from './secure-store.js'
+
+export type MigrateAuthResult = {
+    status: 'already-migrated' | 'no-legacy-state' | 'migrated' | 'skipped'
+    reason?: string
+    migratedUserId?: string
+    migratedEmail?: string
+}
+
+type MigrateOptions = {
+    /** Suppress console output. Postinstall sets this; CLI surfaces use it via warn(). */
+    silent?: boolean
+    /** Override fetch (for tests). */
+    fetchImpl?: typeof fetch
+}
+
+type SessionUser = {
+    id: string
+    email: string
+    name?: string
+}
+
+const SESSION_ENDPOINT = 'https://api.twist.com/api/v3/users/get_session_user'
+
+export async function migrateLegacyAuth(opts: MigrateOptions = {}): Promise<MigrateAuthResult> {
+    const fetchImpl = opts.fetchImpl ?? fetch
+    const config = await getConfig()
+
+    // Already on v2 — the presence of `users` is the marker. Empty array
+    // still counts as migrated (clean slate after a logout).
+    if (Array.isArray(config.users)) {
+        return { status: 'already-migrated' }
+    }
+
+    const legacyToken = await loadLegacyToken(config)
+    if (!legacyToken) {
+        // No usable token to migrate. If there's nothing legacy at all, exit
+        // without writing the file. Otherwise clean up to v2 shape.
+        if (
+            config.token === undefined &&
+            config.authMode === undefined &&
+            config.authScope === undefined &&
+            !config.pendingSecureStoreClear
+        ) {
+            return { status: 'no-legacy-state' }
+        }
+
+        try {
+            await setConfig(toV2(stripLegacy(config), []))
+        } catch (error) {
+            return skipped(opts, `failed to clean up legacy config (${describe(error)})`)
+        }
+        return { status: 'migrated' }
+    }
+
+    // Identify the user behind the legacy token via a one-shot REST call —
+    // no SDK import to keep postinstall lightweight.
+    let user: SessionUser
+    try {
+        user = await fetchSessionUser(legacyToken, fetchImpl)
+    } catch (error) {
+        return skipped(opts, `could not identify Twist user (${describe(error)})`)
+    }
+
+    const record: StoredUser = {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        auth_mode: config.authMode,
+        auth_scope: config.authScope,
+    }
+
+    // Move the token into the per-user keyring slot.
+    let storedSecurely = false
+    try {
+        const userStore = createSecureStore(accountForUser(user.id))
+        await userStore.setSecret(legacyToken)
+        storedSecurely = true
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) {
+            return skipped(opts, `failed to write user-scoped credential (${describe(error)})`)
+        }
+    }
+
+    if (!storedSecurely) {
+        record.api_token = legacyToken
+    }
+
+    const next = toV2(stripLegacy(config), [record], user.id)
+
+    try {
+        await setConfig(next)
+    } catch (error) {
+        return skipped(opts, `failed to update config (${describe(error)})`)
+    }
+
+    // Clean up the legacy keyring entry — best effort, never fatal.
+    try {
+        const legacyStore = createSecureStore(LEGACY_ACCOUNT_NAME)
+        await legacyStore.deleteSecret()
+    } catch {
+        // ignore
+    }
+
+    if (!opts.silent) {
+        console.error(`twist-cli: migrated existing token to multi-user store (${user.email}).`)
+    }
+
+    return { status: 'migrated', migratedUserId: user.id, migratedEmail: user.email }
+}
+
+async function loadLegacyToken(config: Config): Promise<string | null> {
+    if (typeof config.token === 'string' && config.token.trim()) {
+        return config.token.trim()
+    }
+    try {
+        const legacyStore = createSecureStore(LEGACY_ACCOUNT_NAME)
+        const stored = await legacyStore.getSecret()
+        if (stored?.trim()) return stored.trim()
+    } catch (error) {
+        if (!(error instanceof SecureStoreUnavailableError)) throw error
+    }
+    return null
+}
+
+async function fetchSessionUser(token: string, fetchImpl: typeof fetch): Promise<SessionUser> {
+    const response = await fetchImpl(SESSION_ENDPOINT, {
+        headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`)
+    }
+    const data = (await response.json()) as { id?: unknown; email?: unknown; name?: unknown }
+    if (data.id === undefined || data.id === null) {
+        throw new Error('response missing user id')
+    }
+    if (typeof data.email !== 'string' || !data.email) {
+        throw new Error('response missing user email')
+    }
+    return {
+        id: String(data.id),
+        email: data.email,
+        name: typeof data.name === 'string' ? data.name : undefined,
+    }
+}
+
+function toV2(config: Config, users: StoredUser[], defaultUserId?: string): Config {
+    const next: Config = { ...config, config_version: CONFIG_VERSION, users }
+    if (defaultUserId) {
+        next.user = { ...next.user, default_user: defaultUserId }
+    }
+    return next
+}
+
+function stripLegacy(config: Config): Config {
+    const { token: _t, authMode: _m, authScope: _s, pendingSecureStoreClear: _p, ...rest } = config
+    return rest
+}
+
+function describe(error: unknown): string {
+    return error instanceof Error && error.message ? error.message : String(error)
+}
+
+function skipped(opts: MigrateOptions, reason: string): MigrateAuthResult {
+    if (!opts.silent) {
+        console.error(`twist-cli: skipped legacy auth migration — ${reason}.`)
+    }
+    return { status: 'skipped', reason }
+}

--- a/src/postinstall.test.ts
+++ b/src/postinstall.test.ts
@@ -4,6 +4,10 @@ vi.mock('./lib/skills/update-installed.js', () => ({
     updateAllInstalledSkills: vi.fn().mockResolvedValue({ updated: [], skipped: [], errors: [] }),
 }))
 
+vi.mock('./lib/migrate-auth.js', () => ({
+    migrateLegacyAuth: vi.fn().mockResolvedValue({ status: 'no-legacy-state' }),
+}))
+
 describe('postinstall', () => {
     beforeEach(() => {
         vi.resetModules()
@@ -15,9 +19,21 @@ describe('postinstall', () => {
         expect(updateAllInstalledSkills).toHaveBeenCalledWith({ local: false })
     })
 
-    it('swallows errors', async () => {
+    it('calls migrateLegacyAuth silently', async () => {
+        const { migrateLegacyAuth } = await import('./lib/migrate-auth.js')
+        await import('./postinstall.js')
+        expect(migrateLegacyAuth).toHaveBeenCalledWith({ silent: true })
+    })
+
+    it('swallows skill-update errors', async () => {
         const { updateAllInstalledSkills } = await import('./lib/skills/update-installed.js')
         vi.mocked(updateAllInstalledSkills).mockRejectedValueOnce(new Error('fail'))
+        await expect(import('./postinstall.js')).resolves.not.toThrow()
+    })
+
+    it('swallows migration errors', async () => {
+        const { migrateLegacyAuth } = await import('./lib/migrate-auth.js')
+        vi.mocked(migrateLegacyAuth).mockRejectedValueOnce(new Error('fail'))
         await expect(import('./postinstall.js')).resolves.not.toThrow()
     })
 })

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,3 +1,5 @@
+import { migrateLegacyAuth } from './lib/migrate-auth.js'
 import { updateAllInstalledSkills } from './lib/skills/update-installed.js'
 
 updateAllInstalledSkills({ local: false }).catch(() => {})
+migrateLegacyAuth({ silent: true }).catch(() => {})


### PR DESCRIPTION
**Part 4 of 4 stacked PRs — final piece.** Builds on #219.

When this lands, the integration branch `scottl/multi-user-base` is ready to merge into `main` as one release.

## Order

- #217 — refactor: foundation
- #218 — feat: `--user` flag and `tw account list/use`
- #219 — fix: per-account `current_workspace`
- **#220 this PR** — feat: postinstall v1 → v2 migration

## Summary

With multi-user storage in place (parts 1-3), v1 single-user installs need a path forward. This adds a best-effort postinstall migration so existing tokens move to the new per-user keyring slot transparently on upgrade.

### `lib/migrate-auth.ts` (NEW)

- `migrateLegacyAuth` is best-effort: any failure (offline, invalid token, keyring unavailable) leaves the v1 state untouched so the runtime fallback in `resolveActiveUser` keeps serving the legacy token until the next attempt or `tw auth login`.
- Detects v1 shape via absence of `config.users`. `users: []` (a clean v2 logout state) is treated as already-migrated — important so a logged-out v2 install can't silently re-auth from a stale legacy keyring entry.
- Loads the legacy token (config plaintext first, then `api-token` keyring slot) and identifies the user via a one-shot REST call to `/api/v3/users/get_session_user`. Uses raw `fetch` so the postinstall path doesn't pull in the SDK.
- On success: writes a `StoredUser` to `config.users[0]`, sets `config.user.default_user`, stores the token in `user-<id>`, deletes the legacy `api-token` slot (best effort), and strips legacy top-level fields.
- On secure-store failure: persists the token to `users[0].api_token` as plaintext fallback (matches the `upsertUser` contract).

### `postinstall.ts`

Calls `migrateLegacyAuth({ silent: true })`. Failures are swallowed so a flaky upgrade never blocks `npm install`.

### Tests

- `migrate-auth.test.ts` covers: already-migrated short-circuit (`users: []` and `users: [...]`), no-legacy-state empty config, successful migration of a plaintext + keyring legacy token, and the skipped-on-401 path (config untouched).
- `postinstall.test.ts` asserts `migrateLegacyAuth({ silent: true })` is invoked and that errors are swallowed.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 563 pass

## After this lands

Open a final PR `scottl/multi-user-base` → `main` so semantic-release ships one minor (the `feat:` commits across this stack add up to one release with combined release notes).
