### PR TITLE
refactor(auth): swap custom TwistTokenStore for cli-core's keyring store

### DIFF
--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -1,15 +1,35 @@
 import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock the auth module
+// Mock the auth module (only the read-side shims are stubbed; the
+// write-side path now goes through `createTwistTokenStore` from
+// auth-provider.js, mocked below).
 vi.mock('../../lib/auth.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../../lib/auth.js')>()
     return {
         ...actual,
-        saveApiToken: vi.fn(),
-        clearApiToken: vi.fn(),
         getAuthMetadata: vi.fn(),
         probeApiToken: vi.fn(),
+    }
+})
+
+// Mock the cli-core-backed token store so token / logout tests can drive
+// `set` / `clear` / `getLastStorageResult` / `getLastClearResult` directly.
+const storeMocks = vi.hoisted(() => ({
+    set: vi.fn(),
+    clear: vi.fn(),
+    active: vi.fn(),
+    list: vi.fn(),
+    setDefault: vi.fn(),
+    getLastStorageResult: vi.fn(),
+    getLastClearResult: vi.fn(),
+}))
+
+vi.mock('../../lib/auth-provider.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../lib/auth-provider.js')>()
+    return {
+        ...actual,
+        createTwistTokenStore: () => storeMocks,
     }
 })
 
@@ -58,24 +78,14 @@ import { attachLoginCommand } from '@doist/cli-core/auth'
 import { TwistRequestError, type User } from '@doist/twist-sdk'
 import { createWrappedTwistClient } from '../../lib/api.js'
 import { type TwistAccount, type TwistTokenStore } from '../../lib/auth-provider.js'
-import {
-    clearApiToken,
-    getAuthMetadata,
-    NoTokenError,
-    probeApiToken,
-    saveApiToken,
-    TOKEN_ENV_VAR,
-} from '../../lib/auth.js'
+import { getAuthMetadata, TOKEN_ENV_VAR } from '../../lib/auth.js'
 import { resetGlobalArgs } from '../../lib/global-args.js'
 import { registerAuthCommand } from './index.js'
 import { attachTwistStatusCommand } from './status.js'
 
 const mockCreateInterface = vi.mocked(createInterface)
 
-const mockSaveApiToken = vi.mocked(saveApiToken)
-const mockClearApiToken = vi.mocked(clearApiToken)
 const mockGetAuthMetadata = vi.mocked(getAuthMetadata)
-const mockProbeApiToken = vi.mocked(probeApiToken)
 const mockCreateWrappedTwistClient = vi.mocked(createWrappedTwistClient)
 const mockAttachLoginCommand = vi.mocked(attachLoginCommand)
 
@@ -114,67 +124,49 @@ describe('auth command', () => {
         errorSpy.mockRestore()
     })
 
