### PR TITLE
feat(auth): add `tw auth token view` via cli-core attachTokenViewCommand

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -26,7 +26,8 @@ tw auth status --user <ref>      # Target a specific stored account (id, id:<n>,
 tw auth logout                   # Remove saved token and auth metadata
 tw auth logout --json            # Emits `{"ok": true}` (--ndjson is silent)
 tw auth logout --user <ref>      # Target a specific stored account; mismatched ref errors with ACCOUNT_NOT_FOUND
-tw auth token --user <ref>       # Print the saved token for a specific stored account
+tw auth token view               # Print the saved token to stdout (pipe-safe; refuses if TWIST_API_TOKEN is set)
+tw auth token view --user <ref>  # Print the saved token for a specific stored account
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -290,17 +290,24 @@ describe('auth command', () => {
 
         let writeSpy: ReturnType<typeof vi.spyOn>
 
+        // Capture the full stdout payload so we can assert pipe-safety: any
+        // extra preamble/trailer added by a future change would change this
+        // string and fail the test.
+        function stdoutPayload(): string {
+            return writeSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('')
+        }
+
         beforeEach(() => {
             writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
-            delete process.env[TOKEN_ENV_VAR]
         })
 
         afterEach(() => {
             writeSpy.mockRestore()
-            delete process.env[TOKEN_ENV_VAR]
+            vi.unstubAllEnvs()
         })
 
-        it('prints the stored token to stdout for pipe-safe consumption', async () => {
+        it('prints exactly the stored token to stdout with no envelope (pipe-safe)', async () => {
+            vi.stubEnv(TOKEN_ENV_VAR, '')
             mockProbeApiToken.mockResolvedValueOnce({
                 token: 'tk_stored_1234567890',
                 metadata: STORED_METADATA,
@@ -309,11 +316,12 @@ describe('auth command', () => {
             const program = createProgram()
             await program.parseAsync(['node', 'tw', 'auth', 'token', 'view'])
 
-            expect(writeSpy).toHaveBeenCalledWith('tk_stored_1234567890')
+            expect(stdoutPayload()).toBe('tk_stored_1234567890')
+            expect(consoleSpy).not.toHaveBeenCalled()
         })
 
         it('refuses to print when the env var is set so the CLI does not disclose an unmanaged token', async () => {
-            process.env[TOKEN_ENV_VAR] = 'env_token_supplied_externally'
+            vi.stubEnv(TOKEN_ENV_VAR, 'env_token_supplied_externally')
 
             const program = createProgram()
             await expect(
@@ -321,10 +329,11 @@ describe('auth command', () => {
             ).rejects.toHaveProperty('code', 'TOKEN_FROM_ENV')
 
             expect(mockProbeApiToken).not.toHaveBeenCalled()
-            expect(writeSpy).not.toHaveBeenCalled()
+            expect(stdoutPayload()).toBe('')
         })
 
         it('throws NOT_AUTHENTICATED when no token is stored', async () => {
+            vi.stubEnv(TOKEN_ENV_VAR, '')
             mockProbeApiToken.mockRejectedValueOnce(new NoTokenError())
 
             const program = createProgram()
@@ -332,10 +341,11 @@ describe('auth command', () => {
                 program.parseAsync(['node', 'tw', 'auth', 'token', 'view']),
             ).rejects.toHaveProperty('code', 'NOT_AUTHENTICATED')
 
-            expect(writeSpy).not.toHaveBeenCalled()
+            expect(stdoutPayload()).toBe('')
         })
 
         it('matches --user against the stored account by numeric id', async () => {
+            vi.stubEnv(TOKEN_ENV_VAR, '')
             mockProbeApiToken.mockResolvedValueOnce({
                 token: 'tk_stored_1234567890',
                 metadata: STORED_METADATA,
@@ -344,10 +354,12 @@ describe('auth command', () => {
             const program = createProgram()
             await program.parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '1'])
 
-            expect(writeSpy).toHaveBeenCalledWith('tk_stored_1234567890')
+            expect(stdoutPayload()).toBe('tk_stored_1234567890')
+            expect(consoleSpy).not.toHaveBeenCalled()
         })
 
         it('rejects --user with ACCOUNT_NOT_FOUND when the ref does not match the stored account', async () => {
+            vi.stubEnv(TOKEN_ENV_VAR, '')
             mockProbeApiToken.mockResolvedValueOnce({
                 token: 'tk_stored_1234567890',
                 metadata: STORED_METADATA,
@@ -358,7 +370,7 @@ describe('auth command', () => {
                 program.parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '999']),
             ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
 
-            expect(writeSpy).not.toHaveBeenCalled()
+            expect(stdoutPayload()).toBe('')
         })
     })
 

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../lib/auth.js', async (importOriginal) => {
         saveApiToken: vi.fn(),
         clearApiToken: vi.fn(),
         getAuthMetadata: vi.fn(),
+        probeApiToken: vi.fn(),
     }
 })
 
@@ -57,7 +58,14 @@ import { attachLoginCommand } from '@doist/cli-core/auth'
 import { TwistRequestError, type User } from '@doist/twist-sdk'
 import { createWrappedTwistClient } from '../../lib/api.js'
 import { type TwistAccount, type TwistTokenStore } from '../../lib/auth-provider.js'
-import { clearApiToken, getAuthMetadata, saveApiToken } from '../../lib/auth.js'
+import {
+    clearApiToken,
+    getAuthMetadata,
+    NoTokenError,
+    probeApiToken,
+    saveApiToken,
+    TOKEN_ENV_VAR,
+} from '../../lib/auth.js'
 import { registerAuthCommand } from './index.js'
 import { attachTwistStatusCommand } from './status.js'
 
@@ -66,6 +74,7 @@ const mockCreateInterface = vi.mocked(createInterface)
 const mockSaveApiToken = vi.mocked(saveApiToken)
 const mockClearApiToken = vi.mocked(clearApiToken)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
+const mockProbeApiToken = vi.mocked(probeApiToken)
 const mockCreateWrappedTwistClient = vi.mocked(createWrappedTwistClient)
 const mockAttachLoginCommand = vi.mocked(attachLoginCommand)
 
@@ -267,6 +276,89 @@ describe('auth command', () => {
                 value: originalIsTTY,
                 configurable: true,
             })
+        })
+    })
+
+    describe('token view subcommand', () => {
+        const STORED_METADATA = {
+            authMode: 'read-write' as const,
+            authScope: 'user:read',
+            authUserId: 1,
+            authUserName: 'Test User',
+            source: 'secure-store' as const,
+        }
+
+        let writeSpy: ReturnType<typeof vi.spyOn>
+
+        beforeEach(() => {
+            writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            delete process.env[TOKEN_ENV_VAR]
+        })
+
+        afterEach(() => {
+            writeSpy.mockRestore()
+            delete process.env[TOKEN_ENV_VAR]
+        })
+
+        it('prints the stored token to stdout for pipe-safe consumption', async () => {
+            mockProbeApiToken.mockResolvedValueOnce({
+                token: 'tk_stored_1234567890',
+                metadata: STORED_METADATA,
+            })
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'tw', 'auth', 'token', 'view'])
+
+            expect(writeSpy).toHaveBeenCalledWith('tk_stored_1234567890')
+        })
+
+        it('refuses to print when the env var is set so the CLI does not disclose an unmanaged token', async () => {
+            process.env[TOKEN_ENV_VAR] = 'env_token_supplied_externally'
+
+            const program = createProgram()
+            await expect(
+                program.parseAsync(['node', 'tw', 'auth', 'token', 'view']),
+            ).rejects.toHaveProperty('code', 'TOKEN_FROM_ENV')
+
+            expect(mockProbeApiToken).not.toHaveBeenCalled()
+            expect(writeSpy).not.toHaveBeenCalled()
+        })
+
+        it('throws NOT_AUTHENTICATED when no token is stored', async () => {
+            mockProbeApiToken.mockRejectedValueOnce(new NoTokenError())
+
+            const program = createProgram()
+            await expect(
+                program.parseAsync(['node', 'tw', 'auth', 'token', 'view']),
+            ).rejects.toHaveProperty('code', 'NOT_AUTHENTICATED')
+
+            expect(writeSpy).not.toHaveBeenCalled()
+        })
+
+        it('matches --user against the stored account by numeric id', async () => {
+            mockProbeApiToken.mockResolvedValueOnce({
+                token: 'tk_stored_1234567890',
+                metadata: STORED_METADATA,
+            })
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '1'])
+
+            expect(writeSpy).toHaveBeenCalledWith('tk_stored_1234567890')
+        })
+
+        it('rejects --user with ACCOUNT_NOT_FOUND when the ref does not match the stored account', async () => {
+            mockProbeApiToken.mockResolvedValueOnce({
+                token: 'tk_stored_1234567890',
+                metadata: STORED_METADATA,
+            })
+
+            const program = createProgram()
+            await expect(
+                program.parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '999']),
+            ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
+
+            expect(writeSpy).not.toHaveBeenCalled()
         })
     })
 

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,5 +1,7 @@
+import { attachTokenViewCommand } from '@doist/cli-core/auth'
 import { Command } from 'commander'
 import { createTwistTokenStore } from '../../lib/auth-provider.js'
+import { TOKEN_ENV_VAR } from '../../lib/auth.js'
 import { attachTwistLoginCommand } from './login.js'
 import { attachTwistLogoutCommand } from './logout.js'
 import { attachTwistStatusCommand } from './status.js'
@@ -18,7 +20,21 @@ export function registerAuthCommand(program: Command): void {
     attachTwistLogoutCommand(auth, store)
     attachTwistStatusCommand(auth, store)
 
-    auth.command('token [token]')
-        .description('Save API token for CLI authentication')
+    // `token` is a hybrid: the positional `[token]` saves, and the `view`
+    // subcommand prints. Commander matches subcommand names before the parent
+    // action, so `tw auth token view` always dispatches to the view path —
+    // Twist OAuth tokens are opaque random strings so the literal "view" can
+    // never collide with a real token value.
+    const tokenCmd = auth
+        .command('token [token]')
+        .description('Save API token for CLI authentication (or use a subcommand: `view`)')
         .action(loginWithToken)
+
+    attachTokenViewCommand(tokenCmd, {
+        name: 'view',
+        store,
+        envVarName: TOKEN_ENV_VAR,
+        description:
+            'Print the stored API token for the active user (or --user <ref>) to stdout for use in scripts',
+    })
 }

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -30,7 +30,8 @@ tw auth status --user <ref>      # Target a specific stored account (id, id:<n>,
 tw auth logout                   # Remove saved token and auth metadata
 tw auth logout --json            # Emits \`{"ok": true}\` (--ndjson is silent)
 tw auth logout --user <ref>      # Target a specific stored account; mismatched ref errors with ACCOUNT_NOT_FOUND
-tw auth token --user <ref>       # Print the saved token for a specific stored account
+tw auth token view               # Print the saved token to stdout (pipe-safe; refuses if TWIST_API_TOKEN is set)
+tw auth token view --user <ref>  # Print the saved token for a specific stored account
 tw workspaces                    # List available workspaces
 tw workspace use <ref>           # Set current workspace
 tw completion install            # Install shell completions


### PR DESCRIPTION
## Summary

- Wire `@doist/cli-core/auth`'s `attachTokenViewCommand` as a subcommand of the existing `tw auth token [token]` setter — `tw auth token view` prints the stored token to stdout (no envelope) so it is pipe-safe for shell composition (`eval $(tw auth token view)`, etc.).
- Mirrors the pattern todoist-cli adopted in [Doist/todoist-cli#341](https://github.com/Doist/todoist-cli/pull/341); the next standalone step in the cli-core migration after #226.
- Commander matches subcommand names before the parent action, so `tw auth token view` always dispatches to the view path — Twist OAuth tokens are opaque random strings, so a literal "view" cannot collide with a real token value.
- Refuses to print when `TWIST_API_TOKEN` is set (cli-core's `TOKEN_FROM_ENV` guard): the env var takes precedence elsewhere, so printing the saved token would disclose a secret the CLI did not manage.
- `--user <ref>` flag is added by cli-core unconditionally; matches the lone stored account via the existing `TwistTokenStore.active(ref)` path (id-or-label match through `parseRef`), so single-user semantics are preserved.

No changes to the `lib/` layer.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 5 new tests (happy path, `TOKEN_FROM_ENV` refusal, `NOT_AUTHENTICATED`, `--user` id match, `--user` id miss); 611 total pass
- [x] `npm run build`
- [x] `tw auth token --help` shows the new `view` subcommand
- [x] `tw auth token view --help` shows the `--user <ref>` flag
- [ ] Manual end-to-end: `tw auth login` → `tw auth token view` prints the bearer token → `eval $(tw auth token view)` pipes safely
- [ ] Manual env-guard: `TWIST_API_TOKEN=anything tw auth token view` exits with `TOKEN_FROM_ENV`

🤖 Generated with [Claude Code](https://claude.com/claude-code)