### PR TITLE
feat(auth): adopt cli-core 0.12.0 multi-user TokenStore shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@doist/cli-core": "0.10.0",
+                "@doist/cli-core": "0.12.0",
                 "@doist/twist-sdk": "2.5.1",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
@@ -137,13 +137,13 @@
             }
         },
         "node_modules/@doist/cli-core": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.10.0.tgz",
-            "integrity": "sha512-ya/+G0fJ8s+KJxIKsftKUAFGSHKFPGSPfNYJY961xoIuz1F+fm575vesPzWxaCRbmD6Z3vaiXUAxxG7SyfmgLQ==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.12.0.tgz",
+            "integrity": "sha512-6dk9mL+HMmkfijcO9t+AtXO+2vxV6Gj5thD91sExNJfInnmQzFhMSYOJ/8u/k5gzpD9wyVAxL+q+bzt8s9eeQw==",
             "license": "MIT",
             "dependencies": {
                 "chalk": "5.6.2",
-                "yocto-spinner": "1.1.0"
+                "yocto-spinner": "1.2.0"
             },
             "engines": {
                 "node": ">=20.18.1"
@@ -171,21 +171,6 @@
                 "vitest": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@doist/cli-core/node_modules/yocto-spinner": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.1.0.tgz",
-            "integrity": "sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==",
-            "license": "MIT",
-            "dependencies": {
-                "yoctocolors": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=18.19"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@doist/twist-sdk": {
@@ -10676,6 +10661,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/yocto-spinner": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.0.tgz",
+            "integrity": "sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==",
+            "license": "MIT",
+            "dependencies": {
+                "yoctocolors": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=18.19"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "CHANGELOG.md"
     ],
     "dependencies": {
-        "@doist/cli-core": "0.10.0",
+        "@doist/cli-core": "0.12.0",
         "@doist/twist-sdk": "2.5.1",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -22,8 +22,11 @@ tw auth login --ndjson           # Emit an NDJSON envelope for scripted / agent 
 tw auth token                    # Save API token manually (prompts securely; scope unknown, assumed write-capable)
 tw auth status                   # Verify authentication + show mode
 tw auth status --json            # Full status payload as JSON (--ndjson also supported)
+tw auth status --user <ref>      # Target a specific stored account (id, id:<n>, or display name)
 tw auth logout                   # Remove saved token and auth metadata
 tw auth logout --json            # Emits `{"ok": true}` (--ndjson is silent)
+tw auth logout --user <ref>      # Target a specific stored account; mismatched ref errors with ACCOUNT_NOT_FOUND
+tw auth token --user <ref>       # Print the saved token for a specific stored account
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -294,6 +294,10 @@ describe('auth command', () => {
                 },
                 async set() {},
                 async clear() {},
+                async list() {
+                    return [{ account: SNAPSHOT_ACCOUNT, isDefault: true }]
+                },
+                async setDefault() {},
                 getLastStorageResult: () => undefined,
                 getLastClearResult: () => undefined,
             }
@@ -388,6 +392,10 @@ describe('auth command', () => {
                 },
                 async set() {},
                 async clear() {},
+                async list() {
+                    return []
+                },
+                async setDefault() {},
                 getLastStorageResult: () => undefined,
                 getLastClearResult: () => undefined,
             }

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -247,4 +247,116 @@ describe('createTwistTokenStore', () => {
         expect(mockClear).toHaveBeenCalledTimes(1)
         expect(store.getLastClearResult()).toEqual({ storage: 'secure-store' })
     })
+
+    describe('ref-aware lookups', () => {
+        const STORED_METADATA = {
+            authMode: 'read-write' as const,
+            authScope: 'user:read',
+            authUserId: 42,
+            authUserName: 'Ada',
+            source: 'config-file' as const,
+        }
+        const STORED_ACCOUNT = {
+            id: '42',
+            label: 'Ada',
+            authMode: 'read-write' as const,
+            authScope: 'user:read',
+        }
+
+        it('active(ref) returns the snapshot when the numeric id ref matches', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            expect(await createTwistTokenStore().active('42')).toEqual({
+                token: 'tk',
+                account: STORED_ACCOUNT,
+            })
+        })
+
+        it('active(ref) accepts the id:<n> form normalised by parseRef', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            expect(await createTwistTokenStore().active('id:42')).toEqual({
+                token: 'tk',
+                account: STORED_ACCOUNT,
+            })
+        })
+
+        it('active(ref) matches the stored label case-insensitively', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            expect(await createTwistTokenStore().active('ADA')).toEqual({
+                token: 'tk',
+                account: STORED_ACCOUNT,
+            })
+        })
+
+        it('active(ref) throws ACCOUNT_NOT_FOUND on mismatch so status surfaces a distinct error', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            await expect(createTwistTokenStore().active('other')).rejects.toMatchObject({
+                code: 'ACCOUNT_NOT_FOUND',
+            })
+        })
+
+        it('active(ref) throws ACCOUNT_NOT_FOUND when no token is stored at all', async () => {
+            mockProbe.mockRejectedValueOnce(new NoTokenError())
+            await expect(createTwistTokenStore().active('42')).rejects.toMatchObject({
+                code: 'ACCOUNT_NOT_FOUND',
+            })
+        })
+
+        it('active(ref) surfaces a secure-store outage instead of masking it as ACCOUNT_NOT_FOUND', async () => {
+            const { SecureStoreUnavailableError } = await import('./secure-store.js')
+            mockProbe.mockRejectedValueOnce(new SecureStoreUnavailableError('no keyring'))
+            await expect(createTwistTokenStore().active('42')).rejects.toBeInstanceOf(
+                SecureStoreUnavailableError,
+            )
+        })
+
+        it('clear(ref) clears storage when the ref matches', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            mockClear.mockResolvedValueOnce({ storage: 'secure-store' })
+            const store = createTwistTokenStore()
+            await store.clear('42')
+            expect(mockClear).toHaveBeenCalledTimes(1)
+            expect(store.getLastClearResult()).toEqual({ storage: 'secure-store' })
+        })
+
+        it('clear(ref) throws ACCOUNT_NOT_FOUND on mismatch and does not touch storage', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            const store = createTwistTokenStore()
+            await expect(store.clear('other')).rejects.toMatchObject({
+                code: 'ACCOUNT_NOT_FOUND',
+            })
+            expect(mockClear).not.toHaveBeenCalled()
+        })
+
+        it('list() returns the single stored account flagged as default', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            expect(await createTwistTokenStore().list()).toEqual([
+                { account: STORED_ACCOUNT, isDefault: true },
+            ])
+        })
+
+        it('list() returns an empty array when no token is stored', async () => {
+            mockProbe.mockRejectedValueOnce(new NoTokenError())
+            expect(await createTwistTokenStore().list()).toEqual([])
+        })
+
+        it('list() propagates secure-store outage rather than collapsing to "no accounts"', async () => {
+            const { SecureStoreUnavailableError } = await import('./secure-store.js')
+            mockProbe.mockRejectedValueOnce(new SecureStoreUnavailableError('no keyring'))
+            await expect(createTwistTokenStore().list()).rejects.toBeInstanceOf(
+                SecureStoreUnavailableError,
+            )
+        })
+
+        it('setDefault(ref) resolves silently when the ref matches the one stored account', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            await expect(createTwistTokenStore().setDefault('42')).resolves.toBeUndefined()
+        })
+
+        it('setDefault(ref) throws ACCOUNT_NOT_FOUND when the ref does not match', async () => {
+            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
+            await expect(createTwistTokenStore().setDefault('other')).rejects.toMatchObject({
+                code: 'ACCOUNT_NOT_FOUND',
+            })
+        })
+    })
 })

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -1,4 +1,5 @@
 import {
+    type AccountRef,
     type AuthAccount,
     type AuthProvider,
     deriveChallenge,
@@ -274,8 +275,29 @@ export type TwistTokenStore = TokenStore<TwistAccount> & {
 export function createTwistTokenStore(): TwistTokenStore {
     let lastStorageResult: TokenStorageResult | undefined
     let lastClearResult: TokenStorageResult | undefined
+    async function loadSnapshot(): Promise<{ token: string; account: TwistAccount } | null> {
+        try {
+            const { token, metadata } = await probeApiToken()
+            return {
+                token,
+                account: {
+                    id: metadata.authUserId !== undefined ? String(metadata.authUserId) : '',
+                    label: metadata.authUserName ?? '',
+                    authMode: metadata.authMode,
+                    authScope: metadata.authScope ?? '',
+                },
+            }
+        } catch (error) {
+            if (error instanceof NoTokenError) return null
+            if (error instanceof SecureStoreUnavailableError) return null
+            throw error
+        }
+    }
+    function matchesRef(account: TwistAccount, ref: AccountRef): boolean {
+        return account.id === ref || account.label === ref
+    }
     return {
-        async active() {
+        async active(ref?: AccountRef) {
             // Return a snapshot whenever a token resolves — even if the
             // persisted identity is missing (env var, manual `tw auth token`,
             // pre-upgrade config). Callers downstream (e.g. status's
@@ -290,22 +312,10 @@ export function createTwistTokenStore(): TwistTokenStore {
             // the standard `NoTokenError` envelope instead of leaking the raw
             // secure-store error — matching the legacy `getApiToken`
             // behaviour the prior `showStatus()` relied on.
-            try {
-                const { token, metadata } = await probeApiToken()
-                return {
-                    token,
-                    account: {
-                        id: metadata.authUserId !== undefined ? String(metadata.authUserId) : '',
-                        label: metadata.authUserName ?? '',
-                        authMode: metadata.authMode,
-                        authScope: metadata.authScope ?? '',
-                    },
-                }
-            } catch (error) {
-                if (error instanceof NoTokenError) return null
-                if (error instanceof SecureStoreUnavailableError) return null
-                throw error
-            }
+            const snapshot = await loadSnapshot()
+            if (!snapshot) return null
+            if (ref !== undefined && !matchesRef(snapshot.account, ref)) return null
+            return snapshot
         },
         async set(account, token) {
             const userId = Number(account.id)
@@ -316,8 +326,26 @@ export function createTwistTokenStore(): TwistTokenStore {
                 authUserName: account.label,
             })
         },
-        async clear() {
+        async clear(ref?: AccountRef) {
+            if (ref !== undefined) {
+                const snapshot = await loadSnapshot()
+                if (!snapshot || !matchesRef(snapshot.account, ref)) {
+                    lastClearResult = undefined
+                    return
+                }
+            }
             lastClearResult = await clearApiToken()
+        },
+        async list() {
+            const snapshot = await loadSnapshot()
+            return snapshot ? [{ account: snapshot.account, isDefault: true }] : []
+        },
+        async setDefault(ref: AccountRef) {
+            const snapshot = await loadSnapshot()
+            if (!snapshot || !matchesRef(snapshot.account, ref)) {
+                throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${ref}".`)
+            }
+            // Single-user store — already the default.
         },
         getLastStorageResult() {
             return lastStorageResult

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -16,6 +16,7 @@ import {
 } from './auth.js'
 import type { AuthMode } from './config.js'
 import { CliError } from './errors.js'
+import { parseRef } from './refs.js'
 import { SecureStoreUnavailableError } from './secure-store.js'
 
 export const AUTHORIZATION_URL = 'https://twist.com/oauth/authorize'
@@ -275,7 +276,19 @@ export type TwistTokenStore = TokenStore<TwistAccount> & {
 export function createTwistTokenStore(): TwistTokenStore {
     let lastStorageResult: TokenStorageResult | undefined
     let lastClearResult: TokenStorageResult | undefined
-    async function loadSnapshot(): Promise<{ token: string; account: TwistAccount } | null> {
+
+    /**
+     * Read the stored credential. By default `NoTokenError` collapses to
+     * `null` (i.e. "nothing stored" is not an exception), while
+     * `SecureStoreUnavailableError` propagates so callers see a keyring
+     * outage as distinct from "no account". The legacy `active()` no-ref
+     * path opts in to also tolerate the outage so headless / keyring-less
+     * hosts keep falling through to the standard `NoTokenError` envelope
+     * (matching the historical `getApiToken` → `showStatus()` behaviour).
+     */
+    async function loadStoredSnapshot(
+        options: { tolerateOutage?: boolean } = {},
+    ): Promise<{ token: string; account: TwistAccount } | null> {
         try {
             const { token, metadata } = await probeApiToken()
             return {
@@ -289,33 +302,61 @@ export function createTwistTokenStore(): TwistTokenStore {
             }
         } catch (error) {
             if (error instanceof NoTokenError) return null
-            if (error instanceof SecureStoreUnavailableError) return null
+            if (error instanceof SecureStoreUnavailableError) {
+                if (options.tolerateOutage) return null
+                throw error
+            }
             throw error
         }
     }
+
+    /**
+     * Match the stored account against the user-supplied `--user <ref>`,
+     * normalising through `parseRef` so `id:42`, `42`, and a case-insensitive
+     * label all resolve consistently with the rest of the CLI. URL refs
+     * never apply to accounts — fall through to "no match" instead of
+     * silently accepting one.
+     */
     function matchesRef(account: TwistAccount, ref: AccountRef): boolean {
-        return account.id === ref || account.label === ref
+        const parsed = parseRef(ref)
+        if (parsed.type === 'id') return Number(account.id) === parsed.id
+        if (parsed.type === 'name') {
+            return account.label.toLowerCase() === parsed.name.toLowerCase()
+        }
+        return false
     }
+
+    /**
+     * Single source of truth for ref-aware lookups. Returns the snapshot
+     * when `ref` matches the stored account, throws `ACCOUNT_NOT_FOUND`
+     * otherwise (including when nothing is stored). Storage outages
+     * propagate so the caller sees the underlying failure rather than
+     * a misleading "account not found".
+     */
+    async function resolveByRef(
+        ref: AccountRef,
+    ): Promise<{ token: string; account: TwistAccount }> {
+        const snapshot = await loadStoredSnapshot()
+        if (!snapshot || !matchesRef(snapshot.account, ref)) {
+            throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${ref}".`)
+        }
+        return snapshot
+    }
+
     return {
         async active(ref?: AccountRef) {
-            // Return a snapshot whenever a token resolves — even if the
-            // persisted identity is missing (env var, manual `tw auth token`,
-            // pre-upgrade config). Callers downstream (e.g. status's
-            // `fetchLive`) will re-derive the canonical account from the live
-            // API, so the placeholder fields below are intentionally empty.
-            // Returning a snapshot here also avoids a second credential read
-            // in those code paths — the token discovered during `probeApiToken`
-            // is reused rather than re-resolved through `getApiToken`.
-            //
-            // `SecureStoreUnavailableError` is downgraded to `null` (no
-            // snapshot) so headless / keyring-less environments fall back to
-            // the standard `NoTokenError` envelope instead of leaking the raw
-            // secure-store error — matching the legacy `getApiToken`
-            // behaviour the prior `showStatus()` relied on.
-            const snapshot = await loadSnapshot()
-            if (!snapshot) return null
-            if (ref !== undefined && !matchesRef(snapshot.account, ref)) return null
-            return snapshot
+            // No-ref legacy path — tolerate missing keyring / no token and
+            // return null so downstream callers (status's `fetchLive`,
+            // login's pre-flight, etc.) keep falling through to their own
+            // `NoTokenError` envelope rather than seeing a raw keyring
+            // error. Returning a snapshot whenever a token resolves — even
+            // when the persisted identity is empty (env var, manual
+            // `tw auth token`, pre-upgrade config) — also avoids a second
+            // credential read downstream.
+            if (ref === undefined) {
+                return loadStoredSnapshot({ tolerateOutage: true })
+            }
+            return resolveByRef(ref)
         },
         async set(account, token) {
             const userId = Number(account.id)
@@ -327,25 +368,22 @@ export function createTwistTokenStore(): TwistTokenStore {
             })
         },
         async clear(ref?: AccountRef) {
+            // With `ref`, validate before touching storage so a mismatch is
+            // an `ACCOUNT_NOT_FOUND` error rather than a silent
+            // ✓ Logged out — the upstream `attachLogoutCommand` treats any
+            // non-throwing `clear()` as success.
             if (ref !== undefined) {
-                const snapshot = await loadSnapshot()
-                if (!snapshot || !matchesRef(snapshot.account, ref)) {
-                    lastClearResult = undefined
-                    return
-                }
+                await resolveByRef(ref)
             }
             lastClearResult = await clearApiToken()
         },
         async list() {
-            const snapshot = await loadSnapshot()
+            const snapshot = await loadStoredSnapshot()
             return snapshot ? [{ account: snapshot.account, isDefault: true }] : []
         },
         async setDefault(ref: AccountRef) {
-            const snapshot = await loadSnapshot()
-            if (!snapshot || !matchesRef(snapshot.account, ref)) {
-                throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${ref}".`)
-            }
-            // Single-user store — already the default.
+            await resolveByRef(ref)
+            // Single-user store — already the default once `ref` matches.
         },
         getLastStorageResult() {
             return lastStorageResult

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -33,6 +33,7 @@ export type ErrorCode =
     | 'INVALID_NAME'
     | 'MISSING_USERS'
     // Not found
+    | 'ACCOUNT_NOT_FOUND'
     | 'CHANNEL_NOT_FOUND'
     | 'GROUP_NOT_FOUND'
     | 'NOT_FOUND'

--- a/src/lib/global-args.ts
+++ b/src/lib/global-args.ts
@@ -37,7 +37,10 @@ type TwSpecificFlags = {
  * Commander — exposing them in the type would lie about what the binary
  * supports.
  */
-export type TwGlobalArgs = Pick<CoreGlobalArgs, 'json' | 'ndjson' | 'accessible' | 'noSpinner'> &
+export type TwGlobalArgs = Pick<
+    CoreGlobalArgs,
+    'json' | 'ndjson' | 'accessible' | 'noSpinner' | 'user'
+> &
     TwSpecificFlags
 
 /** Back-compat alias — pre-cli-core twist code imported `GlobalArgs` from this module. */

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -26,8 +26,11 @@ tw auth login --ndjson           # Emit an NDJSON envelope for scripted / agent 
 tw auth token                    # Save API token manually (prompts securely; scope unknown, assumed write-capable)
 tw auth status                   # Verify authentication + show mode
 tw auth status --json            # Full status payload as JSON (--ndjson also supported)
+tw auth status --user <ref>      # Target a specific stored account (id, id:<n>, or display name)
 tw auth logout                   # Remove saved token and auth metadata
 tw auth logout --json            # Emits \`{"ok": true}\` (--ndjson is silent)
+tw auth logout --user <ref>      # Target a specific stored account; mismatched ref errors with ACCOUNT_NOT_FOUND
+tw auth token --user <ref>       # Print the saved token for a specific stored account
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions


### PR DESCRIPTION
## Summary

- Bump `@doist/cli-core` from 0.10.0 → 0.12.0.
- Reshape `TwistTokenStore` to the new uniformly-multi-user `TokenStore` contract: `active(ref?)` / `clear(ref?)` honour the optional `AccountRef`, plus new `list()` (one-element / empty) and `setDefault(ref)` (validates against the single stored account, throws `ACCOUNT_NOT_FOUND` on mismatch).
- Widen `TwGlobalArgs` to surface cli-core's new `--user` field.
- Update auth.test.ts store fakes to satisfy the wider contract.

Storage backend stays single-slot — this PR is just contract compliance so the upstream `--user <ref>` flag attached by `attachLogoutCommand` / `attachStatusCommand` / `attachTokenViewCommand` lands cleanly. Multi-account storage is a future PR.

## Test plan

- [x] `npm run type-check`
- [x] `npm run build`
- [x] `npm test` — 594 / 594 pass
- [x] `npm run lint:check`
- [ ] Manual: `tw auth status` / `tw auth logout` still work against an existing token
- [ ] Manual: `tw auth logout --user <id>` matches the stored account; mismatched ref is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)