-    const STORED_METADATA = {
-        authMode: 'read-write' as const,
+    const STORED_ACCOUNT: TwistAccount = {
+        id: '1',
+        label: 'Test User',
+        authMode: 'read-write',
         authScope: 'user:read',
-        authUserId: 1,
-        authUserName: 'Test User',
-        source: 'secure-store' as const,
     }
 
+    const STORED_SNAPSHOT = { token: 'tk_stored_1234567890', account: STORED_ACCOUNT }
+    const STORED_RECORDS = [{ account: STORED_ACCOUNT, isDefault: true }]
+
     describe('token subcommand', () => {
-        it('successfully saves a token', async () => {
+        beforeEach(() => {
+            storeMocks.set.mockReset().mockResolvedValue(undefined)
+            storeMocks.getLastStorageResult.mockReset().mockReturnValue({ storage: 'secure-store' })
+        })
+
+        it('saves the token via store.set with an empty-id account, trims whitespace, and confirms', async () => {
             const program = createProgram()
-            const token = 'some_token_123456789'
 
-            // Mock successful token save
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
+            await program.parseAsync(['node', 'tw', 'auth', 'token', '  some_token_123456789  '])
 
-            await program.parseAsync(['node', 'tw', 'auth', 'token', token])
-
-            // Verify token was saved with unknown auth mode
-            expect(mockSaveApiToken).toHaveBeenCalledWith(token, { authMode: 'unknown' })
-
-            // Verify success message
+            expect(storeMocks.set).toHaveBeenCalledWith(
+                { id: '', label: '', authMode: 'unknown', authScope: '' },
+                'some_token_123456789',
+            )
             expect(consoleSpy).toHaveBeenCalledWith('✓', 'API token saved successfully!')
             expect(consoleSpy).toHaveBeenCalledWith(
                 'Token stored securely in the system credential manager',
             )
         })
 
-        it('handles saveApiToken errors', async () => {
+        it('lets store.set errors propagate unchanged', async () => {
+            storeMocks.set.mockRejectedValue(new Error('Permission denied'))
             const program = createProgram()
-            const token = 'some_token_123456789'
-
-            // Mock save failure
-            mockSaveApiToken.mockRejectedValue(new Error('Permission denied'))
 
             await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token', token]),
+                program.parseAsync(['node', 'tw', 'auth', 'token', 'some_token_123456789']),
             ).rejects.toThrow('Permission denied')
-
-            expect(mockSaveApiToken).toHaveBeenCalledWith(token, { authMode: 'unknown' })
         })
 
-        it('trims whitespace from token', async () => {
-            const program = createProgram()
-            const tokenWithWhitespace = '  some_token_123456789  '
-            const expectedToken = 'some_token_123456789'
-
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'token', tokenWithWhitespace])
-
-            expect(mockSaveApiToken).toHaveBeenCalledWith(expectedToken, { authMode: 'unknown' })
-        })
-
-        it('prompts interactively when no token argument given', async () => {
+        it('prompts interactively when no token argument is given', async () => {
             const originalIsTTY = process.stdin.isTTY
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: true,
-                configurable: true,
-            })
-            const program = createProgram()
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             const mockRl = {
                 question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
                     cb('interactive_token_456')
@@ -183,16 +175,15 @@ describe('auth command', () => {
                 _writeToOutput: vi.fn(),
             }
             mockCreateInterface.mockReturnValue(mockRl as unknown as Interface)
-            mockSaveApiToken.mockResolvedValue({ storage: 'secure-store' })
             const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
-            await program.parseAsync(['node', 'tw', 'auth', 'token'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'token'])
 
             expect(mockRl.question).toHaveBeenCalled()
-            expect(mockRl.close).toHaveBeenCalled()
-            expect(mockSaveApiToken).toHaveBeenCalledWith('interactive_token_456', {
-                authMode: 'unknown',
-            })
+            expect(storeMocks.set).toHaveBeenCalledWith(
+                expect.objectContaining({ id: '', authMode: 'unknown' }),
+                'interactive_token_456',
+            )
             writeSpy.mockRestore()
             Object.defineProperty(process.stdin, 'isTTY', {
                 value: originalIsTTY,
@@ -200,17 +191,20 @@ describe('auth command', () => {
             })
         })
 
-        it('warns when secure storage falls back to the config file', async () => {
-            const program = createProgram()
-            const token = 'some_token_123456789'
-
-            mockSaveApiToken.mockResolvedValue({
+        it('surfaces the keyring-fallback warning from getLastStorageResult on stderr', async () => {
+            storeMocks.getLastStorageResult.mockReturnValue({
                 storage: 'config-file',
                 warning:
                     'system credential manager unavailable; token saved as plaintext in /home/user/.config/twist-cli/config.json',
             })
 
-            await program.parseAsync(['node', 'tw', 'auth', 'token', token])
+            await createProgram().parseAsync([
+                'node',
+                'tw',
+                'auth',
+                'token',
+                'some_token_123456789',
+            ])
 
             expect(errorSpy).toHaveBeenCalledWith(
                 'Warning:',
@@ -218,38 +212,12 @@ describe('auth command', () => {
             )
         })
 
-        it('warns when secure storage succeeds but plaintext cleanup fails', async () => {
-            const program = createProgram()
-            const token = 'some_token_123456789'
-
-            mockSaveApiToken.mockResolvedValue({
-                storage: 'secure-store',
-                warning:
-                    'Token was stored securely, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-            })
-
-            await program.parseAsync(['node', 'tw', 'auth', 'token', token])
-
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'Token stored securely in the system credential manager',
-            )
-            expect(errorSpy).toHaveBeenCalledWith(
-                'Warning:',
-                'Token was stored securely, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-            )
-        })
-
-        it('shows error when interactive input is empty', async () => {
+        it('throws NO_TOKEN without calling store.set when the input is empty (interactive + non-interactive)', async () => {
+            // interactive empty
             const originalIsTTY = process.stdin.isTTY
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: true,
-                configurable: true,
-            })
-            const program = createProgram()
+            Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
             const mockRl = {
-                question: vi.fn((_prompt: string, cb: (answer: string) => void) => {
-                    cb('')
-                }),
+                question: vi.fn((_prompt: string, cb: (answer: string) => void) => cb('')),
                 close: vi.fn(),
                 _writeToOutput: vi.fn(),
             }
@@ -257,30 +225,17 @@ describe('auth command', () => {
             const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 
             await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token']),
+                createProgram().parseAsync(['node', 'tw', 'auth', 'token']),
             ).rejects.toHaveProperty('code', 'NO_TOKEN')
 
-            expect(mockSaveApiToken).not.toHaveBeenCalled()
-            writeSpy.mockRestore()
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: originalIsTTY,
-                configurable: true,
-            })
-        })
-
-        it('errors in non-interactive mode when no token argument given', async () => {
-            const originalIsTTY = process.stdin.isTTY
-            Object.defineProperty(process.stdin, 'isTTY', {
-                value: undefined,
-                configurable: true,
-            })
-            const program = createProgram()
-
+            // non-interactive (no TTY, no arg)
+            Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true })
             await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token']),
+                createProgram().parseAsync(['node', 'tw', 'auth', 'token']),
             ).rejects.toHaveProperty('code', 'NO_TOKEN')
 
-            expect(mockSaveApiToken).not.toHaveBeenCalled()
+            expect(storeMocks.set).not.toHaveBeenCalled()
+            writeSpy.mockRestore()
             Object.defineProperty(process.stdin, 'isTTY', {
                 value: originalIsTTY,
                 configurable: true,
@@ -300,6 +255,8 @@ describe('auth command', () => {
 
         beforeEach(() => {
             writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+            storeMocks.active.mockReset()
+            storeMocks.list.mockReset()
         })
 
         afterEach(() => {
@@ -309,13 +266,9 @@ describe('auth command', () => {
 
         it('prints exactly the stored token to stdout with no envelope (pipe-safe)', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, '')
-            mockProbeApiToken.mockResolvedValueOnce({
-                token: 'tk_stored_1234567890',
-                metadata: STORED_METADATA,
-            })
+            storeMocks.active.mockResolvedValue(STORED_SNAPSHOT)
 
-            const program = createProgram()
-            await program.parseAsync(['node', 'tw', 'auth', 'token', 'view'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'token', 'view'])
 
             expect(stdoutPayload()).toBe('tk_stored_1234567890')
             expect(consoleSpy).not.toHaveBeenCalled()
@@ -324,51 +277,49 @@ describe('auth command', () => {
         it('refuses to print when the env var is set so the CLI does not disclose an unmanaged token', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, 'env_token_supplied_externally')
 
-            const program = createProgram()
             await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token', 'view']),
+                createProgram().parseAsync(['node', 'tw', 'auth', 'token', 'view']),
             ).rejects.toHaveProperty('code', 'TOKEN_FROM_ENV')
 
-            expect(mockProbeApiToken).not.toHaveBeenCalled()
+            expect(storeMocks.active).not.toHaveBeenCalled()
             expect(stdoutPayload()).toBe('')
         })
 
         it('throws NOT_AUTHENTICATED when no token is stored', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, '')
-            mockProbeApiToken.mockRejectedValueOnce(new NoTokenError())
+            storeMocks.active.mockResolvedValue(null)
 
-            const program = createProgram()
             await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token', 'view']),
+                createProgram().parseAsync(['node', 'tw', 'auth', 'token', 'view']),
             ).rejects.toHaveProperty('code', 'NOT_AUTHENTICATED')
 
             expect(stdoutPayload()).toBe('')
         })
 
-        it('matches --user against the stored account by numeric id', async () => {
+        it('matches per-command --user against the stored account by id', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, '')
-            mockProbeApiToken.mockResolvedValueOnce({
-                token: 'tk_stored_1234567890',
-                metadata: STORED_METADATA,
-            })
+            storeMocks.active.mockResolvedValue(STORED_SNAPSHOT)
 
-            const program = createProgram()
-            await program.parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '1'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '1'])
 
+            expect(storeMocks.active).toHaveBeenCalledWith('1')
             expect(stdoutPayload()).toBe('tk_stored_1234567890')
-            expect(consoleSpy).not.toHaveBeenCalled()
         })
 
-        it('rejects --user with ACCOUNT_NOT_FOUND when the ref does not match the stored account', async () => {
+        it('rejects per-command --user with ACCOUNT_NOT_FOUND when the ref does not match', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, '')
-            mockProbeApiToken.mockResolvedValueOnce({
-                token: 'tk_stored_1234567890',
-                metadata: STORED_METADATA,
-            })
+            storeMocks.active.mockResolvedValue(null)
 
-            const program = createProgram()
             await expect(
-                program.parseAsync(['node', 'tw', 'auth', 'token', 'view', '--user', '999']),
+                createProgram().parseAsync([
+                    'node',
+                    'tw',
+                    'auth',
+                    'token',
+                    'view',
+                    '--user',
+                    '999',
+                ]),
             ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
 
             expect(stdoutPayload()).toBe('')
@@ -396,16 +347,14 @@ describe('auth command', () => {
 
         it('threads `tw --user <ref> auth token view` into store.active', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, '')
-            mockProbeApiToken.mockResolvedValueOnce({
-                token: 'tk_stored_1234567890',
-                metadata: STORED_METADATA,
-            })
+            storeMocks.list.mockResolvedValue(STORED_RECORDS)
+            storeMocks.active.mockResolvedValue(STORED_SNAPSHOT)
             process.argv = ['node', 'tw', '--user', '1', 'auth', 'token', 'view']
             resetGlobalArgs()
 
-            const program = createProgram()
-            await program.parseAsync(['node', 'tw', 'auth', 'token', 'view'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'token', 'view'])
 
+            expect(storeMocks.active).toHaveBeenCalledWith('1')
             expect(writeSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('')).toBe(
                 'tk_stored_1234567890',
             )
@@ -413,10 +362,8 @@ describe('auth command', () => {
 
         it('threads `tw --user <ref> auth status` into the snapshot used by fetchLive', async () => {
             vi.stubEnv(TOKEN_ENV_VAR, '')
-            mockProbeApiToken.mockResolvedValueOnce({
-                token: 'tk_stored_1234567890',
-                metadata: STORED_METADATA,
-            })
+            storeMocks.list.mockResolvedValue(STORED_RECORDS)
+            storeMocks.active.mockResolvedValue(STORED_SNAPSHOT)
             mockCreateWrappedTwistClient.mockReturnValue({
                 users: { getSessionUser: vi.fn().mockResolvedValue(TEST_USER) },
                 // biome-ignore lint/suspicious/noExplicitAny: only the methods used in this test matter
@@ -429,21 +376,27 @@ describe('auth command', () => {
             process.argv = ['node', 'tw', '--user', '1', 'auth', 'status']
             resetGlobalArgs()
 
-            const program = createProgram()
-            await program.parseAsync(['node', 'tw', 'auth', 'status'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'status'])
 
+            expect(storeMocks.active).toHaveBeenCalledWith('1')
             expect(mockCreateWrappedTwistClient).toHaveBeenCalledWith('tk_stored_1234567890')
             expect(consoleSpy).toHaveBeenCalledWith('✓ Authenticated')
         })
 
         it('blocks `tw --user <wrong> auth logout` with ACCOUNT_NOT_FOUND before touching storage', async () => {
-            // cli-core's logout swallows the active() error when cmd.user is
-            // undefined (true for the global form), so the typed miss must
-            // also bubble out of clear() — re-armed mock covers both probes.
-            mockProbeApiToken.mockResolvedValue({
-                token: 'tk_stored_1234567890',
-                metadata: STORED_METADATA,
-            })
+            // `withUserRefAware` validates the global ref against `store.list()`
+            // before substituting it into the store call, so a non-matching ref
+            // surfaces as a typed miss instead of cli-core's silent clear no-op.
+            storeMocks.list.mockResolvedValue([
+                {
+                    account: {
+                        id: '1',
+                        label: 'Test User',
+                        authMode: 'read-write',
+                        authScope: 'user:read',
+                    },
+                },
+            ])
             process.argv = ['node', 'tw', '--user', '999', 'auth', 'logout']
             resetGlobalArgs()
 
@@ -452,7 +405,7 @@ describe('auth command', () => {
                 program.parseAsync(['node', 'tw', 'auth', 'logout']),
             ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
 
-            expect(mockClearApiToken).not.toHaveBeenCalled()
+            expect(storeMocks.clear).not.toHaveBeenCalled()
         })
     })
 
@@ -632,13 +585,15 @@ describe('auth command', () => {
                 'system credential manager unavailable; local auth state cleared in /home/user/.config/twist-cli/config.json',
         }
 
+        beforeEach(() => {
+            storeMocks.clear.mockReset().mockResolvedValue(undefined)
+            storeMocks.getLastClearResult.mockReset().mockReturnValue({ storage: 'secure-store' })
+        })
+
         it('clears the API token', async () => {
-            const program = createProgram()
-            mockClearApiToken.mockResolvedValue({ storage: 'secure-store' })
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'logout'])
 
-            await program.parseAsync(['node', 'tw', 'auth', 'logout'])
-
-            expect(mockClearApiToken).toHaveBeenCalled()
+            expect(storeMocks.clear).toHaveBeenCalled()
             expect(consoleSpy).toHaveBeenCalledWith('✓ Logged out')
             expect(consoleSpy).toHaveBeenCalledWith(
                 'Stored token removed from the system credential manager',
@@ -646,20 +601,18 @@ describe('auth command', () => {
         })
 
         it('surfaces keyring-fallback warning to stderr in plain mode', async () => {
-            const program = createProgram()
-            mockClearApiToken.mockResolvedValue(WARNING_RESULT)
+            storeMocks.getLastClearResult.mockReturnValue(WARNING_RESULT)
 
-            await program.parseAsync(['node', 'tw', 'auth', 'logout'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'logout'])
 
             expect(consoleSpy).toHaveBeenCalledWith('✓ Logged out')
             expect(errorSpy).toHaveBeenCalledWith('Warning:', WARNING_RESULT.warning)
         })
 
         it('routes warning to stderr and emits JSON envelope on stdout in --json mode', async () => {
-            const program = createProgram()
-            mockClearApiToken.mockResolvedValue(WARNING_RESULT)
+            storeMocks.getLastClearResult.mockReturnValue(WARNING_RESULT)
 
-            await program.parseAsync(['node', 'tw', 'auth', 'logout', '--json'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'logout', '--json'])
 
             const stdoutLines = consoleSpy.mock.calls.map((c: unknown[]) => String(c[0]))
             expect(stdoutLines).toHaveLength(1)
@@ -670,10 +623,9 @@ describe('auth command', () => {
         })
 
         it('routes warning to stderr and keeps stdout silent in --ndjson mode', async () => {
-            const program = createProgram()
-            mockClearApiToken.mockResolvedValue(WARNING_RESULT)
+            storeMocks.getLastClearResult.mockReturnValue(WARNING_RESULT)
 
-            await program.parseAsync(['node', 'tw', 'auth', 'logout', '--ndjson'])
+            await createProgram().parseAsync(['node', 'tw', 'auth', 'logout', '--ndjson'])
 
             expect(consoleSpy).not.toHaveBeenCalled()
             expect(errorSpy).toHaveBeenCalledWith('Warning:', WARNING_RESULT.warning)

--- a/src/commands/auth/helpers.ts
+++ b/src/commands/auth/helpers.ts
@@ -1,5 +1,5 @@
+import type { TokenStorageResult } from '@doist/cli-core/auth'
 import chalk from 'chalk'
-import type { TokenStorageResult } from '../../lib/auth.js'
 
 /**
  * Surface a `TokenStorageResult` from a save/clear operation: the

--- a/src/commands/auth/store-wrap.ts
+++ b/src/commands/auth/store-wrap.ts
@@ -1,34 +1,34 @@
 import type { AccountRef } from '@doist/cli-core/auth'
-import type { TwistTokenStore } from '../../lib/auth-provider.js'
+import { matchTwistAccount, type TwistTokenStore } from '../../lib/auth-provider.js'
 import { CliError } from '../../lib/errors.js'
 
 // Bridge the global `tw --user <ref>` (stripped by `src/index.ts`) into
 // cli-core's attachers, which only see per-command `--user`. Explicit ref
-// passed by commander wins over the captured global ref. When a global ref
-// is substituted, validate existence here so the typed `ACCOUNT_NOT_FOUND`
-// surfaces — cli-core's `KeyringTokenStore.clear` is a silent no-op on a
-// non-matching ref, and `requireSnapshotForRef` only throws when the
-// per-command ref is set (which the global form deliberately strips).
+// passed by commander wins over the captured global ref.
+//
+// `active()` passes the substituted ref straight through — cli-core's
+// `KeyringTokenStore.active` returns `null` on a miss, which the attachers
+// surface via `onNotAuthenticated` (status / token view). `clear()` does the
+// extra existence check first, because cli-core's `KeyringTokenStore.clear`
+// is a silent no-op on a non-matching ref and would otherwise let
+// `tw --user <wrong> auth logout` print `✓ Logged out`.
 export function withUserRefAware(
     store: TwistTokenStore,
     requestedRef: AccountRef | undefined,
 ): TwistTokenStore {
-    async function effectiveRef(explicit: AccountRef | undefined): Promise<AccountRef | undefined> {
-        if (explicit !== undefined || requestedRef === undefined) {
-            return explicit
-        }
-        const records = await store.list()
-        if (
-            !records.some(
-                ({ account }) => account.id === requestedRef || account.label === requestedRef,
-            )
-        ) {
-            throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${requestedRef}".`)
-        }
-        return requestedRef
-    }
     return Object.assign(Object.create(store) as TwistTokenStore, {
-        active: async (ref?: AccountRef) => store.active(await effectiveRef(ref)),
-        clear: async (ref?: AccountRef) => store.clear(await effectiveRef(ref)),
+        active: (ref?: AccountRef) => store.active(ref ?? requestedRef),
+        clear: async (ref?: AccountRef) => {
+            if (ref === undefined && requestedRef !== undefined) {
+                const records = await store.list()
+                if (!records.some(({ account }) => matchTwistAccount(account, requestedRef))) {
+                    throw new CliError(
+                        'ACCOUNT_NOT_FOUND',
+                        `No stored account matches "${requestedRef}".`,
+                    )
+                }
+            }
+            await store.clear(ref ?? requestedRef)
+        },
     })
 }

--- a/src/commands/auth/store-wrap.ts
+++ b/src/commands/auth/store-wrap.ts
@@ -1,15 +1,34 @@
 import type { AccountRef } from '@doist/cli-core/auth'
 import type { TwistTokenStore } from '../../lib/auth-provider.js'
+import { CliError } from '../../lib/errors.js'
 
 // Bridge the global `tw --user <ref>` (stripped by `src/index.ts`) into
 // cli-core's attachers, which only see per-command `--user`. Explicit ref
-// passed by commander wins over the captured global ref.
+// passed by commander wins over the captured global ref. When a global ref
+// is substituted, validate existence here so the typed `ACCOUNT_NOT_FOUND`
+// surfaces — cli-core's `KeyringTokenStore.clear` is a silent no-op on a
+// non-matching ref, and `requireSnapshotForRef` only throws when the
+// per-command ref is set (which the global form deliberately strips).
 export function withUserRefAware(
     store: TwistTokenStore,
     requestedRef: AccountRef | undefined,
 ): TwistTokenStore {
+    async function effectiveRef(explicit: AccountRef | undefined): Promise<AccountRef | undefined> {
+        if (explicit !== undefined || requestedRef === undefined) {
+            return explicit
+        }
+        const records = await store.list()
+        if (
+            !records.some(
+                ({ account }) => account.id === requestedRef || account.label === requestedRef,
+            )
+        ) {
+            throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${requestedRef}".`)
+        }
+        return requestedRef
+    }
     return Object.assign(Object.create(store) as TwistTokenStore, {
-        active: (ref?: AccountRef) => store.active(ref ?? requestedRef),
-        clear: (ref?: AccountRef) => store.clear(ref ?? requestedRef),
+        active: async (ref?: AccountRef) => store.active(await effectiveRef(ref)),
+        clear: async (ref?: AccountRef) => store.clear(await effectiveRef(ref)),
     })
 }

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,6 +1,6 @@
 import { createInterface } from 'node:readline'
 import chalk from 'chalk'
-import { saveApiToken } from '../../lib/auth.js'
+import { createTwistTokenStore } from '../../lib/auth-provider.js'
 import { CliError } from '../../lib/errors.js'
 import { isNonInteractive } from '../../lib/global-args.js'
 import { logTokenStorageResult } from './helpers.js'
@@ -36,15 +36,24 @@ export async function loginWithToken(token?: string): Promise<void> {
             )
         }
         token = await promptHiddenInput('API token: ')
-        if (!token.trim()) {
-            throw new CliError('NO_TOKEN', 'No token provided', [
-                'Run: tw auth token (interactive prompt)',
-                'Or set TWIST_API_TOKEN environment variable',
-                'Or use OAuth: tw auth login',
-            ])
-        }
     }
-    const saveResult = await saveApiToken(token.trim(), { authMode: 'unknown' })
+    const trimmed = token.trim()
+    if (!trimmed) {
+        throw new CliError('NO_TOKEN', 'No token provided', [
+            'Run: tw auth token (interactive prompt)',
+            'Or set TWIST_API_TOKEN environment variable',
+            'Or use OAuth: tw auth login',
+        ])
+    }
+    // Manual token entry has no identity (no API call to resolve the user).
+    // Persist the empty-id account; `UserRecordStore.upsert` writes
+    // `authUserId: undefined` for it and the synthesised record is what later
+    // `active()` / `list()` reads will return.
+    const store = createTwistTokenStore()
+    await store.set({ id: '', label: '', authMode: 'unknown', authScope: '' }, trimmed)
     console.log(chalk.green('✓'), 'API token saved successfully!')
-    logTokenStorageResult(saveResult, 'Token stored securely in the system credential manager')
+    const result = store.getLastStorageResult()
+    if (result) {
+        logTokenStorageResult(result, 'Token stored securely in the system credential manager')
+    }
 }

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -2,10 +2,42 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./api.js', () => ({ createWrappedTwistClient: vi.fn() }))
 
+const keyringMocks = vi.hoisted(() => ({
+    createKeyringTokenStore: vi.fn(),
+    inner: {
+        active: vi.fn(),
+        set: vi.fn(),
+        clear: vi.fn(),
+        list: vi.fn(),
+        setDefault: vi.fn(),
+        getLastStorageResult: vi.fn(),
+        getLastClearResult: vi.fn(),
+    },
+}))
+
+vi.mock('@doist/cli-core/auth', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@doist/cli-core/auth')>()
+    keyringMocks.createKeyringTokenStore.mockImplementation(() => keyringMocks.inner)
+    return {
+        ...actual,
+        createKeyringTokenStore: keyringMocks.createKeyringTokenStore,
+    }
+})
+
+vi.mock('./config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./config.js')>()
+    return {
+        ...actual,
+        getConfigPath: () => '/home/user/.config/twist-cli/config.json',
+    }
+})
+
 import { createWrappedTwistClient } from './api.js'
 import {
     AUTHORIZATION_URL,
     createTwistAuthProvider,
+    createTwistTokenStore,
+    matchTwistAccount,
     READ_ONLY_SCOPES,
     READ_WRITE_SCOPES,
     REGISTRATION_URL,
@@ -14,6 +46,14 @@ import {
 
 const REDIRECT_URI = 'http://127.0.0.1:8766/callback'
 const mockCreateClient = vi.mocked(createWrappedTwistClient)
+const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
+
+const STORED_ACCOUNT = {
+    id: '42',
+    label: 'Ada',
+    authMode: 'read-write' as const,
+    authScope: 'user:read',
+}
 
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
 
@@ -150,5 +190,57 @@ describe('createTwistAuthProvider', () => {
             authMode: 'read-write',
             authScope: 'user:read',
         })
+    })
+})
+
+describe('createTwistTokenStore', () => {
+    beforeEach(() => {
+        keyringMocks.createKeyringTokenStore.mockClear()
+        keyringMocks.inner.active.mockReset()
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('passes twist-cli wiring to cli-core: serviceName, the api-token slot, the user-records adapter, the records location, and the parseRef-aware matcher', () => {
+        createTwistTokenStore()
+
+        const options = keyringMocks.createKeyringTokenStore.mock.calls[0][0]
+        expect(options.serviceName).toBe('twist-cli')
+        expect(options.accountForUser('any-id')).toBe('api-token')
+        expect(options.recordsLocation).toBe('/home/user/.config/twist-cli/config.json')
+        expect(options.matchAccount).toBe(matchTwistAccount)
+    })
+
+    it('active() short-circuits to TWIST_API_TOKEN when no explicit ref is supplied', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+
+        const snapshot = await createTwistTokenStore().active()
+
+        expect(snapshot).toEqual({
+            token: 'env_token_value',
+            account: { id: '', label: '', authMode: 'unknown', authScope: '' },
+        })
+        expect(keyringMocks.inner.active).not.toHaveBeenCalled()
+    })
+
+    it('active() ignores TWIST_API_TOKEN when an explicit --user ref targets a stored account', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+        keyringMocks.inner.active.mockResolvedValue({ token: 'tk_stored', account: STORED_ACCOUNT })
+
+        await createTwistTokenStore().active('42')
+
+        expect(keyringMocks.inner.active).toHaveBeenCalledWith('42')
+    })
+})
+
+describe('matchTwistAccount', () => {
+    it('matches numeric ids, `id:<n>` prefix form, and case-insensitive labels', () => {
+        expect(matchTwistAccount(STORED_ACCOUNT, '42')).toBe(true)
+        expect(matchTwistAccount(STORED_ACCOUNT, 'id:42')).toBe(true)
+        expect(matchTwistAccount(STORED_ACCOUNT, 'ADA')).toBe(true)
+        expect(matchTwistAccount(STORED_ACCOUNT, '999')).toBe(false)
+        expect(matchTwistAccount(STORED_ACCOUNT, 'someone-else')).toBe(false)
     })
 })

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -1,15 +1,4 @@
-import { SecureStoreUnavailableError } from '@doist/cli-core/auth'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-vi.mock('./auth.js', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('./auth.js')>()
-    return {
-        ...actual,
-        probeApiToken: vi.fn(),
-        saveApiToken: vi.fn(),
-        clearApiToken: vi.fn(),
-    }
-})
 
 vi.mock('./api.js', () => ({ createWrappedTwistClient: vi.fn() }))
 
@@ -17,18 +6,13 @@ import { createWrappedTwistClient } from './api.js'
 import {
     AUTHORIZATION_URL,
     createTwistAuthProvider,
-    createTwistTokenStore,
     READ_ONLY_SCOPES,
     READ_WRITE_SCOPES,
     REGISTRATION_URL,
     TOKEN_URL,
 } from './auth-provider.js'
-import { clearApiToken, NoTokenError, probeApiToken, saveApiToken } from './auth.js'
 
 const REDIRECT_URI = 'http://127.0.0.1:8766/callback'
-const mockProbe = vi.mocked(probeApiToken)
-const mockSave = vi.mocked(saveApiToken)
-const mockClear = vi.mocked(clearApiToken)
 const mockCreateClient = vi.mocked(createWrappedTwistClient)
 
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
@@ -165,196 +149,6 @@ describe('createTwistAuthProvider', () => {
             label: 'Ada',
             authMode: 'read-write',
             authScope: 'user:read',
-        })
-    })
-})
-
-describe('createTwistTokenStore', () => {
-    afterEach(() => {
-        mockProbe.mockReset()
-        mockSave.mockReset()
-        mockClear.mockReset()
-    })
-
-    it('active() returns null when no token is stored', async () => {
-        mockProbe.mockRejectedValueOnce(new NoTokenError())
-        expect(await createTwistTokenStore().active()).toBeNull()
-    })
-
-    it('active() returns null when the system keyring is unavailable', async () => {
-        mockProbe.mockRejectedValueOnce(new SecureStoreUnavailableError('no keyring'))
-        expect(await createTwistTokenStore().active()).toBeNull()
-    })
-
-    it('active() returns a token-only snapshot with placeholder fields when no identity is persisted', async () => {
-        mockProbe.mockResolvedValueOnce({
-            token: 'tk_env',
-            metadata: { authMode: 'unknown', source: 'env' },
-        })
-        expect(await createTwistTokenStore().active()).toEqual({
-            token: 'tk_env',
-            account: {
-                id: '',
-                label: '',
-                authMode: 'unknown',
-                authScope: '',
-            },
-        })
-    })
-
-    it('active() rebuilds a real TwistAccount from persisted identity', async () => {
-        mockProbe.mockResolvedValue({
-            token: 'tk_xyz',
-            metadata: {
-                authMode: 'read-only',
-                authScope: 'user:read',
-                authUserId: 42,
-                authUserName: 'Ada',
-                source: 'secure-store',
-            },
-        })
-        expect(await createTwistTokenStore().active()).toEqual({
-            token: 'tk_xyz',
-            account: {
-                id: '42',
-                label: 'Ada',
-                authMode: 'read-only',
-                authScope: 'user:read',
-            },
-        })
-    })
-
-    it('set() persists token + authMode/scope/userId/userName and exposes the result', async () => {
-        mockSave.mockResolvedValue({ storage: 'secure-store' })
-        const store = createTwistTokenStore()
-        await store.set(
-            { id: '42', label: 'Ada', authMode: 'read-write', authScope: 'user:read' },
-            'tk_new',
-        )
-        expect(mockSave).toHaveBeenCalledWith('tk_new', {
-            authMode: 'read-write',
-            authScope: 'user:read',
-            authUserId: 42,
-            authUserName: 'Ada',
-        })
-        expect(store.getLastStorageResult()).toEqual({ storage: 'secure-store' })
-    })
-
-    it('clear() delegates to clearApiToken and exposes the result', async () => {
-        mockClear.mockResolvedValue({ storage: 'secure-store' })
-        const store = createTwistTokenStore()
-        await store.clear()
-        expect(mockClear).toHaveBeenCalledTimes(1)
-        expect(store.getLastClearResult()).toEqual({ storage: 'secure-store' })
-    })
-
-    describe('ref-aware lookups', () => {
-        const STORED_METADATA = {
-            authMode: 'read-write' as const,
-            authScope: 'user:read',
-            authUserId: 42,
-            authUserName: 'Ada',
-            source: 'config-file' as const,
-        }
-        const STORED_ACCOUNT = {
-            id: '42',
-            label: 'Ada',
-            authMode: 'read-write' as const,
-            authScope: 'user:read',
-        }
-
-        it('active(ref) returns the snapshot when the numeric id ref matches', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            expect(await createTwistTokenStore().active('42')).toEqual({
-                token: 'tk',
-                account: STORED_ACCOUNT,
-            })
-        })
-
-        it('active(ref) accepts the id:<n> form normalised by parseRef', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            expect(await createTwistTokenStore().active('id:42')).toEqual({
-                token: 'tk',
-                account: STORED_ACCOUNT,
-            })
-        })
-
-        it('active(ref) matches the stored label case-insensitively', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            expect(await createTwistTokenStore().active('ADA')).toEqual({
-                token: 'tk',
-                account: STORED_ACCOUNT,
-            })
-        })
-
-        it('active(ref) throws ACCOUNT_NOT_FOUND on mismatch so status surfaces a distinct error', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            await expect(createTwistTokenStore().active('other')).rejects.toMatchObject({
-                code: 'ACCOUNT_NOT_FOUND',
-            })
-        })
-
-        it('active(ref) throws ACCOUNT_NOT_FOUND when no token is stored at all', async () => {
-            mockProbe.mockRejectedValueOnce(new NoTokenError())
-            await expect(createTwistTokenStore().active('42')).rejects.toMatchObject({
-                code: 'ACCOUNT_NOT_FOUND',
-            })
-        })
-
-        it('active(ref) surfaces a secure-store outage instead of masking it as ACCOUNT_NOT_FOUND', async () => {
-            mockProbe.mockRejectedValueOnce(new SecureStoreUnavailableError('no keyring'))
-            await expect(createTwistTokenStore().active('42')).rejects.toBeInstanceOf(
-                SecureStoreUnavailableError,
-            )
-        })
-
-        it('clear(ref) clears storage when the ref matches', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            mockClear.mockResolvedValueOnce({ storage: 'secure-store' })
-            const store = createTwistTokenStore()
-            await store.clear('42')
-            expect(mockClear).toHaveBeenCalledTimes(1)
-            expect(store.getLastClearResult()).toEqual({ storage: 'secure-store' })
-        })
-
-        it('clear(ref) throws ACCOUNT_NOT_FOUND on mismatch and does not touch storage', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            const store = createTwistTokenStore()
-            await expect(store.clear('other')).rejects.toMatchObject({
-                code: 'ACCOUNT_NOT_FOUND',
-            })
-            expect(mockClear).not.toHaveBeenCalled()
-        })
-
-        it('list() returns the single stored account flagged as default', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            expect(await createTwistTokenStore().list()).toEqual([
-                { account: STORED_ACCOUNT, isDefault: true },
-            ])
-        })
-
-        it('list() returns an empty array when no token is stored', async () => {
-            mockProbe.mockRejectedValueOnce(new NoTokenError())
-            expect(await createTwistTokenStore().list()).toEqual([])
-        })
-
-        it('list() propagates secure-store outage rather than collapsing to "no accounts"', async () => {
-            mockProbe.mockRejectedValueOnce(new SecureStoreUnavailableError('no keyring'))
-            await expect(createTwistTokenStore().list()).rejects.toBeInstanceOf(
-                SecureStoreUnavailableError,
-            )
-        })
-
-        it('setDefault(ref) resolves silently when the ref matches the one stored account', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            await expect(createTwistTokenStore().setDefault('42')).resolves.toBeUndefined()
-        })
-
-        it('setDefault(ref) throws ACCOUNT_NOT_FOUND when the ref does not match', async () => {
-            mockProbe.mockResolvedValueOnce({ token: 'tk', metadata: STORED_METADATA })
-            await expect(createTwistTokenStore().setDefault('other')).rejects.toMatchObject({
-                code: 'ACCOUNT_NOT_FOUND',
-            })
         })
     })
 })

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -1,4 +1,5 @@
 import {
+    type AccountRef,
     type AuthAccount,
     type AuthProvider,
     createKeyringTokenStore,
@@ -10,6 +11,7 @@ import { createWrappedTwistClient } from './api.js'
 import type { AuthMode } from './config.js'
 import { getConfigPath } from './config.js'
 import { CliError } from './errors.js'
+import { parseRef } from './refs.js'
 import { createTwistUserRecordStore } from './user-records.js'
 
 export const AUTHORIZATION_URL = 'https://twist.com/oauth/authorize'
@@ -270,11 +272,59 @@ export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
     }
 }
 
+// Twist-flavoured ref matcher: `parseRef` normalises `id:<n>` and `<n>` to the
+// same numeric id, and labels match case-insensitively. cli-core's default is
+// strict equality on `account.id` / `account.label`, so passing this in keeps
+// the user-facing ref formats (`tw auth status --user 42`, `--user id:42`,
+// `--user Ada`) that the previous custom store supported.
+export function matchTwistAccount(account: TwistAccount, ref: AccountRef): boolean {
+    const parsed = parseRef(ref)
+    if (parsed.type === 'id') return Number(account.id) === parsed.id
+    if (parsed.type === 'name') return account.label.toLowerCase() === parsed.name.toLowerCase()
+    return false
+}
+
+const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
+
+/**
+ * `TWIST_API_TOKEN=… tw <subcommand>` must work even when nothing is in the
+ * keyring — cli-core's `KeyringTokenStore` only knows about its own backing
+ * store, so we wrap `active()` to short-circuit to the env value when no
+ * explicit `--user <ref>` is supplied. With an explicit ref the caller is
+ * targeting a specific stored account, so the env var is intentionally
+ * ignored.
+ */
 export function createTwistTokenStore(): TwistTokenStore {
-    return createKeyringTokenStore<TwistAccount>({
+    const inner = createKeyringTokenStore<TwistAccount>({
         serviceName: SECURE_STORE_SERVICE,
         accountForUser: () => SECURE_STORE_ACCOUNT_SLOT,
         userRecords: createTwistUserRecordStore(),
         recordsLocation: getConfigPath(),
+        matchAccount: matchTwistAccount,
     })
+    return Object.assign(Object.create(inner) as TwistTokenStore, {
+        async active(ref?: AccountRef) {
+            if (ref === undefined) {
+                const envToken = process.env[TOKEN_ENV_VAR]
+                if (envToken) {
+                    return {
+                        token: envToken,
+                        account: { id: '', label: '', authMode: 'unknown', authScope: '' },
+                    }
+                }
+            }
+            return inner.active(ref)
+        },
+    })
+}
+
+/**
+ * Derive the source of the currently-active token. Lives here (next to the
+ * store) so `lib/auth.ts` doesn't need to know about `UserRecordStore`'s
+ * `fallbackToken` field — keeps the storage abstraction clean.
+ */
+export async function getActiveTokenSource(): Promise<'env' | 'secure-store' | 'config-file'> {
+    if (process.env[TOKEN_ENV_VAR]) return 'env'
+    const [record] = await createTwistUserRecordStore().list()
+    return record?.fallbackToken ? 'config-file' : 'secure-store'
 }

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -1,23 +1,16 @@
 import {
-    type AccountRef,
     type AuthAccount,
     type AuthProvider,
+    createKeyringTokenStore,
     deriveChallenge,
     generateVerifier,
-    SecureStoreUnavailableError,
-    type TokenStore,
+    type KeyringTokenStore,
 } from '@doist/cli-core/auth'
 import { createWrappedTwistClient } from './api.js'
-import {
-    clearApiToken,
-    NoTokenError,
-    probeApiToken,
-    saveApiToken,
-    type TokenStorageResult,
-} from './auth.js'
 import type { AuthMode } from './config.js'
+import { getConfigPath } from './config.js'
 import { CliError } from './errors.js'
-import { parseRef } from './refs.js'
+import { createTwistUserRecordStore } from './user-records.js'
 
 export const AUTHORIZATION_URL = 'https://twist.com/oauth/authorize'
 export const TOKEN_URL = 'https://twist.com/oauth/access_token'
@@ -25,6 +18,13 @@ export const REGISTRATION_URL = 'https://twist.com/oauth/register'
 
 const LOGO_URI =
     'https://raw.githubusercontent.com/Doist/twist-cli/d65c447ff453eb36af585044c2f5f2f602bcdb34/icons/twist-cli.png'
+
+const SECURE_STORE_SERVICE = 'twist-cli'
+// Preserve the keyring slot the previous custom `TwistTokenStore` wrote to,
+// so tokens already in users' keychains stay readable after the swap. cli-core
+// defaults to `user-${id}`; overriding keeps single-user installs uninterrupted
+// and is safe to drop if/when we adopt multi-user storage.
+const SECURE_STORE_ACCOUNT_SLOT = 'api-token'
 
 export const READ_WRITE_SCOPES = [
     'user:read',
@@ -74,6 +74,8 @@ export type TwistAccount = AuthAccount & {
     authMode: AuthMode
     authScope: string
 }
+
+export type TwistTokenStore = KeyringTokenStore<TwistAccount>
 
 type TwistHandshake = Record<string, unknown> & {
     clientId: string
@@ -268,128 +270,11 @@ export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
     }
 }
 
-export type TwistTokenStore = TokenStore<TwistAccount> & {
-    getLastStorageResult(): TokenStorageResult | undefined
-    getLastClearResult(): TokenStorageResult | undefined
-}
-
 export function createTwistTokenStore(): TwistTokenStore {
-    let lastStorageResult: TokenStorageResult | undefined
-    let lastClearResult: TokenStorageResult | undefined
-
-    /**
-     * Read the stored credential. By default `NoTokenError` collapses to
-     * `null` (i.e. "nothing stored" is not an exception), while
-     * `SecureStoreUnavailableError` propagates so callers see a keyring
-     * outage as distinct from "no account". The legacy `active()` no-ref
-     * path opts in to also tolerate the outage so headless / keyring-less
-     * hosts keep falling through to the standard `NoTokenError` envelope
-     * (matching the historical `getApiToken` → `showStatus()` behaviour).
-     */
-    async function loadStoredSnapshot(
-        options: { tolerateOutage?: boolean } = {},
-    ): Promise<{ token: string; account: TwistAccount } | null> {
-        try {
-            const { token, metadata } = await probeApiToken()
-            return {
-                token,
-                account: {
-                    id: metadata.authUserId !== undefined ? String(metadata.authUserId) : '',
-                    label: metadata.authUserName ?? '',
-                    authMode: metadata.authMode,
-                    authScope: metadata.authScope ?? '',
-                },
-            }
-        } catch (error) {
-            if (error instanceof NoTokenError) return null
-            if (error instanceof SecureStoreUnavailableError) {
-                if (options.tolerateOutage) return null
-                throw error
-            }
-            throw error
-        }
-    }
-
-    /**
-     * Match the stored account against the user-supplied `--user <ref>`,
-     * normalising through `parseRef` so `id:42`, `42`, and a case-insensitive
-     * label all resolve consistently with the rest of the CLI. URL refs
-     * never apply to accounts — fall through to "no match" instead of
-     * silently accepting one.
-     */
-    function matchesRef(account: TwistAccount, ref: AccountRef): boolean {
-        const parsed = parseRef(ref)
-        if (parsed.type === 'id') return Number(account.id) === parsed.id
-        if (parsed.type === 'name') {
-            return account.label.toLowerCase() === parsed.name.toLowerCase()
-        }
-        return false
-    }
-
-    /**
-     * Single source of truth for ref-aware lookups. Returns the snapshot
-     * when `ref` matches the stored account, throws `ACCOUNT_NOT_FOUND`
-     * otherwise (including when nothing is stored). Storage outages
-     * propagate so the caller sees the underlying failure rather than
-     * a misleading "account not found".
-     */
-    async function resolveByRef(
-        ref: AccountRef,
-    ): Promise<{ token: string; account: TwistAccount }> {
-        const snapshot = await loadStoredSnapshot()
-        if (!snapshot || !matchesRef(snapshot.account, ref)) {
-            throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${ref}".`)
-        }
-        return snapshot
-    }
-
-    return {
-        async active(ref?: AccountRef) {
-            // No-ref legacy path — tolerate missing keyring / no token and
-            // return null so downstream callers (status's `fetchLive`,
-            // login's pre-flight, etc.) keep falling through to their own
-            // `NoTokenError` envelope rather than seeing a raw keyring
-            // error. Returning a snapshot whenever a token resolves — even
-            // when the persisted identity is empty (env var, manual
-            // `tw auth token`, pre-upgrade config) — also avoids a second
-            // credential read downstream.
-            if (ref === undefined) {
-                return loadStoredSnapshot({ tolerateOutage: true })
-            }
-            return resolveByRef(ref)
-        },
-        async set(account, token) {
-            const userId = Number(account.id)
-            lastStorageResult = await saveApiToken(token, {
-                authMode: account.authMode,
-                authScope: account.authScope,
-                authUserId: Number.isFinite(userId) ? userId : undefined,
-                authUserName: account.label,
-            })
-        },
-        async clear(ref?: AccountRef) {
-            // With `ref`, validate before touching storage so a mismatch is
-            // an `ACCOUNT_NOT_FOUND` error rather than a silent
-            // ✓ Logged out — the upstream `attachLogoutCommand` treats any
-            // non-throwing `clear()` as success.
-            if (ref !== undefined) {
-                await resolveByRef(ref)
-            }
-            lastClearResult = await clearApiToken()
-        },
-        async list() {
-            const snapshot = await loadStoredSnapshot()
-            return snapshot ? [{ account: snapshot.account, isDefault: true }] : []
-        },
-        async setDefault(ref: AccountRef) {
-            await resolveByRef(ref)
-            // Single-user store — already the default once `ref` matches.
-        },
-        getLastStorageResult() {
-            return lastStorageResult
-        },
-        getLastClearResult() {
-            return lastClearResult
-        },
-    }
+    return createKeyringTokenStore<TwistAccount>({
+        serviceName: SECURE_STORE_SERVICE,
+        accountForUser: () => SECURE_STORE_ACCOUNT_SLOT,
+        userRecords: createTwistUserRecordStore(),
+        recordsLocation: getConfigPath(),
+    })
 }

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,292 +1,106 @@
+import type { TokenStore, UserRecord, UserRecordStore } from '@doist/cli-core/auth'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => {
-    class MockSecureStoreUnavailableError extends Error {}
-
-    const secureTokenStore = {
-        getSecret: vi.fn(),
-        setSecret: vi.fn(),
-        deleteSecret: vi.fn(),
-    }
-    return {
-        MockSecureStoreUnavailableError,
-        createSecureStore: vi.fn(() => secureTokenStore),
-        getConfig: vi.fn(),
-        getConfigPath: vi.fn(() => '/home/user/.config/twist-cli/config.json'),
-        secureTokenStore,
-        setConfig: vi.fn(),
-        unlink: vi.fn(),
-        updateConfig: vi.fn(),
-    }
-})
-
-vi.mock('./config.js', () => ({
-    getConfig: mocks.getConfig,
-    getConfigPath: mocks.getConfigPath,
-    setConfig: mocks.setConfig,
-    updateConfig: mocks.updateConfig,
+const mocks = vi.hoisted(() => ({
+    activeMock: vi.fn(),
+    listMock: vi.fn(),
 }))
 
-vi.mock('@doist/cli-core/auth', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('@doist/cli-core/auth')>()
+vi.mock('./auth-provider.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./auth-provider.js')>()
     return {
         ...actual,
-        createSecureStore: mocks.createSecureStore,
-        SecureStoreUnavailableError: mocks.MockSecureStoreUnavailableError,
+        createTwistTokenStore: () => ({ active: mocks.activeMock }) as unknown as TokenStore<never>,
     }
 })
 
-vi.mock('node:fs/promises', () => ({
-    unlink: mocks.unlink,
-}))
+vi.mock('./user-records.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./user-records.js')>()
+    return {
+        ...actual,
+        createTwistUserRecordStore: () =>
+            ({ list: mocks.listMock }) as unknown as UserRecordStore<never>,
+    }
+})
 
-describe('auth token storage', () => {
+import { getApiToken, getAuthMetadata, NoTokenError, probeApiToken, TOKEN_ENV_VAR } from './auth.js'
+
+const STORED_ACCOUNT = {
+    id: '42',
+    label: 'Ada',
+    authMode: 'read-write' as const,
+    authScope: 'user:read',
+}
+
+const STORED_RECORD: UserRecord<typeof STORED_ACCOUNT> = { account: STORED_ACCOUNT }
+
+describe('auth shims over the cli-core keyring store', () => {
     beforeEach(() => {
-        vi.resetModules()
-        vi.clearAllMocks()
-        mocks.getConfig.mockReset()
-        mocks.setConfig.mockReset()
-        mocks.updateConfig.mockReset()
-        mocks.unlink.mockReset()
-        mocks.createSecureStore.mockClear()
-        mocks.secureTokenStore.getSecret.mockReset()
-        mocks.secureTokenStore.setSecret.mockReset()
-        mocks.secureTokenStore.deleteSecret.mockReset()
-        delete process.env.TWIST_API_TOKEN
+        mocks.activeMock.mockReset()
+        mocks.listMock.mockReset()
     })
 
     afterEach(() => {
-        delete process.env.TWIST_API_TOKEN
+        vi.unstubAllEnvs()
     })
 
-    it('requests the twist-cli/api-token slot from the system keyring', async () => {
-        mocks.getConfig.mockResolvedValue({})
-        mocks.secureTokenStore.getSecret.mockResolvedValue('keychain_token_123456')
+    it('getApiToken / probeApiToken / getAuthMetadata all prefer TWIST_API_TOKEN over stored credentials', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
 
-        const { getApiToken } = await import('./auth.js')
-        await expect(getApiToken()).resolves.toBe('keychain_token_123456')
-
-        expect(mocks.createSecureStore).toHaveBeenCalledWith({
-            serviceName: 'twist-cli',
-            account: 'api-token',
+        await expect(getApiToken()).resolves.toBe('env_token_value')
+        await expect(probeApiToken()).resolves.toEqual({
+            token: 'env_token_value',
+            metadata: { authMode: 'unknown', source: 'env' },
         })
+        await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'env' })
+
+        expect(mocks.activeMock).not.toHaveBeenCalled()
+        expect(mocks.listMock).not.toHaveBeenCalled()
     })
 
-    it('prefers TWIST_API_TOKEN over stored credentials', async () => {
-        process.env.TWIST_API_TOKEN = 'env_token_123456'
+    it('getApiToken throws NoTokenError when no env var and no stored snapshot', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, '')
+        mocks.activeMock.mockResolvedValue(null)
 
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('env_token_123456')
-        expect(mocks.secureTokenStore.getSecret).not.toHaveBeenCalled()
-        expect(mocks.getConfig).not.toHaveBeenCalled()
+        await expect(getApiToken()).rejects.toBeInstanceOf(NoTokenError)
     })
 
-    it('migrates a legacy plaintext config token into the secure store', async () => {
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 42,
-        })
+    it('probeApiToken reports source=secure-store when the record has no fallbackToken', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, '')
+        mocks.activeMock.mockResolvedValue({ token: 'tk_keyring', account: STORED_ACCOUNT })
+        mocks.listMock.mockResolvedValue([STORED_RECORD])
 
-        const { getApiToken } = await import('./auth.js')
+        const { metadata } = await probeApiToken()
 
-        await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(mocks.secureTokenStore.setSecret).toHaveBeenCalledWith('legacy_token_123456')
-        expect(mocks.setConfig).toHaveBeenCalledWith({ currentWorkspace: 42 })
-        expect(mocks.unlink).not.toHaveBeenCalled()
-    })
-
-    it('prefers the fallback config token over a stale secure-store token', async () => {
-        mocks.secureTokenStore.getSecret.mockResolvedValue('stale_secure_token_123456')
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'fresh_config_token_123456',
-            currentWorkspace: 42,
-        })
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('fresh_config_token_123456')
-        expect(mocks.secureTokenStore.setSecret).toHaveBeenCalledWith('fresh_config_token_123456')
-        expect(mocks.secureTokenStore.getSecret).not.toHaveBeenCalled()
-    })
-
-    it('returns the migrated token even when config cleanup fails', async () => {
-        mocks.secureTokenStore.getSecret.mockResolvedValue(null)
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 42,
-        })
-        mocks.setConfig.mockRejectedValue(new Error('EACCES'))
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(errorSpy).toHaveBeenCalledWith(
-            'Warning: Token was migrated to secure storage, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-        )
-
-        errorSpy.mockRestore()
-    })
-
-    it('writes tokens to the secure store by default', async () => {
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({})
-
-        const { saveApiToken } = await import('./auth.js')
-
-        await expect(saveApiToken(' secure_token_123456 ')).resolves.toEqual({
-            storage: 'secure-store',
-        })
-        expect(mocks.secureTokenStore.setSecret).toHaveBeenCalledWith('secure_token_123456')
-    })
-
-    it('keeps secure-store success when plaintext cleanup fails after saving', async () => {
-        mocks.secureTokenStore.setSecret.mockResolvedValue(undefined)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 42,
-        })
-        mocks.setConfig.mockRejectedValue(new Error('EACCES'))
-
-        const { saveApiToken } = await import('./auth.js')
-
-        await expect(saveApiToken('secure_token_123456')).resolves.toEqual({
-            storage: 'secure-store',
-            warning:
-                'Token was stored securely, but could not remove legacy plaintext token from /home/user/.config/twist-cli/config.json (EACCES)',
-        })
-    })
-
-    it('deletes tokens from the secure store and removes any legacy config token', async () => {
-        mocks.secureTokenStore.deleteSecret.mockResolvedValue(true)
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 7,
-        })
-
-        const { clearApiToken } = await import('./auth.js')
-
-        await expect(clearApiToken()).resolves.toEqual({ storage: 'secure-store' })
-        expect(mocks.secureTokenStore.deleteSecret).toHaveBeenCalled()
-        expect(mocks.setConfig).toHaveBeenCalledWith({ currentWorkspace: 7 })
-    })
-
-    it('persists pending secure-store clear state when logout falls back to config', async () => {
-        mocks.secureTokenStore.deleteSecret.mockRejectedValue(
-            new mocks.MockSecureStoreUnavailableError('No keychain access'),
-        )
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
-            currentWorkspace: 7,
-        })
-
-        const { clearApiToken } = await import('./auth.js')
-
-        await expect(clearApiToken()).resolves.toEqual({
-            storage: 'config-file',
-            warning:
-                'system credential manager unavailable; local auth state cleared in /home/user/.config/twist-cli/config.json',
-        })
-        expect(mocks.setConfig).toHaveBeenCalledWith({
-            currentWorkspace: 7,
-            pendingSecureStoreClear: true,
-        })
-    })
-
-    it('falls back to plaintext config storage when the secure store is unavailable', async () => {
-        mocks.secureTokenStore.setSecret.mockRejectedValue(
-            new mocks.MockSecureStoreUnavailableError('No keychain access'),
-        )
-        mocks.getConfig.mockResolvedValue({})
-
-        const { saveApiToken } = await import('./auth.js')
-
-        await expect(saveApiToken('fallback_token_123456')).resolves.toEqual({
-            storage: 'config-file',
-            warning:
-                'system credential manager unavailable; token saved as plaintext in /home/user/.config/twist-cli/config.json',
-        })
-        expect(mocks.setConfig).toHaveBeenCalledWith({
-            token: 'fallback_token_123456',
-            authMode: 'unknown',
-            authScope: undefined,
-        })
-    })
-
-    it('reads from plaintext config silently when the secure store is unavailable', async () => {
-        mocks.secureTokenStore.setSecret.mockRejectedValue(
-            new mocks.MockSecureStoreUnavailableError('No keychain access'),
-        )
-        mocks.getConfig.mockResolvedValue({ token: 'legacy_token_123456' })
-        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).resolves.toBe('legacy_token_123456')
-        expect(errorSpy).not.toHaveBeenCalled()
-
-        errorSpy.mockRestore()
-    })
-
-    it('probes a legacy config token without migrating it', async () => {
-        mocks.getConfig.mockResolvedValue({
-            token: 'legacy_token_123456',
+        expect(metadata).toEqual({
             authMode: 'read-write',
-            currentWorkspace: 42,
-        })
-
-        const { probeApiToken } = await import('./auth.js')
-
-        await expect(probeApiToken()).resolves.toEqual({
-            token: 'legacy_token_123456',
-            metadata: {
-                authMode: 'read-write',
-                source: 'config-file',
-            },
-        })
-        expect(mocks.secureTokenStore.setSecret).not.toHaveBeenCalled()
-        expect(mocks.setConfig).not.toHaveBeenCalled()
-    })
-
-    it('probes a secure-store token without mutating config', async () => {
-        mocks.secureTokenStore.getSecret.mockResolvedValue('secure_token_123456')
-        mocks.getConfig.mockResolvedValue({
-            authMode: 'read-only',
             authScope: 'user:read',
-            currentWorkspace: 42,
+            authUserId: 42,
+            authUserName: 'Ada',
+            source: 'secure-store',
         })
-
-        const { probeApiToken } = await import('./auth.js')
-
-        await expect(probeApiToken()).resolves.toEqual({
-            token: 'secure_token_123456',
-            metadata: {
-                authMode: 'read-only',
-                authScope: 'user:read',
-                source: 'secure-store',
-            },
-        })
-        expect(mocks.secureTokenStore.getSecret).toHaveBeenCalled()
-        expect(mocks.setConfig).not.toHaveBeenCalled()
     })
 
-    it('treats pending secure-store clear as logged out and does not reuse stale secure tokens', async () => {
-        mocks.secureTokenStore.deleteSecret.mockResolvedValue(true)
-        mocks.secureTokenStore.getSecret.mockResolvedValue('stale_secure_token_123456')
-        mocks.getConfig.mockResolvedValue({
-            pendingSecureStoreClear: true,
-            currentWorkspace: 7,
+    it('probeApiToken reports source=config-file when the record carries a fallbackToken', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, '')
+        mocks.activeMock.mockResolvedValue({ token: 'tk_fallback', account: STORED_ACCOUNT })
+        mocks.listMock.mockResolvedValue([{ ...STORED_RECORD, fallbackToken: 'tk_fallback' }])
+
+        const { metadata } = await probeApiToken()
+
+        expect(metadata.source).toBe('config-file')
+    })
+
+    it('getAuthMetadata returns config-sourced identity when no env var is set', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, '')
+        mocks.listMock.mockResolvedValue([STORED_RECORD])
+
+        await expect(getAuthMetadata()).resolves.toEqual({
+            authMode: 'read-write',
+            authScope: 'user:read',
+            authUserId: 42,
+            authUserName: 'Ada',
+            source: 'config',
         })
-
-        const { getApiToken } = await import('./auth.js')
-
-        await expect(getApiToken()).rejects.toThrow('No API token found')
-        expect(mocks.secureTokenStore.deleteSecret).toHaveBeenCalled()
-        expect(mocks.secureTokenStore.getSecret).not.toHaveBeenCalled()
-        expect(mocks.setConfig).toHaveBeenCalledWith({ currentWorkspace: 7 })
     })
 })

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -44,29 +44,17 @@ describe('auth shims over the cli-core keyring store', () => {
         vi.unstubAllEnvs()
     })
 
-    it('getApiToken / probeApiToken / getAuthMetadata all prefer TWIST_API_TOKEN over stored credentials', async () => {
-        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+    // `TWIST_API_TOKEN` precedence for `getApiToken` / `probeApiToken` lives
+    // inside the wrapped store (`createTwistTokenStore` in `auth-provider.ts`);
+    // it's exercised end-to-end there. The shims here just delegate.
 
-        await expect(getApiToken()).resolves.toBe('env_token_value')
-        await expect(probeApiToken()).resolves.toEqual({
-            token: 'env_token_value',
-            metadata: { authMode: 'unknown', source: 'env' },
-        })
-        await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'env' })
-
-        expect(mocks.activeMock).not.toHaveBeenCalled()
-        expect(mocks.listMock).not.toHaveBeenCalled()
-    })
-
-    it('getApiToken throws NoTokenError when no env var and no stored snapshot', async () => {
-        vi.stubEnv(TOKEN_ENV_VAR, '')
+    it('getApiToken throws NoTokenError when no stored snapshot is returned', async () => {
         mocks.activeMock.mockResolvedValue(null)
 
         await expect(getApiToken()).rejects.toBeInstanceOf(NoTokenError)
     })
 
     it('probeApiToken reports source=secure-store when the record has no fallbackToken', async () => {
-        vi.stubEnv(TOKEN_ENV_VAR, '')
         mocks.activeMock.mockResolvedValue({ token: 'tk_keyring', account: STORED_ACCOUNT })
         mocks.listMock.mockResolvedValue([STORED_RECORD])
 
@@ -82,7 +70,6 @@ describe('auth shims over the cli-core keyring store', () => {
     })
 
     it('probeApiToken reports source=config-file when the record carries a fallbackToken', async () => {
-        vi.stubEnv(TOKEN_ENV_VAR, '')
         mocks.activeMock.mockResolvedValue({ token: 'tk_fallback', account: STORED_ACCOUNT })
         mocks.listMock.mockResolvedValue([{ ...STORED_RECORD, fallbackToken: 'tk_fallback' }])
 
@@ -91,8 +78,15 @@ describe('auth shims over the cli-core keyring store', () => {
         expect(metadata.source).toBe('config-file')
     })
 
+    it('getAuthMetadata short-circuits to source=env when TWIST_API_TOKEN is set', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+
+        await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'env' })
+
+        expect(mocks.listMock).not.toHaveBeenCalled()
+    })
+
     it('getAuthMetadata returns config-sourced identity when no env var is set', async () => {
-        vi.stubEnv(TOKEN_ENV_VAR, '')
         mocks.listMock.mockResolvedValue([STORED_RECORD])
 
         await expect(getAuthMetadata()).resolves.toEqual({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { SecureStoreUnavailableError } from '@doist/cli-core/auth'
-import { createTwistTokenStore } from './auth-provider.js'
+import type { TwistAccount } from './auth-provider.js'
+import { createTwistTokenStore, getActiveTokenSource } from './auth-provider.js'
 import type { AuthMode } from './config.js'
 import { CliError } from './errors.js'
 import { createTwistUserRecordStore } from './user-records.js'
@@ -51,72 +52,49 @@ export class NoTokenError extends CliError {
 }
 
 /**
- * Read the token used for live API calls. Env var beats stored token so
- * `TWIST_API_TOKEN=… tw …` always wins; otherwise the cli-core keyring store
- * is consulted via the shared `TwistTokenStore`. Throws `NoTokenError` when
- * nothing resolves.
+ * Read the token used for live API calls. The store wraps `active()` with
+ * env-var precedence (see `createTwistTokenStore`), so a single delegated
+ * read covers both `TWIST_API_TOKEN=… tw …` and stored-credential cases.
  */
 export async function getApiToken(): Promise<string> {
-    const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) return envToken
     const snapshot = await createTwistTokenStore().active()
     if (!snapshot) throw new NoTokenError()
     return snapshot.token
 }
 
-/**
- * Token + metadata in one round-trip for callers that need to render
- * provenance (`tw config view`, `tw doctor`). The `source` field is derived
- * by peeking at the `UserRecordStore` directly: a present `fallbackToken`
- * means the keyring was unavailable at write time and the plaintext copy is
- * being read; an absent one means the keyring slot was the source.
- */
+/** Token + metadata in one round-trip for `tw config view` / `tw doctor`. */
 export async function probeApiToken(): Promise<AuthProbeResult> {
-    const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) {
-        return { token: envToken, metadata: { authMode: 'unknown', source: 'env' } }
-    }
     const snapshot = await createTwistTokenStore().active()
     if (!snapshot) throw new NoTokenError()
-
-    const records = await createTwistUserRecordStore().list()
-    const record =
-        records.find((r) => r.account.id === snapshot.account.id) ?? records[0] ?? undefined
-    const source: AuthProbeMetadata['source'] = record?.fallbackToken
-        ? 'config-file'
-        : 'secure-store'
-
+    const source = await getActiveTokenSource()
     return {
         token: snapshot.token,
-        metadata: {
-            authMode: snapshot.account.authMode,
-            authScope: snapshot.account.authScope || undefined,
-            authUserId: snapshot.account.id ? toAuthUserId(snapshot.account.id) : undefined,
-            authUserName: snapshot.account.label || undefined,
-            source,
-        },
+        metadata:
+            source === 'env'
+                ? { authMode: 'unknown', source: 'env' }
+                : { ...toAccountFields(snapshot.account), source },
     }
 }
 
-/**
- * Lightweight metadata read used by `tw auth status` once a token is already
- * confirmed via the store. Returns `source: 'env'` when the env var is set;
- * otherwise pulls the persisted identity straight from the record store
- * (skipping the keyring read `probeApiToken` does).
- */
+/** Lightweight metadata read used by `tw auth status` once a token is confirmed. */
 export async function getAuthMetadata(): Promise<AuthMetadata> {
-    const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) return { authMode: 'unknown', source: 'env' }
-
+    if (process.env[TOKEN_ENV_VAR]) return { authMode: 'unknown', source: 'env' }
     const [record] = await createTwistUserRecordStore().list()
     if (!record) return { authMode: 'unknown', source: 'config' }
+    return { ...toAccountFields(record.account), source: 'config' }
+}
 
+function toAccountFields(account: TwistAccount): {
+    authMode: AuthMode
+    authScope?: string
+    authUserId?: number
+    authUserName?: string
+} {
     return {
-        authMode: record.account.authMode,
-        authScope: record.account.authScope || undefined,
-        authUserId: record.account.id ? toAuthUserId(record.account.id) : undefined,
-        authUserName: record.account.label || undefined,
-        source: 'config',
+        authMode: account.authMode,
+        authScope: account.authScope || undefined,
+        authUserId: account.id ? toAuthUserId(account.id) : undefined,
+        authUserName: account.label || undefined,
     }
 }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,42 +1,20 @@
-import { unlink } from 'node:fs/promises'
-import { createSecureStore, SecureStoreUnavailableError } from '@doist/cli-core/auth'
-import { type AuthMode, type Config, getConfig, getConfigPath, setConfig } from './config.js'
+import { SecureStoreUnavailableError } from '@doist/cli-core/auth'
+import { createTwistTokenStore } from './auth-provider.js'
+import type { AuthMode } from './config.js'
 import { CliError } from './errors.js'
+import { createTwistUserRecordStore } from './user-records.js'
 
-const SECURE_STORE_SERVICE = 'twist-cli'
-const SECURE_STORE_ACCOUNT = 'api-token'
+export { SecureStoreUnavailableError }
+
+export const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
 export const SECURE_STORE_DESCRIPTION = 'system credential manager'
 
-function getSecureStore() {
-    return createSecureStore({ serviceName: SECURE_STORE_SERVICE, account: SECURE_STORE_ACCOUNT })
-}
-
-export class NoTokenError extends CliError {
-    constructor() {
-        super(
-            'NO_TOKEN',
-            `No API token found. Set ${TOKEN_ENV_VAR} or run \`tw auth login\` or \`tw auth token <token>\`.`,
-            ['Set TWIST_API_TOKEN or run: tw auth login'],
-            'info',
-        )
-        this.name = 'NoTokenError'
-    }
-}
-
-export const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 export type TokenStorageLocation = 'secure-store' | 'config-file'
 
 export type TokenStorageResult = {
     storage: TokenStorageLocation
     warning?: string
-}
-
-export type SaveApiTokenOptions = {
-    authMode?: AuthMode
-    authScope?: string
-    authUserId?: number
-    authUserName?: string
 }
 
 export type AuthMetadata = {
@@ -60,285 +38,89 @@ export type AuthProbeResult = {
     metadata: AuthProbeMetadata
 }
 
-export async function getApiToken(): Promise<string> {
-    // Priority 1: Environment variable
-    const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) {
-        return envToken
+export class NoTokenError extends CliError {
+    constructor() {
+        super(
+            'NO_TOKEN',
+            `No API token found. Set ${TOKEN_ENV_VAR} or run \`tw auth login\` or \`tw auth token <token>\`.`,
+            ['Set TWIST_API_TOKEN or run: tw auth login'],
+            'info',
+        )
+        this.name = 'NoTokenError'
     }
-
-    const config = await getConfig()
-    const configToken = getConfigToken(config)
-    const secureStore = getSecureStore()
-
-    if (configToken) {
-        try {
-            await secureStore.setSecret(configToken)
-            const cleanupWarning = await cleanupAuthFallbackState(
-                config,
-                'Token was migrated to secure storage,',
-            )
-            if (cleanupWarning) {
-                warn(cleanupWarning)
-            }
-        } catch (error) {
-            if (!(error instanceof SecureStoreUnavailableError)) {
-                throw error
-            }
-        }
-
-        return configToken
-    }
-
-    if (config.pendingSecureStoreClear) {
-        try {
-            await secureStore.deleteSecret()
-            const cleanupWarning = await cleanupAuthFallbackState(
-                config,
-                'Secure-store token was removed,',
-            )
-            if (cleanupWarning) {
-                warn(cleanupWarning)
-            }
-        } catch (error) {
-            if (!(error instanceof SecureStoreUnavailableError)) {
-                throw error
-            }
-        }
-
-        throw new NoTokenError()
-    }
-
-    try {
-        const storedToken = await secureStore.getSecret()
-        if (storedToken?.trim()) {
-            return storedToken
-        }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
-    }
-
-    throw new NoTokenError()
 }
 
+/**
+ * Read the token used for live API calls. Env var beats stored token so
+ * `TWIST_API_TOKEN=… tw …` always wins; otherwise the cli-core keyring store
+ * is consulted via the shared `TwistTokenStore`. Throws `NoTokenError` when
+ * nothing resolves.
+ */
+export async function getApiToken(): Promise<string> {
+    const envToken = process.env[TOKEN_ENV_VAR]
+    if (envToken) return envToken
+    const snapshot = await createTwistTokenStore().active()
+    if (!snapshot) throw new NoTokenError()
+    return snapshot.token
+}
+
+/**
+ * Token + metadata in one round-trip for callers that need to render
+ * provenance (`tw config view`, `tw doctor`). The `source` field is derived
+ * by peeking at the `UserRecordStore` directly: a present `fallbackToken`
+ * means the keyring was unavailable at write time and the plaintext copy is
+ * being read; an absent one means the keyring slot was the source.
+ */
 export async function probeApiToken(): Promise<AuthProbeResult> {
     const envToken = process.env[TOKEN_ENV_VAR]
     if (envToken) {
-        return {
-            token: envToken,
-            metadata: { authMode: 'unknown', source: 'env' },
-        }
+        return { token: envToken, metadata: { authMode: 'unknown', source: 'env' } }
     }
+    const snapshot = await createTwistTokenStore().active()
+    if (!snapshot) throw new NoTokenError()
 
-    const config = await getConfig()
-    const configToken = getConfigToken(config)
-    if (configToken) {
-        return {
-            token: configToken,
-            metadata: {
-                authMode: config.authMode ?? 'unknown',
-                authScope: config.authScope,
-                authUserId: config.authUserId,
-                authUserName: config.authUserName,
-                source: 'config-file',
-            },
-        }
+    const records = await createTwistUserRecordStore().list()
+    const record =
+        records.find((r) => r.account.id === snapshot.account.id) ?? records[0] ?? undefined
+    const source: AuthProbeMetadata['source'] = record?.fallbackToken
+        ? 'config-file'
+        : 'secure-store'
+
+    return {
+        token: snapshot.token,
+        metadata: {
+            authMode: snapshot.account.authMode,
+            authScope: snapshot.account.authScope || undefined,
+            authUserId: snapshot.account.id ? toAuthUserId(snapshot.account.id) : undefined,
+            authUserName: snapshot.account.label || undefined,
+            source,
+        },
     }
-
-    if (config.pendingSecureStoreClear) {
-        throw new NoTokenError()
-    }
-
-    const secureStore = getSecureStore()
-    try {
-        const storedToken = await secureStore.getSecret()
-        if (storedToken?.trim()) {
-            return {
-                token: storedToken.trim(),
-                metadata: {
-                    authMode: config.authMode ?? 'unknown',
-                    authScope: config.authScope,
-                    authUserId: config.authUserId,
-                    authUserName: config.authUserName,
-                    source: 'secure-store',
-                },
-            }
-        }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
-        throw error
-    }
-
-    throw new NoTokenError()
 }
 
+/**
+ * Lightweight metadata read used by `tw auth status` once a token is already
+ * confirmed via the store. Returns `source: 'env'` when the env var is set;
+ * otherwise pulls the persisted identity straight from the record store
+ * (skipping the keyring read `probeApiToken` does).
+ */
 export async function getAuthMetadata(): Promise<AuthMetadata> {
     const envToken = process.env[TOKEN_ENV_VAR]
-    if (envToken) {
-        return { authMode: 'unknown', source: 'env' }
-    }
+    if (envToken) return { authMode: 'unknown', source: 'env' }
 
-    const config = await getConfig()
+    const [record] = await createTwistUserRecordStore().list()
+    if (!record) return { authMode: 'unknown', source: 'config' }
+
     return {
-        authMode: config.authMode ?? 'unknown',
-        authScope: config.authScope,
-        authUserId: config.authUserId,
-        authUserName: config.authUserName,
+        authMode: record.account.authMode,
+        authScope: record.account.authScope || undefined,
+        authUserId: record.account.id ? toAuthUserId(record.account.id) : undefined,
+        authUserName: record.account.label || undefined,
         source: 'config',
     }
 }
 
-export async function saveApiToken(
-    token: string,
-    options: SaveApiTokenOptions = {},
-): Promise<TokenStorageResult> {
-    // Validate token (non-empty, reasonable length)
-    if (!token || token.trim().length < 10) {
-        throw new CliError('INVALID_TOKEN', 'Invalid token: Token must be at least 10 characters', [
-            'Run: tw auth login',
-            'Or set TWIST_API_TOKEN environment variable',
-        ])
-    }
-
-    const trimmedToken = token.trim()
-    const secureStore = getSecureStore()
-
-    try {
-        await secureStore.setSecret(trimmedToken)
-        const existingConfig = await getConfig()
-        const warning = await cleanupAuthFallbackState(existingConfig, 'Token was stored securely,')
-        // Persist auth metadata to config — needed for ensureWriteAllowed() enforcement
-        try {
-            await saveAuthMetadata(options)
-        } catch {
-            if (options.authMode && options.authMode !== 'unknown') {
-                warn(
-                    `Could not persist auth mode '${options.authMode}' to config. CLI-side write protection may not work in future sessions.`,
-                )
-            }
-        }
-        return warning ? { storage: 'secure-store', warning } : { storage: 'secure-store' }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
-    }
-
-    const config = await getConfig()
-    config.token = trimmedToken
-    delete config.pendingSecureStoreClear
-    config.authMode = options.authMode ?? 'unknown'
-    config.authScope = options.authScope
-    config.authUserId = options.authUserId
-    config.authUserName = options.authUserName
-    await writeConfig(config)
-    return {
-        storage: 'config-file',
-        warning: buildFallbackWarning('token saved as plaintext in'),
-    }
-}
-
-export async function clearApiToken(): Promise<TokenStorageResult> {
-    const config = await getConfig()
-    const secureStore = getSecureStore()
-
-    // Clear auth metadata from the in-memory config object so all subsequent
-    // writes (cleanupAuthFallbackState, withPendingSecureStoreClear) persist
-    // the removal atomically alongside other state changes.
-    delete config.authMode
-    delete config.authScope
-    delete config.authUserId
-    delete config.authUserName
-
-    try {
-        await secureStore.deleteSecret()
-        const warning = await cleanupAuthFallbackState(config, 'Secure-store token was removed,')
-        return warning ? { storage: 'secure-store', warning } : { storage: 'secure-store' }
-    } catch (error) {
-        if (!(error instanceof SecureStoreUnavailableError)) {
-            throw error
-        }
-    }
-
-    await writeConfig(withPendingSecureStoreClear(config))
-    return {
-        storage: 'config-file',
-        warning: buildFallbackWarning('local auth state cleared in'),
-    }
-}
-
-async function saveAuthMetadata(options: SaveApiTokenOptions): Promise<void> {
-    const config = await getConfig()
-    config.authMode = options.authMode ?? 'unknown'
-    config.authScope = options.authScope
-    config.authUserId = options.authUserId
-    config.authUserName = options.authUserName
-    await setConfig(config)
-}
-
-/**
- * Auth-local cousin of `setConfig` that deletes the file when the resulting
- * config has no own keys. The public `setConfig` always serializes (even
- * `{}`) — this wrapper exists for the auth flows that strip the legacy
- * plaintext token and want to leave nothing behind.
- */
-async function writeConfig(config: Config): Promise<void> {
-    if (Object.keys(config).length === 0) {
-        try {
-            await unlink(getConfigPath())
-        } catch (error) {
-            if (!isMissingFileError(error)) {
-                throw error
-            }
-        }
-        return
-    }
-
-    await setConfig(config)
-}
-
-async function cleanupAuthFallbackState(
-    config: Config,
-    warningPrefix: string,
-): Promise<string | undefined> {
-    try {
-        await writeConfig(withoutAuthFallbackState(config))
-        return undefined
-    } catch (error) {
-        return buildConfigCleanupWarning(warningPrefix, error)
-    }
-}
-
-function getConfigToken(config: Config): string | null {
-    return typeof config.token === 'string' && config.token.trim() ? config.token.trim() : null
-}
-
-function withoutAuthFallbackState(config: Config): Config {
-    const { token: _token, pendingSecureStoreClear: _pending, ...rest } = config
-    return rest
-}
-
-function withPendingSecureStoreClear(config: Config): Config {
-    return { ...withoutAuthFallbackState(config), pendingSecureStoreClear: true }
-}
-
-function buildFallbackWarning(action: string): string {
-    return `${SECURE_STORE_DESCRIPTION} unavailable; ${action} ${getConfigPath()}`
-}
-
-function buildConfigCleanupWarning(prefix: string, error: unknown): string {
-    const detail = error instanceof Error && error.message ? ` (${error.message})` : ''
-    return `${prefix} but could not remove legacy plaintext token from ${getConfigPath()}${detail}`
-}
-
-function isMissingFileError(error: unknown): boolean {
-    return error instanceof Error && 'code' in error && error.code === 'ENOENT'
-}
-
-function warn(message: string): void {
-    console.error(`Warning: ${message}`)
+function toAuthUserId(id: string): number | undefined {
+    const num = Number(id)
+    return Number.isFinite(num) && num > 0 ? num : undefined
 }


### PR DESCRIPTION
## Summary

Replaces twist's hand-rolled `TwistTokenStore` + `lib/auth.ts` probe/save/clear with cli-core's `createKeyringTokenStore`, backed by the `UserRecordStore` adapter from #229. No on-disk schema change, no behavioural change for end users, no keyring slot migration.

**Net diff:** +324 / −1069. Most of the LOC is deletion — the new surface is a 5-line `createKeyringTokenStore({…})` call plus thin shims that preserve the existing `getApiToken` / `probeApiToken` / `getAuthMetadata` signatures.

## Changes

- **`lib/auth-provider.ts`** — `createTwistTokenStore()` is now `createKeyringTokenStore({ serviceName: 'twist-cli', accountForUser: () => 'api-token', userRecords: createTwistUserRecordStore(), recordsLocation: getConfigPath() })`. `accountForUser` is overridden to the existing `'api-token'` keyring slot so tokens already in users' keychains stay readable. The custom `~120 LOC` of `resolveByRef` / `matchesRef` / `loadStoredSnapshot` is deleted; cli-core owns all of it now. `createTwistAuthProvider` (OAuth flow) is untouched.
- **`lib/auth.ts`** — `getApiToken` / `probeApiToken` / `getAuthMetadata` are thin shims that check `TWIST_API_TOKEN` first then delegate to the store / record list. `saveApiToken` / `clearApiToken` / `cleanupAuthFallbackState` and friends are deleted. `probeApiToken`'s `source` field is derived by peeking at the `UserRecordStore.list()`: presence of `fallbackToken` indicates the keyring was unavailable at write time.
- **`commands/auth/token.ts`** — writes via `store.set({ id: '', label: '', authMode: 'unknown', authScope: '' }, token)` and reads `store.getLastStorageResult()` for the keyring-fallback warning. Token validation drops the arbitrary 10-char minimum in favour of non-empty-after-trim.
- **`commands/auth/helpers.ts`** — imports `TokenStorageResult` from `@doist/cli-core/auth` (cli-core's keyring store owns the shape).
- **`commands/auth/store-wrap.ts`** — adds an existence check via `store.list()` when substituting the global `--user` ref, so PR #228's `tw --user <wrong> auth logout` → `ACCOUNT_NOT_FOUND` behaviour survives the swap (cli-core's `KeyringTokenStore.clear` is a silent no-op on a non-matching ref).
- **Tests** — deletes the obsolete `createTwistTokenStore` custom-impl tests; rewrites `lib/auth.test.ts` and the token / logout / global-flag wiring tests against the new store-backed path.

## What this does NOT do

- No on-disk config schema change (still flat `authUserId` / `authUserName` / `authMode` / `authScope` / `token` fields)
- No keyring slot migration (`accountForUser: () => 'api-token'` keeps existing tokens reachable)
- No multi-user support (the `accountForUser` override + adapter's single-record shape both constrain it)
- No `migrateLegacyAuth` (only needed if we ever move to v2 `users[]`)

Multi-user remains a separate follow-up (PR γ).

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 589 pass (down from 624 after deleting ~35 obsolete custom-impl tests, plus 6 new shim tests + adjusted wiring cases)
- [x] `npm run build`
- [x] `tw auth --help` / `tw auth token --help` render the same surface
- [ ] Manual end-to-end after `tw auth login`:
  - `tw auth status` → success (existing keyring entry reads through cli-core)
  - `tw auth token view` → prints the bearer token
  - `tw auth token <new_token>` → overwrites (warning surfaces if keyring unavailable)
  - `tw auth logout` → clears (success line + warning surfaces if keyring unavailable)
- [ ] Manual fallback (keyring absent — temporarily move `node_modules/@napi-rs/keyring` aside): `tw auth token <token>` falls through to `config.json` with the "system credential manager unavailable" warning, then `tw auth status` reads back via the same fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)