### PR TITLE
feat(auth): schema v2 + multi-account migration foundation

### DIFF
--- a/src/lib/auth-constants.ts
+++ b/src/lib/auth-constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared identifiers for the OS keyring. Imported by both the runtime token
+ * store (`auth-provider.ts`) and the one-shot migration (`migrate-auth.ts`)
+ * so the slot a writer parks a secret in and the slot a reader pulls it from
+ * can't drift if either value changes.
+ */
+export const SECURE_STORE_SERVICE = 'twist-cli'
+
+/**
+ * Pre-γ1 single-user keyring slot. `migrateLegacyAuth` deletes this after a
+ * successful migration; the runtime token store reads it as a last-resort
+ * fallback when migration couldn't complete (e.g. user is offline so
+ * `identifyAccount` can't reach Twist).
+ */
+export const LEGACY_KEYRING_ACCOUNT = 'api-token'

--- a/src/lib/auth-constants.ts
+++ b/src/lib/auth-constants.ts
@@ -1,15 +1,9 @@
-/**
- * Shared identifiers for the OS keyring. Imported by both the runtime token
- * store (`auth-provider.ts`) and the one-shot migration (`migrate-auth.ts`)
- * so the slot a writer parks a secret in and the slot a reader pulls it from
- * can't drift if either value changes.
- */
+/** OS keyring `service` identifier for every twist-cli secret. */
 export const SECURE_STORE_SERVICE = 'twist-cli'
 
 /**
- * Pre-γ1 single-user keyring slot. `migrateLegacyAuth` deletes this after a
- * successful migration; the runtime token store reads it as a last-resort
- * fallback when migration couldn't complete (e.g. user is offline so
- * `identifyAccount` can't reach Twist).
+ * Legacy single-user keyring slot. `migrateLegacyAuth` deletes it after a
+ * successful migration; the runtime token store reads it as a last resort
+ * when migration can't complete (e.g. offline `identifyAccount`).
  */
 export const LEGACY_KEYRING_ACCOUNT = 'api-token'

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -78,13 +78,7 @@ const STORED_ACCOUNT = {
 
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
 
-/**
- * `createTwistTokenStore` memoises a module-level migration promise. To
- * exercise the cold-cache path in each test (and avoid shipping a
- * test-only reset export from the production module) we reset the
- * module registry and re-import. Mocks declared above re-apply on
- * re-import.
- */
+/** Reset the module-level migration memo for each test by re-importing. */
 async function loadCreateTwistTokenStore(): Promise<
     typeof import('./auth-provider.js').createTwistTokenStore
 > {
@@ -251,7 +245,7 @@ describe('createTwistTokenStore', () => {
         vi.unstubAllEnvs()
     })
 
-    it('passes twist-cli wiring to cli-core: serviceName, no accountForUser override (cli-core default user-${id} is used after γ1), the user-records adapter, the records location, and the parseRef-aware matcher', async () => {
+    it('passes twist-cli wiring to cli-core: serviceName, no accountForUser override (uses cli-core default `user-${id}`), records location, and the parseRef-aware matcher', async () => {
         const createTwistTokenStore = await loadCreateTwistTokenStore()
         createTwistTokenStore()
 
@@ -302,9 +296,7 @@ describe('createTwistTokenStore', () => {
         await store.set(STORED_ACCOUNT, 'tk')
         await store.setDefault('42')
 
-        // Migration runs exactly once even across mixed reads + writes — that's
-        // the "memoised" half of the contract. If it re-ran per call we'd
-        // double-charge the cold-cache penalty on every CLI invocation.
+        // Memoised: migration must run exactly once across mixed reads + writes.
         expect(migrateMocks.runMigrateLegacyAuth).toHaveBeenCalledTimes(1)
         expect(migrateMocks.runMigrateLegacyAuth).toHaveBeenCalledWith({ silent: true })
     })
@@ -376,11 +368,7 @@ describe('createTwistTokenStore', () => {
         expect(keyringMocks.createSecureStore).not.toHaveBeenCalled()
     })
 
-    it('falls back to legacy when runMigrateLegacyAuth itself rejects (the catch branch of ensureMigrated)', async () => {
-        // Exercises the `catch(() => null)` swallow inside `ensureMigrated`.
-        // Without this branch a thrown migration would propagate and the CLI
-        // would crash on first invocation post-upgrade for users with a
-        // half-broken keyring / disk.
+    it('falls back to legacy when runMigrateLegacyAuth rejects (catch branch of ensureMigrated)', async () => {
         migrateMocks.runMigrateLegacyAuth.mockRejectedValue(new Error('boom'))
         keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
         configMocks.getConfig.mockResolvedValue({
@@ -398,7 +386,7 @@ describe('createTwistTokenStore', () => {
         expect(keyringMocks.inner.active).not.toHaveBeenCalled()
     })
 
-    it('legacy snapshot synthesises account.id = "" for `tw auth token <token>` users with no authUserId (preserves the pre-γ1 single-user adapter behaviour)', async () => {
+    it('legacy snapshot synthesises account.id = "" for `tw auth token <token>` users with no authUserId on disk', async () => {
         migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
             status: 'skipped',
             reason: 'identify-failed',
@@ -417,9 +405,6 @@ describe('createTwistTokenStore', () => {
     })
 
     it('active(ref) ignores the legacy snapshot when an explicit --user targets a different account', async () => {
-        // Without this guard `tw <cmd> --user 999` while offline would silently
-        // authenticate as the default legacy user (id 42) instead of failing
-        // with the expected account-not-found outcome.
         migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
             status: 'skipped',
             reason: 'identify-failed',
@@ -463,9 +448,6 @@ describe('createTwistTokenStore', () => {
     })
 
     it('set() discharges legacy state on disk before writing v2, when migration is inconclusive', async () => {
-        // Without this, a manual `tw auth token <new>` during the offline
-        // window would land in v2 but the next invocation would still read
-        // the unchanged legacy token via the active() fallback path.
         migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
             status: 'skipped',
             reason: 'identify-failed',

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -2,6 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./api.js', () => ({ createWrappedTwistClient: vi.fn() }))
 
+vi.mock('./migrate-auth.js', () => ({
+    runMigrateLegacyAuth: vi.fn().mockResolvedValue({ status: 'no-legacy-state' }),
+}))
+
 const keyringMocks = vi.hoisted(() => ({
     createKeyringTokenStore: vi.fn(),
     inner: {
@@ -35,6 +39,7 @@ vi.mock('./config.js', async (importOriginal) => {
 import { createWrappedTwistClient } from './api.js'
 import {
     AUTHORIZATION_URL,
+    __resetMigrationPromiseForTests,
     createTwistAuthProvider,
     createTwistTokenStore,
     matchTwistAccount,
@@ -197,18 +202,19 @@ describe('createTwistTokenStore', () => {
     beforeEach(() => {
         keyringMocks.createKeyringTokenStore.mockClear()
         keyringMocks.inner.active.mockReset()
+        __resetMigrationPromiseForTests()
     })
 
     afterEach(() => {
         vi.unstubAllEnvs()
     })
 
-    it('passes twist-cli wiring to cli-core: serviceName, the api-token slot, the user-records adapter, the records location, and the parseRef-aware matcher', () => {
+    it('passes twist-cli wiring to cli-core: serviceName, no accountForUser override (cli-core default user-${id} is used after γ1), the user-records adapter, the records location, and the parseRef-aware matcher', () => {
         createTwistTokenStore()
 
         const options = keyringMocks.createKeyringTokenStore.mock.calls[0][0]
         expect(options.serviceName).toBe('twist-cli')
-        expect(options.accountForUser('any-id')).toBe('api-token')
+        expect(options.accountForUser).toBeUndefined()
         expect(options.recordsLocation).toBe('/home/user/.config/twist-cli/config.json')
         expect(options.matchAccount).toBe(matchTwistAccount)
     })

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -76,6 +76,19 @@ const STORED_ACCOUNT = {
     authScope: 'user:read',
 }
 
+const SKIPPED_RESULT = {
+    status: 'skipped',
+    reason: 'identify-failed',
+    detail: 'offline',
+} as const
+
+const LEGACY_CONFIG = {
+    authUserId: 42,
+    authUserName: 'Ada',
+    authMode: 'read-write' as const,
+    authScope: 'user:read',
+}
+
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
 
 /** Reset the module-level migration memo for each test by re-importing. */
@@ -283,10 +296,6 @@ describe('createTwistTokenStore', () => {
 
     it('runs runMigrateLegacyAuth on the first store access and memoises across subsequent calls', async () => {
         keyringMocks.inner.active.mockResolvedValue(null)
-        keyringMocks.inner.list.mockResolvedValue([])
-        keyringMocks.inner.clear.mockResolvedValue(undefined)
-        keyringMocks.inner.set.mockResolvedValue(undefined)
-        keyringMocks.inner.setDefault.mockResolvedValue(undefined)
         const createTwistTokenStore = await loadCreateTwistTokenStore()
         const store = createTwistTokenStore()
 
@@ -302,18 +311,9 @@ describe('createTwistTokenStore', () => {
     })
 
     it('falls back to the legacy api-token keyring slot when migration is skipped (offline `identifyAccount`)', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
         keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
-        configMocks.getConfig.mockResolvedValue({
-            authUserId: 42,
-            authUserName: 'Ada',
-            authMode: 'read-write',
-            authScope: 'user:read',
-        })
+        configMocks.getConfig.mockResolvedValue(LEGACY_CONFIG)
         const createTwistTokenStore = await loadCreateTwistTokenStore()
 
         const snapshot = await createTwistTokenStore().active()
@@ -324,30 +324,18 @@ describe('createTwistTokenStore', () => {
         })
         expect(snapshot).toEqual({
             token: 'tk_legacy_keyring',
-            account: {
-                id: '42',
-                label: 'Ada',
-                authMode: 'read-write',
-                authScope: 'user:read',
-            },
+            account: { id: '42', label: 'Ada', authMode: 'read-write', authScope: 'user:read' },
         })
         // v2 path is not consulted when the legacy fallback succeeded.
         expect(keyringMocks.inner.active).not.toHaveBeenCalled()
     })
 
-    it('falls back to the legacy plaintext config.token when migration is skipped and the keyring is empty', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
-        keyringMocks.secureStoreGetSecret.mockResolvedValue(null)
+    it('falls back to plaintext config.token when migration is skipped and the keyring is empty', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
         configMocks.getConfig.mockResolvedValue({
+            ...LEGACY_CONFIG,
             token: '  tk_legacy_plaintext  ',
-            authUserId: 42,
-            authUserName: 'Ada',
             authMode: 'read-only',
-            authScope: 'user:read',
         })
         const createTwistTokenStore = await loadCreateTwistTokenStore()
 
@@ -371,12 +359,7 @@ describe('createTwistTokenStore', () => {
     it('falls back to legacy when runMigrateLegacyAuth rejects (catch branch of ensureMigrated)', async () => {
         migrateMocks.runMigrateLegacyAuth.mockRejectedValue(new Error('boom'))
         keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
-        configMocks.getConfig.mockResolvedValue({
-            authUserId: 42,
-            authUserName: 'Ada',
-            authMode: 'read-write',
-            authScope: 'user:read',
-        })
+        configMocks.getConfig.mockResolvedValue(LEGACY_CONFIG)
         const createTwistTokenStore = await loadCreateTwistTokenStore()
 
         const snapshot = await createTwistTokenStore().active()
@@ -387,15 +370,8 @@ describe('createTwistTokenStore', () => {
     })
 
     it('legacy snapshot synthesises account.id = "" for `tw auth token <token>` users with no authUserId on disk', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
-        configMocks.getConfig.mockResolvedValue({
-            token: 'tk_token_only',
-            authMode: 'unknown',
-        })
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
+        configMocks.getConfig.mockResolvedValue({ token: 'tk_token_only', authMode: 'unknown' })
         const createTwistTokenStore = await loadCreateTwistTokenStore()
 
         const snapshot = await createTwistTokenStore().active()
@@ -404,60 +380,31 @@ describe('createTwistTokenStore', () => {
         expect(snapshot?.account.label).toBe('')
     })
 
-    it('active(ref) ignores the legacy snapshot when an explicit --user targets a different account', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
+    it('active(ref) returns the legacy snapshot when ref matches, falls through to v2 when it doesn’t', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
         keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
-        configMocks.getConfig.mockResolvedValue({
-            authUserId: 42,
-            authUserName: 'Ada',
-            authMode: 'read-write',
-            authScope: 'user:read',
-        })
+        configMocks.getConfig.mockResolvedValue(LEGACY_CONFIG)
         keyringMocks.inner.active.mockResolvedValue(null)
         const createTwistTokenStore = await loadCreateTwistTokenStore()
+        const store = createTwistTokenStore()
 
-        const snapshot = await createTwistTokenStore().active('999')
+        const matched = await store.active('42')
+        expect(matched?.token).toBe('tk_legacy_keyring')
 
+        const mismatched = await store.active('999')
+        expect(mismatched).toBeNull()
         expect(keyringMocks.inner.active).toHaveBeenCalledWith('999')
-        expect(snapshot).toBeNull()
     })
 
-    it('active(ref) returns the legacy snapshot when the ref matches the legacy account', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
-        keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
-        configMocks.getConfig.mockResolvedValue({
-            authUserId: 42,
-            authUserName: 'Ada',
-            authMode: 'read-write',
-            authScope: 'user:read',
-        })
+    it('set() / clear() discharge legacy state on disk when migration is inconclusive', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
         const createTwistTokenStore = await loadCreateTwistTokenStore()
+        const store = createTwistTokenStore()
 
-        const snapshot = await createTwistTokenStore().active('42')
+        await store.set(STORED_ACCOUNT, 'tk_new')
+        await store.clear('42')
 
-        expect(snapshot?.token).toBe('tk_legacy_keyring')
-        expect(keyringMocks.inner.active).not.toHaveBeenCalled()
-    })
-
-    it('set() discharges legacy state on disk before writing v2, when migration is inconclusive', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
-        const createTwistTokenStore = await loadCreateTwistTokenStore()
-
-        await createTwistTokenStore().set(STORED_ACCOUNT, 'tk_new')
-
-        expect(keyringMocks.secureStoreDeleteSecret).toHaveBeenCalledTimes(1)
+        expect(keyringMocks.secureStoreDeleteSecret).toHaveBeenCalledTimes(2)
         expect(configMocks.updateConfig).toHaveBeenCalledWith({
             token: undefined,
             authMode: undefined,
@@ -467,20 +414,6 @@ describe('createTwistTokenStore', () => {
             pendingSecureStoreClear: undefined,
         })
         expect(keyringMocks.inner.set).toHaveBeenCalledWith(STORED_ACCOUNT, 'tk_new')
-    })
-
-    it('clear() discharges legacy state when migration is inconclusive (so logout actually logs the user out)', async () => {
-        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
-        const createTwistTokenStore = await loadCreateTwistTokenStore()
-
-        await createTwistTokenStore().clear('42')
-
-        expect(keyringMocks.secureStoreDeleteSecret).toHaveBeenCalledTimes(1)
-        expect(configMocks.updateConfig).toHaveBeenCalled()
         expect(keyringMocks.inner.clear).toHaveBeenCalledWith('42')
     })
 

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -12,6 +12,7 @@ const keyringMocks = vi.hoisted(() => ({
     createKeyringTokenStore: vi.fn(),
     createSecureStore: vi.fn(),
     secureStoreGetSecret: vi.fn(),
+    secureStoreDeleteSecret: vi.fn(),
     inner: {
         active: vi.fn(),
         set: vi.fn(),
@@ -29,7 +30,7 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
     keyringMocks.createSecureStore.mockImplementation(() => ({
         getSecret: keyringMocks.secureStoreGetSecret,
         setSecret: vi.fn(),
-        deleteSecret: vi.fn(),
+        deleteSecret: keyringMocks.secureStoreDeleteSecret,
     }))
     return {
         ...actual,
@@ -40,6 +41,7 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
 
 const configMocks = vi.hoisted(() => ({
     getConfig: vi.fn(),
+    updateConfig: vi.fn(),
 }))
 
 vi.mock('./config.js', async (importOriginal) => {
@@ -48,6 +50,7 @@ vi.mock('./config.js', async (importOriginal) => {
         ...actual,
         getConfigPath: () => '/home/user/.config/twist-cli/config.json',
         getConfig: configMocks.getConfig,
+        updateConfig: configMocks.updateConfig,
     }
 })
 
@@ -231,15 +234,17 @@ describe('createTwistTokenStore', () => {
         keyringMocks.createKeyringTokenStore.mockClear()
         keyringMocks.createSecureStore.mockClear()
         keyringMocks.secureStoreGetSecret.mockReset().mockResolvedValue(null)
+        keyringMocks.secureStoreDeleteSecret.mockReset().mockResolvedValue(true)
         keyringMocks.inner.active.mockReset()
-        keyringMocks.inner.set.mockReset()
-        keyringMocks.inner.clear.mockReset()
-        keyringMocks.inner.list.mockReset()
-        keyringMocks.inner.setDefault.mockReset()
+        keyringMocks.inner.set.mockReset().mockResolvedValue(undefined)
+        keyringMocks.inner.clear.mockReset().mockResolvedValue(undefined)
+        keyringMocks.inner.list.mockReset().mockResolvedValue([])
+        keyringMocks.inner.setDefault.mockReset().mockResolvedValue(undefined)
         migrateMocks.runMigrateLegacyAuth
             .mockReset()
             .mockResolvedValue({ status: 'no-legacy-state' })
         configMocks.getConfig.mockReset().mockResolvedValue({})
+        configMocks.updateConfig.mockReset().mockResolvedValue(undefined)
     })
 
     afterEach(() => {
@@ -369,6 +374,144 @@ describe('createTwistTokenStore', () => {
 
         expect(snapshot).toEqual({ token: 'tk_v2', account: STORED_ACCOUNT })
         expect(keyringMocks.createSecureStore).not.toHaveBeenCalled()
+    })
+
+    it('falls back to legacy when runMigrateLegacyAuth itself rejects (the catch branch of ensureMigrated)', async () => {
+        // Exercises the `catch(() => null)` swallow inside `ensureMigrated`.
+        // Without this branch a thrown migration would propagate and the CLI
+        // would crash on first invocation post-upgrade for users with a
+        // half-broken keyring / disk.
+        migrateMocks.runMigrateLegacyAuth.mockRejectedValue(new Error('boom'))
+        keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
+        configMocks.getConfig.mockResolvedValue({
+            authUserId: 42,
+            authUserName: 'Ada',
+            authMode: 'read-write',
+            authScope: 'user:read',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active()
+
+        expect(snapshot?.token).toBe('tk_legacy_keyring')
+        expect(snapshot?.account.id).toBe('42')
+        expect(keyringMocks.inner.active).not.toHaveBeenCalled()
+    })
+
+    it('legacy snapshot synthesises account.id = "" for `tw auth token <token>` users with no authUserId (preserves the pre-γ1 single-user adapter behaviour)', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        configMocks.getConfig.mockResolvedValue({
+            token: 'tk_token_only',
+            authMode: 'unknown',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active()
+
+        expect(snapshot?.account.id).toBe('')
+        expect(snapshot?.account.label).toBe('')
+    })
+
+    it('active(ref) ignores the legacy snapshot when an explicit --user targets a different account', async () => {
+        // Without this guard `tw <cmd> --user 999` while offline would silently
+        // authenticate as the default legacy user (id 42) instead of failing
+        // with the expected account-not-found outcome.
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
+        configMocks.getConfig.mockResolvedValue({
+            authUserId: 42,
+            authUserName: 'Ada',
+            authMode: 'read-write',
+            authScope: 'user:read',
+        })
+        keyringMocks.inner.active.mockResolvedValue(null)
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active('999')
+
+        expect(keyringMocks.inner.active).toHaveBeenCalledWith('999')
+        expect(snapshot).toBeNull()
+    })
+
+    it('active(ref) returns the legacy snapshot when the ref matches the legacy account', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
+        configMocks.getConfig.mockResolvedValue({
+            authUserId: 42,
+            authUserName: 'Ada',
+            authMode: 'read-write',
+            authScope: 'user:read',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active('42')
+
+        expect(snapshot?.token).toBe('tk_legacy_keyring')
+        expect(keyringMocks.inner.active).not.toHaveBeenCalled()
+    })
+
+    it('set() discharges legacy state on disk before writing v2, when migration is inconclusive', async () => {
+        // Without this, a manual `tw auth token <new>` during the offline
+        // window would land in v2 but the next invocation would still read
+        // the unchanged legacy token via the active() fallback path.
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        await createTwistTokenStore().set(STORED_ACCOUNT, 'tk_new')
+
+        expect(keyringMocks.secureStoreDeleteSecret).toHaveBeenCalledTimes(1)
+        expect(configMocks.updateConfig).toHaveBeenCalledWith({
+            token: undefined,
+            authMode: undefined,
+            authScope: undefined,
+            authUserId: undefined,
+            authUserName: undefined,
+            pendingSecureStoreClear: undefined,
+        })
+        expect(keyringMocks.inner.set).toHaveBeenCalledWith(STORED_ACCOUNT, 'tk_new')
+    })
+
+    it('clear() discharges legacy state when migration is inconclusive (so logout actually logs the user out)', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        await createTwistTokenStore().clear('42')
+
+        expect(keyringMocks.secureStoreDeleteSecret).toHaveBeenCalledTimes(1)
+        expect(configMocks.updateConfig).toHaveBeenCalled()
+        expect(keyringMocks.inner.clear).toHaveBeenCalledWith('42')
+    })
+
+    it('set() / clear() do NOT touch legacy state when migration is conclusive (no needless writes on the happy path)', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({ status: 'no-legacy-state' })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+        const store = createTwistTokenStore()
+
+        await store.set(STORED_ACCOUNT, 'tk_new')
+        await store.clear('42')
+
+        expect(keyringMocks.secureStoreDeleteSecret).not.toHaveBeenCalled()
+        expect(configMocks.updateConfig).not.toHaveBeenCalled()
     })
 })
 

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -2,12 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('./api.js', () => ({ createWrappedTwistClient: vi.fn() }))
 
-vi.mock('./migrate-auth.js', () => ({
-    runMigrateLegacyAuth: vi.fn().mockResolvedValue({ status: 'no-legacy-state' }),
+const migrateMocks = vi.hoisted(() => ({
+    runMigrateLegacyAuth: vi.fn(),
 }))
+
+vi.mock('./migrate-auth.js', () => migrateMocks)
 
 const keyringMocks = vi.hoisted(() => ({
     createKeyringTokenStore: vi.fn(),
+    createSecureStore: vi.fn(),
+    secureStoreGetSecret: vi.fn(),
     inner: {
         active: vi.fn(),
         set: vi.fn(),
@@ -22,26 +26,35 @@ const keyringMocks = vi.hoisted(() => ({
 vi.mock('@doist/cli-core/auth', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@doist/cli-core/auth')>()
     keyringMocks.createKeyringTokenStore.mockImplementation(() => keyringMocks.inner)
+    keyringMocks.createSecureStore.mockImplementation(() => ({
+        getSecret: keyringMocks.secureStoreGetSecret,
+        setSecret: vi.fn(),
+        deleteSecret: vi.fn(),
+    }))
     return {
         ...actual,
         createKeyringTokenStore: keyringMocks.createKeyringTokenStore,
+        createSecureStore: keyringMocks.createSecureStore,
     }
 })
+
+const configMocks = vi.hoisted(() => ({
+    getConfig: vi.fn(),
+}))
 
 vi.mock('./config.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('./config.js')>()
     return {
         ...actual,
         getConfigPath: () => '/home/user/.config/twist-cli/config.json',
+        getConfig: configMocks.getConfig,
     }
 })
 
 import { createWrappedTwistClient } from './api.js'
 import {
     AUTHORIZATION_URL,
-    __resetMigrationPromiseForTests,
     createTwistAuthProvider,
-    createTwistTokenStore,
     matchTwistAccount,
     READ_ONLY_SCOPES,
     READ_WRITE_SCOPES,
@@ -61,6 +74,21 @@ const STORED_ACCOUNT = {
 }
 
 const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
+
+/**
+ * `createTwistTokenStore` memoises a module-level migration promise. To
+ * exercise the cold-cache path in each test (and avoid shipping a
+ * test-only reset export from the production module) we reset the
+ * module registry and re-import. Mocks declared above re-apply on
+ * re-import.
+ */
+async function loadCreateTwistTokenStore(): Promise<
+    typeof import('./auth-provider.js').createTwistTokenStore
+> {
+    vi.resetModules()
+    const mod = await import('./auth-provider.js')
+    return mod.createTwistTokenStore
+}
 
 describe('createTwistAuthProvider', () => {
     let fetchSpy: ReturnType<typeof vi.spyOn>
@@ -201,26 +229,38 @@ describe('createTwistAuthProvider', () => {
 describe('createTwistTokenStore', () => {
     beforeEach(() => {
         keyringMocks.createKeyringTokenStore.mockClear()
+        keyringMocks.createSecureStore.mockClear()
+        keyringMocks.secureStoreGetSecret.mockReset().mockResolvedValue(null)
         keyringMocks.inner.active.mockReset()
-        __resetMigrationPromiseForTests()
+        keyringMocks.inner.set.mockReset()
+        keyringMocks.inner.clear.mockReset()
+        keyringMocks.inner.list.mockReset()
+        keyringMocks.inner.setDefault.mockReset()
+        migrateMocks.runMigrateLegacyAuth
+            .mockReset()
+            .mockResolvedValue({ status: 'no-legacy-state' })
+        configMocks.getConfig.mockReset().mockResolvedValue({})
     })
 
     afterEach(() => {
         vi.unstubAllEnvs()
     })
 
-    it('passes twist-cli wiring to cli-core: serviceName, no accountForUser override (cli-core default user-${id} is used after γ1), the user-records adapter, the records location, and the parseRef-aware matcher', () => {
+    it('passes twist-cli wiring to cli-core: serviceName, no accountForUser override (cli-core default user-${id} is used after γ1), the user-records adapter, the records location, and the parseRef-aware matcher', async () => {
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
         createTwistTokenStore()
 
         const options = keyringMocks.createKeyringTokenStore.mock.calls[0][0]
         expect(options.serviceName).toBe('twist-cli')
         expect(options.accountForUser).toBeUndefined()
         expect(options.recordsLocation).toBe('/home/user/.config/twist-cli/config.json')
-        expect(options.matchAccount).toBe(matchTwistAccount)
+        const { matchTwistAccount: matcher } = await import('./auth-provider.js')
+        expect(options.matchAccount).toBe(matcher)
     })
 
-    it('active() short-circuits to TWIST_API_TOKEN when no explicit ref is supplied', async () => {
+    it('active() short-circuits to TWIST_API_TOKEN when no explicit ref is supplied (and never even awaits migration)', async () => {
         vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
 
         const snapshot = await createTwistTokenStore().active()
 
@@ -229,15 +269,106 @@ describe('createTwistTokenStore', () => {
             account: { id: '', label: '', authMode: 'unknown', authScope: '' },
         })
         expect(keyringMocks.inner.active).not.toHaveBeenCalled()
+        expect(migrateMocks.runMigrateLegacyAuth).not.toHaveBeenCalled()
     })
 
     it('active() ignores TWIST_API_TOKEN when an explicit --user ref targets a stored account', async () => {
         vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
         keyringMocks.inner.active.mockResolvedValue({ token: 'tk_stored', account: STORED_ACCOUNT })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
 
         await createTwistTokenStore().active('42')
 
         expect(keyringMocks.inner.active).toHaveBeenCalledWith('42')
+    })
+
+    it('runs runMigrateLegacyAuth on the first store access and memoises across subsequent calls', async () => {
+        keyringMocks.inner.active.mockResolvedValue(null)
+        keyringMocks.inner.list.mockResolvedValue([])
+        keyringMocks.inner.clear.mockResolvedValue(undefined)
+        keyringMocks.inner.set.mockResolvedValue(undefined)
+        keyringMocks.inner.setDefault.mockResolvedValue(undefined)
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+        const store = createTwistTokenStore()
+
+        await store.active('42')
+        await store.list()
+        await store.clear('42')
+        await store.set(STORED_ACCOUNT, 'tk')
+        await store.setDefault('42')
+
+        // Migration runs exactly once even across mixed reads + writes — that's
+        // the "memoised" half of the contract. If it re-ran per call we'd
+        // double-charge the cold-cache penalty on every CLI invocation.
+        expect(migrateMocks.runMigrateLegacyAuth).toHaveBeenCalledTimes(1)
+        expect(migrateMocks.runMigrateLegacyAuth).toHaveBeenCalledWith({ silent: true })
+    })
+
+    it('falls back to the legacy api-token keyring slot when migration is skipped (offline `identifyAccount`)', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        keyringMocks.secureStoreGetSecret.mockResolvedValue('tk_legacy_keyring')
+        configMocks.getConfig.mockResolvedValue({
+            authUserId: 42,
+            authUserName: 'Ada',
+            authMode: 'read-write',
+            authScope: 'user:read',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active()
+
+        expect(keyringMocks.createSecureStore).toHaveBeenCalledWith({
+            serviceName: 'twist-cli',
+            account: 'api-token',
+        })
+        expect(snapshot).toEqual({
+            token: 'tk_legacy_keyring',
+            account: {
+                id: '42',
+                label: 'Ada',
+                authMode: 'read-write',
+                authScope: 'user:read',
+            },
+        })
+        // v2 path is not consulted when the legacy fallback succeeded.
+        expect(keyringMocks.inner.active).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the legacy plaintext config.token when migration is skipped and the keyring is empty', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        keyringMocks.secureStoreGetSecret.mockResolvedValue(null)
+        configMocks.getConfig.mockResolvedValue({
+            token: '  tk_legacy_plaintext  ',
+            authUserId: 42,
+            authUserName: 'Ada',
+            authMode: 'read-only',
+            authScope: 'user:read',
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active()
+
+        expect(snapshot?.token).toBe('tk_legacy_plaintext')
+        expect(snapshot?.account.authMode).toBe('read-only')
+    })
+
+    it('delegates to the v2 store when migration is conclusive (no-legacy-state) — no legacy read attempt', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({ status: 'no-legacy-state' })
+        keyringMocks.inner.active.mockResolvedValue({ token: 'tk_v2', account: STORED_ACCOUNT })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().active()
+
+        expect(snapshot).toEqual({ token: 'tk_v2', account: STORED_ACCOUNT })
+        expect(keyringMocks.createSecureStore).not.toHaveBeenCalled()
     })
 })
 

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -288,26 +288,21 @@ function migrationIsConclusive(result: MigrateAuthResult<TwistAccount>): boolean
 
 /**
  * Synthesise a snapshot from v1 state still on disk (legacy keyring slot,
- * then plaintext `config.token`). Used only as a fallback when migration
- * can't complete. Token-only users with no `authUserId` get `account.id =
- * ''` so callers can detect the unidentified-account state.
+ * then plaintext `config.token`). Fallback for when migration can't complete.
+ * Token-only users with no `authUserId` get `account.id = ''`.
  */
 async function readLegacyTokenSnapshot(): Promise<{
     token: string
     account: TwistAccount
 } | null> {
-    let token: string | null = null
-    try {
-        const secureStore = createSecureStore({
-            serviceName: SECURE_STORE_SERVICE,
-            account: LEGACY_KEYRING_ACCOUNT,
-        })
-        token = await secureStore.getSecret()
-    } catch {
-        // Keyring unreachable — fall through to plaintext.
-    }
+    const fromKeyring = await createSecureStore({
+        serviceName: SECURE_STORE_SERVICE,
+        account: LEGACY_KEYRING_ACCOUNT,
+    })
+        .getSecret()
+        .catch(() => null)
     const config = await getConfig()
-    if (!token) token = config.token?.trim() || null
+    const token = fromKeyring || config.token?.trim() || null
     if (!token) return null
     return {
         token,
@@ -323,26 +318,23 @@ async function readLegacyTokenSnapshot(): Promise<{
 /**
  * Clear the legacy keyring slot + v1 flat config fields. Runs before a
  * write/clear when migration is inconclusive so v2 writes aren't shadowed
- * by a stale legacy token on the next read. Best-effort: a failure here
- * leaves the legacy entry put, which is harmless once migration completes.
+ * by a stale legacy token. Best-effort — failures leave legacy in place.
  */
 async function dischargeLegacyState(): Promise<void> {
-    try {
-        await createSecureStore({
+    await Promise.allSettled([
+        createSecureStore({
             serviceName: SECURE_STORE_SERVICE,
             account: LEGACY_KEYRING_ACCOUNT,
-        }).deleteSecret()
-    } catch {}
-    try {
-        await updateConfig({
+        }).deleteSecret(),
+        updateConfig({
             token: undefined,
             authMode: undefined,
             authScope: undefined,
             authUserId: undefined,
             authUserName: undefined,
             pendingSecureStoreClear: undefined,
-        })
-    } catch {}
+        }),
+    ])
 }
 
 /**

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -11,6 +11,7 @@ import { createWrappedTwistClient } from './api.js'
 import type { AuthMode } from './config.js'
 import { getConfigPath } from './config.js'
 import { CliError } from './errors.js'
+import { runMigrateLegacyAuth } from './migrate-auth.js'
 import { parseRef } from './refs.js'
 import { createTwistUserRecordStore } from './user-records.js'
 
@@ -22,11 +23,6 @@ const LOGO_URI =
     'https://raw.githubusercontent.com/Doist/twist-cli/d65c447ff453eb36af585044c2f5f2f602bcdb34/icons/twist-cli.png'
 
 const SECURE_STORE_SERVICE = 'twist-cli'
-// Preserve the keyring slot the previous custom `TwistTokenStore` wrote to,
-// so tokens already in users' keychains stay readable after the swap. cli-core
-// defaults to `user-${id}`; overriding keeps single-user installs uninterrupted
-// and is safe to drop if/when we adopt multi-user storage.
-const SECURE_STORE_ACCOUNT_SLOT = 'api-token'
 
 export const READ_WRITE_SCOPES = [
     'user:read',
@@ -287,17 +283,42 @@ export function matchTwistAccount(account: TwistAccount, ref: AccountRef): boole
 const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
 /**
+ * Memoised one-shot v1 → v2 migration trigger. The first read/write to the
+ * store on a cold process awaits it; later operations short-circuit on the
+ * resolved promise. Errors are swallowed (the cli-core helper itself runs in
+ * silent mode and leaves v1 state untouched on failure) so the CLI never
+ * fails to start because a migration attempt blew up.
+ */
+let migrationPromise: Promise<void> | undefined
+function ensureMigrated(): Promise<void> {
+    if (!migrationPromise) {
+        migrationPromise = runMigrateLegacyAuth({ silent: true })
+            .then(() => undefined)
+            .catch(() => undefined)
+    }
+    return migrationPromise
+}
+
+/** Test-only — reset the memoised migration promise so subsequent reads re-run it. */
+export function __resetMigrationPromiseForTests(): void {
+    migrationPromise = undefined
+}
+
+/**
  * `TWIST_API_TOKEN=… tw <subcommand>` must work even when nothing is in the
  * keyring — cli-core's `KeyringTokenStore` only knows about its own backing
  * store, so we wrap `active()` to short-circuit to the env value when no
  * explicit `--user <ref>` is supplied. With an explicit ref the caller is
  * targeting a specific stored account, so the env var is intentionally
  * ignored.
+ *
+ * Every method that touches stored state also awaits `ensureMigrated()` so a
+ * user who installed with `--ignore-scripts` (skipping the postinstall hook)
+ * still gets their v1 token promoted to v2 transparently on first command.
  */
 export function createTwistTokenStore(): TwistTokenStore {
     const inner = createKeyringTokenStore<TwistAccount>({
         serviceName: SECURE_STORE_SERVICE,
-        accountForUser: () => SECURE_STORE_ACCOUNT_SLOT,
         userRecords: createTwistUserRecordStore(),
         recordsLocation: getConfigPath(),
         matchAccount: matchTwistAccount,
@@ -313,7 +334,24 @@ export function createTwistTokenStore(): TwistTokenStore {
                     }
                 }
             }
+            await ensureMigrated()
             return inner.active(ref)
+        },
+        async set(account: TwistAccount, token: string) {
+            await ensureMigrated()
+            return inner.set(account, token)
+        },
+        async clear(ref?: AccountRef) {
+            await ensureMigrated()
+            return inner.clear(ref)
+        },
+        async list() {
+            await ensureMigrated()
+            return inner.list()
+        },
+        async setDefault(ref: AccountRef) {
+            await ensureMigrated()
+            return inner.setDefault(ref)
         },
     })
 }
@@ -325,6 +363,9 @@ export function createTwistTokenStore(): TwistTokenStore {
  */
 export async function getActiveTokenSource(): Promise<'env' | 'secure-store' | 'config-file'> {
     if (process.env[TOKEN_ENV_VAR]) return 'env'
-    const [record] = await createTwistUserRecordStore().list()
+    const store = createTwistUserRecordStore()
+    const [records, defaultId] = await Promise.all([store.list(), store.getDefaultId()])
+    const record =
+        (defaultId !== null && records.find((r) => r.account.id === defaultId)) || records[0]
     return record?.fallbackToken ? 'config-file' : 'secure-store'
 }

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -264,11 +264,10 @@ export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
     }
 }
 
-// Twist-flavoured ref matcher: `parseRef` normalises `id:<n>` and `<n>` to the
-// same numeric id, and labels match case-insensitively. cli-core's default is
-// strict equality on `account.id` / `account.label`, so passing this in keeps
-// the user-facing ref formats (`tw auth status --user 42`, `--user id:42`,
-// `--user Ada`) that the previous custom store supported.
+/**
+ * Accepts `42`, `id:42`, and case-insensitive labels — `parseRef` normalises
+ * the numeric forms. Broader than cli-core's default strict-equality matcher.
+ */
 export function matchTwistAccount(account: TwistAccount, ref: AccountRef): boolean {
     const parsed = parseRef(ref)
     if (parsed.type === 'id') return Number(account.id) === parsed.id
@@ -278,7 +277,7 @@ export function matchTwistAccount(account: TwistAccount, ref: AccountRef): boole
 
 const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
-/** A migration result that means the v2 store is the authoritative source. */
+/** True when the v2 store is the authoritative source. */
 function migrationIsConclusive(result: MigrateAuthResult<TwistAccount>): boolean {
     return (
         result.status === 'migrated' ||
@@ -288,13 +287,10 @@ function migrationIsConclusive(result: MigrateAuthResult<TwistAccount>): boolean
 }
 
 /**
- * Read v1 credentials still on disk (legacy keyring slot first, then the
- * plaintext `config.token` slot). Used only when `migrateLegacyAuth` couldn't
- * complete this run — never on the happy path. Returns a synthetic snapshot
- * with whatever v1 auth metadata is in `config.json` so consumers like `tw
- * auth status` keep working. `tw auth token <token>` users have no
- * `authUserId`; their synthetic snapshot carries `account.id === ''`
- * (matching the pre-γ1 behaviour of the old single-user adapter).
+ * Synthesise a snapshot from v1 state still on disk (legacy keyring slot,
+ * then plaintext `config.token`). Used only as a fallback when migration
+ * can't complete. Token-only users with no `authUserId` get `account.id =
+ * ''` so callers can detect the unidentified-account state.
  */
 async function readLegacyTokenSnapshot(): Promise<{
     token: string
@@ -325,13 +321,10 @@ async function readLegacyTokenSnapshot(): Promise<{
 }
 
 /**
- * Best-effort clean-up of v1 state on disk. Runs before a write / clear when
- * `migrateLegacyAuth` couldn't complete — so a user who logs in with
- * `tw auth token <new>` or out via `tw auth logout` during the post-upgrade
- * offline window doesn't end up with v2 writes shadowed by a stale legacy
- * token. Mirrors the cleanup that `migrateLegacyAuth.cleanupLegacyConfig`
- * does once it can reach the API. Failures (offline keyring, etc.) are
- * swallowed: the v2 write is what counts, the legacy state is just noise.
+ * Clear the legacy keyring slot + v1 flat config fields. Runs before a
+ * write/clear when migration is inconclusive so v2 writes aren't shadowed
+ * by a stale legacy token on the next read. Best-effort: a failure here
+ * leaves the legacy entry put, which is harmless once migration completes.
  */
 async function dischargeLegacyState(): Promise<void> {
     try {
@@ -339,10 +332,7 @@ async function dischargeLegacyState(): Promise<void> {
             serviceName: SECURE_STORE_SERVICE,
             account: LEGACY_KEYRING_ACCOUNT,
         }).deleteSecret()
-    } catch {
-        // Keyring unreachable — the legacy entry stays put; harmless because
-        // the v2 store is what `active()` will read once migration completes.
-    }
+    } catch {}
     try {
         await updateConfig({
             token: undefined,
@@ -352,21 +342,14 @@ async function dischargeLegacyState(): Promise<void> {
             authUserName: undefined,
             pendingSecureStoreClear: undefined,
         })
-    } catch {
-        // Same rationale — best effort.
-    }
+    } catch {}
 }
 
 /**
- * Memoised one-shot v1 → v2 migration trigger. The first read/write to the
- * store on a cold process awaits it; later operations short-circuit on the
- * resolved promise. Errors are swallowed (the cli-core helper itself runs in
- * silent mode and leaves v1 state untouched on failure) so the CLI never
- * fails to start because a migration attempt blew up; the runtime falls back
- * to the legacy snapshot below when the result isn't conclusive.
- *
- * Module-private; tests reset it with `vi.resetModules()` + dynamic
- * `import('./auth-provider.js')` so no test-only seam ships in dist/.
+ * Memoised one-shot migration trigger. Resolves with `null` on rejection
+ * so the CLI never fails to start because of a migration error — the
+ * legacy snapshot fallback below handles that case. Tests reset the memo
+ * with `vi.resetModules()` + a dynamic re-import.
  */
 let migrationPromise: Promise<MigrateAuthResult<TwistAccount> | null> | undefined
 function ensureMigrated(): Promise<MigrateAuthResult<TwistAccount> | null> {
@@ -377,25 +360,16 @@ function ensureMigrated(): Promise<MigrateAuthResult<TwistAccount> | null> {
 }
 
 /**
- * `TWIST_API_TOKEN=… tw <subcommand>` must work even when nothing is in the
- * keyring — cli-core's `KeyringTokenStore` only knows about its own backing
- * store, so we wrap `active()` to short-circuit to the env value when no
- * explicit `--user <ref>` is supplied. With an explicit ref the caller is
- * targeting a specific stored account, so the env var is intentionally
- * ignored.
+ * `TWIST_API_TOKEN` short-circuits `active()` only when no explicit ref is
+ * supplied — cli-core's `KeyringTokenStore` doesn't know about the env var,
+ * and an explicit ref means the caller targets a specific stored account.
  *
- * Every method that touches stored state also awaits `ensureMigrated()` so a
- * user who installed with `--ignore-scripts` (skipping the postinstall hook)
- * still gets their v1 token promoted to v2 transparently on first command.
- * When migration couldn't complete (offline `identifyAccount`, keyring
- * unreachable, …):
- *   - `active()` falls back to the legacy snapshot so the user isn't treated
- *     as logged out. An explicit `--user <ref>` is honoured against the
- *     legacy account so `tw --user <other-id>` can't accidentally resolve to
- *     the legacy default.
- *   - `set()` / `clear()` first discharge the legacy state on disk before
- *     writing v2, so a manual `tw auth token <new>` or `tw auth logout`
- *     doesn't leave a stale v1 token to shadow the v2 write on the next run.
+ * `ensureMigrated()` runs on every stored-state op so `--ignore-scripts`
+ * installs still migrate on first command. When migration isn't conclusive:
+ *  - `active()` falls back to the legacy snapshot, honouring `ref` so it
+ *    can't resolve to a different account than the caller asked for.
+ *  - `set()` / `clear()` discharge legacy state on disk first so v2 writes
+ *    aren't shadowed by a stale v1 token on the next read.
  */
 export function createTwistTokenStore(): TwistTokenStore {
     const inner = createKeyringTokenStore<TwistAccount>({
@@ -450,13 +424,9 @@ export function createTwistTokenStore(): TwistTokenStore {
 }
 
 /**
- * Derive the source of the currently-active token. Lives here (next to the
- * store) so `lib/auth.ts` doesn't need to know about `UserRecordStore`'s
- * `fallbackToken` field — keeps the storage abstraction clean. Surfaces
- * `'config-file'` whenever a plaintext token is on disk, including the
- * legacy `config.token` slot that `migrateLegacyAuth` hasn't cleaned up
- * yet, so `tw doctor` / `tw config view` reports the security-relevant
- * state during the post-upgrade offline window.
+ * Where the currently-active token lives. Returns `'config-file'` whenever
+ * a plaintext token is on disk — including the legacy `config.token` slot —
+ * so doctor/config-view reports the security-relevant state accurately.
  */
 export async function getActiveTokenSource(): Promise<'env' | 'secure-store' | 'config-file'> {
     if (process.env[TOKEN_ENV_VAR]) return 'env'
@@ -464,8 +434,6 @@ export async function getActiveTokenSource(): Promise<'env' | 'secure-store' | '
     const record = getDefaultUserRecord(config)
     if (record?.fallbackToken) return 'config-file'
     if (record) return 'secure-store'
-    // No v2 record yet — legacy `config.token` may still be on disk if
-    // `migrateLegacyAuth` was skipped (offline, etc.).
     if (config.token?.trim()) return 'config-file'
     return 'secure-store'
 }

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -10,11 +10,12 @@ import {
     type MigrateAuthResult,
 } from '@doist/cli-core/auth'
 import { createWrappedTwistClient } from './api.js'
-import { type AuthMode, getConfig, getConfigPath } from './config.js'
+import { LEGACY_KEYRING_ACCOUNT, SECURE_STORE_SERVICE } from './auth-constants.js'
+import { type AuthMode, getConfig, getConfigPath, updateConfig } from './config.js'
 import { CliError } from './errors.js'
 import { runMigrateLegacyAuth } from './migrate-auth.js'
 import { parseRef } from './refs.js'
-import { toTwistAccount } from './twist-account.js'
+import { makeTwistAccount, toTwistAccount } from './twist-account.js'
 import { createTwistUserRecordStore, getDefaultUserRecord } from './user-records.js'
 
 export const AUTHORIZATION_URL = 'https://twist.com/oauth/authorize'
@@ -23,8 +24,6 @@ export const REGISTRATION_URL = 'https://twist.com/oauth/register'
 
 const LOGO_URI =
     'https://raw.githubusercontent.com/Doist/twist-cli/d65c447ff453eb36af585044c2f5f2f602bcdb34/icons/twist-cli.png'
-
-const SECURE_STORE_SERVICE = 'twist-cli'
 
 export const READ_WRITE_SCOPES = [
     'user:read',
@@ -279,12 +278,6 @@ export function matchTwistAccount(account: TwistAccount, ref: AccountRef): boole
 
 const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
-// Legacy pre-γ1 keyring slot. Read as a last resort in `active()` when
-// `migrateLegacyAuth` couldn't complete (e.g. the user is offline so
-// `identifyAccount` can't reach Twist) so the CLI stays usable instead of
-// silently treating the user as logged out.
-const LEGACY_KEYRING_ACCOUNT = 'api-token'
-
 /** A migration result that means the v2 store is the authoritative source. */
 function migrationIsConclusive(result: MigrateAuthResult<TwistAccount>): boolean {
     return (
@@ -299,7 +292,9 @@ function migrationIsConclusive(result: MigrateAuthResult<TwistAccount>): boolean
  * plaintext `config.token` slot). Used only when `migrateLegacyAuth` couldn't
  * complete this run — never on the happy path. Returns a synthetic snapshot
  * with whatever v1 auth metadata is in `config.json` so consumers like `tw
- * auth status` keep working.
+ * auth status` keep working. `tw auth token <token>` users have no
+ * `authUserId`; their synthetic snapshot carries `account.id === ''`
+ * (matching the pre-γ1 behaviour of the old single-user adapter).
  */
 async function readLegacyTokenSnapshot(): Promise<{
     token: string
@@ -320,10 +315,45 @@ async function readLegacyTokenSnapshot(): Promise<{
     if (!token) return null
     return {
         token,
-        account: toTwistAccount(
-            { id: config.authUserId ?? 0, name: config.authUserName ?? '' },
-            { authMode: config.authMode, authScope: config.authScope },
-        ),
+        account: makeTwistAccount({
+            id: config.authUserId !== undefined ? String(config.authUserId) : '',
+            label: config.authUserName ?? '',
+            authMode: config.authMode,
+            authScope: config.authScope,
+        }),
+    }
+}
+
+/**
+ * Best-effort clean-up of v1 state on disk. Runs before a write / clear when
+ * `migrateLegacyAuth` couldn't complete — so a user who logs in with
+ * `tw auth token <new>` or out via `tw auth logout` during the post-upgrade
+ * offline window doesn't end up with v2 writes shadowed by a stale legacy
+ * token. Mirrors the cleanup that `migrateLegacyAuth.cleanupLegacyConfig`
+ * does once it can reach the API. Failures (offline keyring, etc.) are
+ * swallowed: the v2 write is what counts, the legacy state is just noise.
+ */
+async function dischargeLegacyState(): Promise<void> {
+    try {
+        await createSecureStore({
+            serviceName: SECURE_STORE_SERVICE,
+            account: LEGACY_KEYRING_ACCOUNT,
+        }).deleteSecret()
+    } catch {
+        // Keyring unreachable — the legacy entry stays put; harmless because
+        // the v2 store is what `active()` will read once migration completes.
+    }
+    try {
+        await updateConfig({
+            token: undefined,
+            authMode: undefined,
+            authScope: undefined,
+            authUserId: undefined,
+            authUserName: undefined,
+            pendingSecureStoreClear: undefined,
+        })
+    } catch {
+        // Same rationale — best effort.
     }
 }
 
@@ -358,8 +388,14 @@ function ensureMigrated(): Promise<MigrateAuthResult<TwistAccount> | null> {
  * user who installed with `--ignore-scripts` (skipping the postinstall hook)
  * still gets their v1 token promoted to v2 transparently on first command.
  * When migration couldn't complete (offline `identifyAccount`, keyring
- * unreachable, …), `active()` falls back to the legacy snapshot so the user
- * isn't treated as logged out.
+ * unreachable, …):
+ *   - `active()` falls back to the legacy snapshot so the user isn't treated
+ *     as logged out. An explicit `--user <ref>` is honoured against the
+ *     legacy account so `tw --user <other-id>` can't accidentally resolve to
+ *     the legacy default.
+ *   - `set()` / `clear()` first discharge the legacy state on disk before
+ *     writing v2, so a manual `tw auth token <new>` or `tw auth logout`
+ *     doesn't leave a stale v1 token to shadow the v2 write on the next run.
  */
 export function createTwistTokenStore(): TwistTokenStore {
     const inner = createKeyringTokenStore<TwistAccount>({
@@ -368,6 +404,12 @@ export function createTwistTokenStore(): TwistTokenStore {
         recordsLocation: getConfigPath(),
         matchAccount: matchTwistAccount,
     })
+    const maybeDischargeLegacy = async (): Promise<void> => {
+        const result = await ensureMigrated()
+        if (result === null || !migrationIsConclusive(result)) {
+            await dischargeLegacyState()
+        }
+    }
     return Object.assign(Object.create(inner) as TwistTokenStore, {
         async active(ref?: AccountRef) {
             if (ref === undefined) {
@@ -382,16 +424,18 @@ export function createTwistTokenStore(): TwistTokenStore {
             const result = await ensureMigrated()
             if (result === null || !migrationIsConclusive(result)) {
                 const legacy = await readLegacyTokenSnapshot()
-                if (legacy) return legacy
+                if (legacy && (ref === undefined || matchTwistAccount(legacy.account, ref))) {
+                    return legacy
+                }
             }
             return inner.active(ref)
         },
         async set(account: TwistAccount, token: string) {
-            await ensureMigrated()
+            await maybeDischargeLegacy()
             return inner.set(account, token)
         },
         async clear(ref?: AccountRef) {
-            await ensureMigrated()
+            await maybeDischargeLegacy()
             return inner.clear(ref)
         },
         async list() {
@@ -408,10 +452,20 @@ export function createTwistTokenStore(): TwistTokenStore {
 /**
  * Derive the source of the currently-active token. Lives here (next to the
  * store) so `lib/auth.ts` doesn't need to know about `UserRecordStore`'s
- * `fallbackToken` field — keeps the storage abstraction clean.
+ * `fallbackToken` field — keeps the storage abstraction clean. Surfaces
+ * `'config-file'` whenever a plaintext token is on disk, including the
+ * legacy `config.token` slot that `migrateLegacyAuth` hasn't cleaned up
+ * yet, so `tw doctor` / `tw config view` reports the security-relevant
+ * state during the post-upgrade offline window.
  */
 export async function getActiveTokenSource(): Promise<'env' | 'secure-store' | 'config-file'> {
     if (process.env[TOKEN_ENV_VAR]) return 'env'
-    const record = getDefaultUserRecord(await getConfig())
-    return record?.fallbackToken ? 'config-file' : 'secure-store'
+    const config = await getConfig()
+    const record = getDefaultUserRecord(config)
+    if (record?.fallbackToken) return 'config-file'
+    if (record) return 'secure-store'
+    // No v2 record yet — legacy `config.token` may still be on disk if
+    // `migrateLegacyAuth` was skipped (offline, etc.).
+    if (config.token?.trim()) return 'config-file'
+    return 'secure-store'
 }

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -378,7 +378,7 @@ export function createTwistTokenStore(): TwistTokenStore {
         recordsLocation: getConfigPath(),
         matchAccount: matchTwistAccount,
     })
-    const maybeDischargeLegacy = async (): Promise<void> => {
+    async function maybeDischargeLegacy(): Promise<void> {
         const result = await ensureMigrated()
         if (result === null || !migrationIsConclusive(result)) {
             await dischargeLegacyState()

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -3,17 +3,19 @@ import {
     type AuthAccount,
     type AuthProvider,
     createKeyringTokenStore,
+    createSecureStore,
     deriveChallenge,
     generateVerifier,
     type KeyringTokenStore,
+    type MigrateAuthResult,
 } from '@doist/cli-core/auth'
 import { createWrappedTwistClient } from './api.js'
-import type { AuthMode } from './config.js'
-import { getConfigPath } from './config.js'
+import { type AuthMode, getConfig, getConfigPath } from './config.js'
 import { CliError } from './errors.js'
 import { runMigrateLegacyAuth } from './migrate-auth.js'
 import { parseRef } from './refs.js'
-import { createTwistUserRecordStore } from './user-records.js'
+import { toTwistAccount } from './twist-account.js'
+import { createTwistUserRecordStore, getDefaultUserRecord } from './user-records.js'
 
 export const AUTHORIZATION_URL = 'https://twist.com/oauth/authorize'
 export const TOKEN_URL = 'https://twist.com/oauth/access_token'
@@ -258,12 +260,7 @@ export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
             const hs = asHandshake(handshake)
             const client = createWrappedTwistClient(token)
             const user = await client.users.getSessionUser()
-            return {
-                id: String(user.id),
-                label: user.name,
-                authMode: hs.authMode ?? 'unknown',
-                authScope: hs.authScope ?? '',
-            }
+            return toTwistAccount(user, { authMode: hs.authMode, authScope: hs.authScope })
         },
     }
 }
@@ -282,26 +279,71 @@ export function matchTwistAccount(account: TwistAccount, ref: AccountRef): boole
 
 const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
+// Legacy pre-γ1 keyring slot. Read as a last resort in `active()` when
+// `migrateLegacyAuth` couldn't complete (e.g. the user is offline so
+// `identifyAccount` can't reach Twist) so the CLI stays usable instead of
+// silently treating the user as logged out.
+const LEGACY_KEYRING_ACCOUNT = 'api-token'
+
+/** A migration result that means the v2 store is the authoritative source. */
+function migrationIsConclusive(result: MigrateAuthResult<TwistAccount>): boolean {
+    return (
+        result.status === 'migrated' ||
+        result.status === 'already-migrated' ||
+        result.status === 'no-legacy-state'
+    )
+}
+
+/**
+ * Read v1 credentials still on disk (legacy keyring slot first, then the
+ * plaintext `config.token` slot). Used only when `migrateLegacyAuth` couldn't
+ * complete this run — never on the happy path. Returns a synthetic snapshot
+ * with whatever v1 auth metadata is in `config.json` so consumers like `tw
+ * auth status` keep working.
+ */
+async function readLegacyTokenSnapshot(): Promise<{
+    token: string
+    account: TwistAccount
+} | null> {
+    let token: string | null = null
+    try {
+        const secureStore = createSecureStore({
+            serviceName: SECURE_STORE_SERVICE,
+            account: LEGACY_KEYRING_ACCOUNT,
+        })
+        token = await secureStore.getSecret()
+    } catch {
+        // Keyring unreachable — fall through to plaintext.
+    }
+    const config = await getConfig()
+    if (!token) token = config.token?.trim() || null
+    if (!token) return null
+    return {
+        token,
+        account: toTwistAccount(
+            { id: config.authUserId ?? 0, name: config.authUserName ?? '' },
+            { authMode: config.authMode, authScope: config.authScope },
+        ),
+    }
+}
+
 /**
  * Memoised one-shot v1 → v2 migration trigger. The first read/write to the
  * store on a cold process awaits it; later operations short-circuit on the
  * resolved promise. Errors are swallowed (the cli-core helper itself runs in
  * silent mode and leaves v1 state untouched on failure) so the CLI never
- * fails to start because a migration attempt blew up.
+ * fails to start because a migration attempt blew up; the runtime falls back
+ * to the legacy snapshot below when the result isn't conclusive.
+ *
+ * Module-private; tests reset it with `vi.resetModules()` + dynamic
+ * `import('./auth-provider.js')` so no test-only seam ships in dist/.
  */
-let migrationPromise: Promise<void> | undefined
-function ensureMigrated(): Promise<void> {
+let migrationPromise: Promise<MigrateAuthResult<TwistAccount> | null> | undefined
+function ensureMigrated(): Promise<MigrateAuthResult<TwistAccount> | null> {
     if (!migrationPromise) {
-        migrationPromise = runMigrateLegacyAuth({ silent: true })
-            .then(() => undefined)
-            .catch(() => undefined)
+        migrationPromise = runMigrateLegacyAuth({ silent: true }).catch(() => null)
     }
     return migrationPromise
-}
-
-/** Test-only — reset the memoised migration promise so subsequent reads re-run it. */
-export function __resetMigrationPromiseForTests(): void {
-    migrationPromise = undefined
 }
 
 /**
@@ -315,6 +357,9 @@ export function __resetMigrationPromiseForTests(): void {
  * Every method that touches stored state also awaits `ensureMigrated()` so a
  * user who installed with `--ignore-scripts` (skipping the postinstall hook)
  * still gets their v1 token promoted to v2 transparently on first command.
+ * When migration couldn't complete (offline `identifyAccount`, keyring
+ * unreachable, …), `active()` falls back to the legacy snapshot so the user
+ * isn't treated as logged out.
  */
 export function createTwistTokenStore(): TwistTokenStore {
     const inner = createKeyringTokenStore<TwistAccount>({
@@ -334,7 +379,11 @@ export function createTwistTokenStore(): TwistTokenStore {
                     }
                 }
             }
-            await ensureMigrated()
+            const result = await ensureMigrated()
+            if (result === null || !migrationIsConclusive(result)) {
+                const legacy = await readLegacyTokenSnapshot()
+                if (legacy) return legacy
+            }
             return inner.active(ref)
         },
         async set(account: TwistAccount, token: string) {
@@ -363,9 +412,6 @@ export function createTwistTokenStore(): TwistTokenStore {
  */
 export async function getActiveTokenSource(): Promise<'env' | 'secure-store' | 'config-file'> {
     if (process.env[TOKEN_ENV_VAR]) return 'env'
-    const store = createTwistUserRecordStore()
-    const [records, defaultId] = await Promise.all([store.list(), store.getDefaultId()])
-    const record =
-        (defaultId !== null && records.find((r) => r.account.id === defaultId)) || records[0]
+    const record = getDefaultUserRecord(await getConfig())
     return record?.fallbackToken ? 'config-file' : 'secure-store'
 }

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
     activeMock: vi.fn(),
     listMock: vi.fn(),
+    getDefaultIdMock: vi.fn(),
 }))
 
 vi.mock('./auth-provider.js', async (importOriginal) => {
@@ -19,7 +20,10 @@ vi.mock('./user-records.js', async (importOriginal) => {
     return {
         ...actual,
         createTwistUserRecordStore: () =>
-            ({ list: mocks.listMock }) as unknown as UserRecordStore<never>,
+            ({
+                list: mocks.listMock,
+                getDefaultId: mocks.getDefaultIdMock,
+            }) as unknown as UserRecordStore<never>,
     }
 })
 
@@ -38,6 +42,7 @@ describe('auth shims over the cli-core keyring store', () => {
     beforeEach(() => {
         mocks.activeMock.mockReset()
         mocks.listMock.mockReset()
+        mocks.getDefaultIdMock.mockReset().mockResolvedValue(null)
     })
 
     afterEach(() => {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -149,12 +149,7 @@ describe('auth shims over the cli-core keyring store', () => {
         await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'config' })
     })
 
-    it('getAuthMetadata falls back to v1 flat fields when users[] is empty but legacy state is still on disk (post-upgrade offline window)', async () => {
-        // The skipped-migration path leaves config.token + the v1 metadata
-        // fields in place. Without this fallback `ensureWriteAllowed` would
-        // see `authMode: 'unknown'` and let mutating commands slip past the
-        // local READ_ONLY guard until the next CLI invocation completes the
-        // migration. Surfaces real `read-only` so the guard fires.
+    it('getAuthMetadata falls back to v1 flat fields when users[] is empty but legacy state is on disk (real authMode reaches ensureWriteAllowed)', async () => {
         mocks.getConfigMock.mockResolvedValue({
             token: 'tk_legacy',
             authMode: 'read-only',

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -112,34 +112,23 @@ describe('auth shims over the cli-core keyring store', () => {
         })
     })
 
-    it('getAuthMetadata picks the record matching defaultUserId, not the first one in users[]', async () => {
-        // Bob is appended later but pinned as default — Ada (first in the
-        // array) must not win, otherwise `tw auth status` would lie about
-        // which account is active.
-        mocks.getConfigMock.mockResolvedValue({
+    it('getAuthMetadata picks the record matching defaultUserId, falling back to the first when the pinned id is missing', async () => {
+        mocks.getConfigMock.mockResolvedValueOnce({
             users: [ADA_USER, BOB_USER],
             defaultUserId: '99',
         } satisfies Config)
-
-        await expect(getAuthMetadata()).resolves.toEqual({
-            authMode: 'read-only',
-            authScope: 'user:read',
+        await expect(getAuthMetadata()).resolves.toMatchObject({
             authUserId: 99,
             authUserName: 'Bob',
-            source: 'config',
         })
-    })
 
-    it('getAuthMetadata falls back to the first user when defaultUserId points at no stored record', async () => {
-        mocks.getConfigMock.mockResolvedValue({
+        mocks.getConfigMock.mockResolvedValueOnce({
             users: [ADA_USER, BOB_USER],
             defaultUserId: 'gone',
         } satisfies Config)
-
         await expect(getAuthMetadata()).resolves.toMatchObject({
             authUserId: 42,
             authUserName: 'Ada',
-            source: 'config',
         })
     })
 
@@ -149,15 +138,15 @@ describe('auth shims over the cli-core keyring store', () => {
         await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'config' })
     })
 
-    it('getAuthMetadata falls back to v1 flat fields when users[] is empty but legacy state is on disk (real authMode reaches ensureWriteAllowed)', async () => {
-        mocks.getConfigMock.mockResolvedValue({
+    it('getAuthMetadata falls back to v1 flat fields when users[] is empty but legacy state is on disk', async () => {
+        // Preserves real authMode so ensureWriteAllowed's READ_ONLY guard fires.
+        mocks.getConfigMock.mockResolvedValueOnce({
             token: 'tk_legacy',
             authMode: 'read-only',
             authScope: 'user:read',
             authUserId: 42,
             authUserName: 'Ada',
         } satisfies Config)
-
         await expect(getAuthMetadata()).resolves.toEqual({
             authMode: 'read-only',
             authScope: 'user:read',
@@ -165,11 +154,9 @@ describe('auth shims over the cli-core keyring store', () => {
             authUserName: 'Ada',
             source: 'config',
         })
-    })
 
-    it('getAuthMetadata legacy fallback handles `tw auth token` users with no authMode on disk (authMode → "unknown")', async () => {
-        mocks.getConfigMock.mockResolvedValue({ token: 'tk_token_only' } satisfies Config)
-
+        // `tw auth token` users have no authMode → defaults to 'unknown'.
+        mocks.getConfigMock.mockResolvedValueOnce({ token: 'tk_token_only' } satisfies Config)
         await expect(getAuthMetadata()).resolves.toEqual({
             authMode: 'unknown',
             source: 'config',

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,10 +1,10 @@
-import type { TokenStore, UserRecord, UserRecordStore } from '@doist/cli-core/auth'
+import type { TokenStore } from '@doist/cli-core/auth'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from './config.js'
 
 const mocks = vi.hoisted(() => ({
     activeMock: vi.fn(),
-    listMock: vi.fn(),
-    getDefaultIdMock: vi.fn(),
+    getConfigMock: vi.fn(),
 }))
 
 vi.mock('./auth-provider.js', async (importOriginal) => {
@@ -15,15 +15,11 @@ vi.mock('./auth-provider.js', async (importOriginal) => {
     }
 })
 
-vi.mock('./user-records.js', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('./user-records.js')>()
+vi.mock('./config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./config.js')>()
     return {
         ...actual,
-        createTwistUserRecordStore: () =>
-            ({
-                list: mocks.listMock,
-                getDefaultId: mocks.getDefaultIdMock,
-            }) as unknown as UserRecordStore<never>,
+        getConfig: mocks.getConfigMock,
     }
 })
 
@@ -36,13 +32,24 @@ const STORED_ACCOUNT = {
     authScope: 'user:read',
 }
 
-const STORED_RECORD: UserRecord<typeof STORED_ACCOUNT> = { account: STORED_ACCOUNT }
+const ADA_USER = {
+    id: '42',
+    name: 'Ada',
+    authMode: 'read-write' as const,
+    authScope: 'user:read',
+}
+
+const BOB_USER = {
+    id: '99',
+    name: 'Bob',
+    authMode: 'read-only' as const,
+    authScope: 'user:read',
+}
 
 describe('auth shims over the cli-core keyring store', () => {
     beforeEach(() => {
         mocks.activeMock.mockReset()
-        mocks.listMock.mockReset()
-        mocks.getDefaultIdMock.mockReset().mockResolvedValue(null)
+        mocks.getConfigMock.mockReset().mockResolvedValue({} satisfies Config)
     })
 
     afterEach(() => {
@@ -59,9 +66,9 @@ describe('auth shims over the cli-core keyring store', () => {
         await expect(getApiToken()).rejects.toBeInstanceOf(NoTokenError)
     })
 
-    it('probeApiToken reports source=secure-store when the record has no fallbackToken', async () => {
+    it('probeApiToken reports source=secure-store when the active record has no fallbackToken', async () => {
         mocks.activeMock.mockResolvedValue({ token: 'tk_keyring', account: STORED_ACCOUNT })
-        mocks.listMock.mockResolvedValue([STORED_RECORD])
+        mocks.getConfigMock.mockResolvedValue({ users: [ADA_USER] } satisfies Config)
 
         const { metadata } = await probeApiToken()
 
@@ -74,9 +81,11 @@ describe('auth shims over the cli-core keyring store', () => {
         })
     })
 
-    it('probeApiToken reports source=config-file when the record carries a fallbackToken', async () => {
+    it('probeApiToken reports source=config-file when the active record carries a plaintext token', async () => {
         mocks.activeMock.mockResolvedValue({ token: 'tk_fallback', account: STORED_ACCOUNT })
-        mocks.listMock.mockResolvedValue([{ ...STORED_RECORD, fallbackToken: 'tk_fallback' }])
+        mocks.getConfigMock.mockResolvedValue({
+            users: [{ ...ADA_USER, token: 'tk_fallback' }],
+        } satisfies Config)
 
         const { metadata } = await probeApiToken()
 
@@ -88,11 +97,11 @@ describe('auth shims over the cli-core keyring store', () => {
 
         await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'env' })
 
-        expect(mocks.listMock).not.toHaveBeenCalled()
+        expect(mocks.getConfigMock).not.toHaveBeenCalled()
     })
 
-    it('getAuthMetadata returns config-sourced identity when no env var is set', async () => {
-        mocks.listMock.mockResolvedValue([STORED_RECORD])
+    it('getAuthMetadata returns config-sourced identity for the single-user case (no defaultUserId)', async () => {
+        mocks.getConfigMock.mockResolvedValue({ users: [ADA_USER] } satisfies Config)
 
         await expect(getAuthMetadata()).resolves.toEqual({
             authMode: 'read-write',
@@ -101,5 +110,42 @@ describe('auth shims over the cli-core keyring store', () => {
             authUserName: 'Ada',
             source: 'config',
         })
+    })
+
+    it('getAuthMetadata picks the record matching defaultUserId, not the first one in users[]', async () => {
+        // Bob is appended later but pinned as default — Ada (first in the
+        // array) must not win, otherwise `tw auth status` would lie about
+        // which account is active.
+        mocks.getConfigMock.mockResolvedValue({
+            users: [ADA_USER, BOB_USER],
+            defaultUserId: '99',
+        } satisfies Config)
+
+        await expect(getAuthMetadata()).resolves.toEqual({
+            authMode: 'read-only',
+            authScope: 'user:read',
+            authUserId: 99,
+            authUserName: 'Bob',
+            source: 'config',
+        })
+    })
+
+    it('getAuthMetadata falls back to the first user when defaultUserId points at no stored record', async () => {
+        mocks.getConfigMock.mockResolvedValue({
+            users: [ADA_USER, BOB_USER],
+            defaultUserId: 'gone',
+        } satisfies Config)
+
+        await expect(getAuthMetadata()).resolves.toMatchObject({
+            authUserId: 42,
+            authUserName: 'Ada',
+            source: 'config',
+        })
+    })
+
+    it('getAuthMetadata reports source=config with unknown mode when no users are stored', async () => {
+        mocks.getConfigMock.mockResolvedValue({} satisfies Config)
+
+        await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'config' })
     })
 })

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -148,4 +148,36 @@ describe('auth shims over the cli-core keyring store', () => {
 
         await expect(getAuthMetadata()).resolves.toEqual({ authMode: 'unknown', source: 'config' })
     })
+
+    it('getAuthMetadata falls back to v1 flat fields when users[] is empty but legacy state is still on disk (post-upgrade offline window)', async () => {
+        // The skipped-migration path leaves config.token + the v1 metadata
+        // fields in place. Without this fallback `ensureWriteAllowed` would
+        // see `authMode: 'unknown'` and let mutating commands slip past the
+        // local READ_ONLY guard until the next CLI invocation completes the
+        // migration. Surfaces real `read-only` so the guard fires.
+        mocks.getConfigMock.mockResolvedValue({
+            token: 'tk_legacy',
+            authMode: 'read-only',
+            authScope: 'user:read',
+            authUserId: 42,
+            authUserName: 'Ada',
+        } satisfies Config)
+
+        await expect(getAuthMetadata()).resolves.toEqual({
+            authMode: 'read-only',
+            authScope: 'user:read',
+            authUserId: 42,
+            authUserName: 'Ada',
+            source: 'config',
+        })
+    })
+
+    it('getAuthMetadata legacy fallback handles `tw auth token` users with no authMode on disk (authMode → "unknown")', async () => {
+        mocks.getConfigMock.mockResolvedValue({ token: 'tk_token_only' } satisfies Config)
+
+        await expect(getAuthMetadata()).resolves.toEqual({
+            authMode: 'unknown',
+            source: 'config',
+        })
+    })
 })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,9 +1,9 @@
 import { SecureStoreUnavailableError } from '@doist/cli-core/auth'
 import type { TwistAccount } from './auth-provider.js'
 import { createTwistTokenStore, getActiveTokenSource } from './auth-provider.js'
-import type { AuthMode } from './config.js'
+import { type AuthMode, getConfig } from './config.js'
 import { CliError } from './errors.js'
-import { createTwistUserRecordStore } from './user-records.js'
+import { getDefaultUserRecord } from './user-records.js'
 
 export { SecureStoreUnavailableError }
 
@@ -79,10 +79,7 @@ export async function probeApiToken(): Promise<AuthProbeResult> {
 /** Lightweight metadata read used by `tw auth status` once a token is confirmed. */
 export async function getAuthMetadata(): Promise<AuthMetadata> {
     if (process.env[TOKEN_ENV_VAR]) return { authMode: 'unknown', source: 'env' }
-    const store = createTwistUserRecordStore()
-    const [records, defaultId] = await Promise.all([store.list(), store.getDefaultId()])
-    const record =
-        (defaultId !== null && records.find((r) => r.account.id === defaultId)) || records[0]
+    const record = getDefaultUserRecord(await getConfig())
     if (!record) return { authMode: 'unknown', source: 'config' }
     return { ...toAccountFields(record.account), source: 'config' }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -79,7 +79,10 @@ export async function probeApiToken(): Promise<AuthProbeResult> {
 /** Lightweight metadata read used by `tw auth status` once a token is confirmed. */
 export async function getAuthMetadata(): Promise<AuthMetadata> {
     if (process.env[TOKEN_ENV_VAR]) return { authMode: 'unknown', source: 'env' }
-    const [record] = await createTwistUserRecordStore().list()
+    const store = createTwistUserRecordStore()
+    const [records, defaultId] = await Promise.all([store.list(), store.getDefaultId()])
+    const record =
+        (defaultId !== null && records.find((r) => r.account.id === defaultId)) || records[0]
     if (!record) return { authMode: 'unknown', source: 'config' }
     return { ...toAccountFields(record.account), source: 'config' }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -51,11 +51,7 @@ export class NoTokenError extends CliError {
     }
 }
 
-/**
- * Read the token used for live API calls. The store wraps `active()` with
- * env-var precedence (see `createTwistTokenStore`), so a single delegated
- * read covers both `TWIST_API_TOKEN=… tw …` and stored-credential cases.
- */
+/** Read the active token. The store wraps env-var precedence internally. */
 export async function getApiToken(): Promise<string> {
     const snapshot = await createTwistTokenStore().active()
     if (!snapshot) throw new NoTokenError()
@@ -77,11 +73,9 @@ export async function probeApiToken(): Promise<AuthProbeResult> {
 }
 
 /**
- * Lightweight metadata read used by `tw auth status` and `ensureWriteAllowed`.
- * Falls back to the v1 flat fields when no v2 record exists yet so a legacy
- * `read-only` token isn't reported as `'unknown'` during the post-upgrade
- * offline window — that would let mutating commands slip past the local
- * READ_ONLY guard until migration completes.
+ * Auth metadata for `tw auth status` and `ensureWriteAllowed`. Falls back
+ * to v1 flat fields when no v2 record exists so a legacy `read-only` token
+ * isn't reported as `'unknown'` — that would skip the local READ_ONLY guard.
  */
 export async function getAuthMetadata(): Promise<AuthMetadata> {
     if (process.env[TOKEN_ENV_VAR]) return { authMode: 'unknown', source: 'env' }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -76,12 +76,28 @@ export async function probeApiToken(): Promise<AuthProbeResult> {
     }
 }
 
-/** Lightweight metadata read used by `tw auth status` once a token is confirmed. */
+/**
+ * Lightweight metadata read used by `tw auth status` and `ensureWriteAllowed`.
+ * Falls back to the v1 flat fields when no v2 record exists yet so a legacy
+ * `read-only` token isn't reported as `'unknown'` during the post-upgrade
+ * offline window — that would let mutating commands slip past the local
+ * READ_ONLY guard until migration completes.
+ */
 export async function getAuthMetadata(): Promise<AuthMetadata> {
     if (process.env[TOKEN_ENV_VAR]) return { authMode: 'unknown', source: 'env' }
-    const record = getDefaultUserRecord(await getConfig())
-    if (!record) return { authMode: 'unknown', source: 'config' }
-    return { ...toAccountFields(record.account), source: 'config' }
+    const config = await getConfig()
+    const record = getDefaultUserRecord(config)
+    if (record) return { ...toAccountFields(record.account), source: 'config' }
+    if (config.token?.trim() || config.authUserId !== undefined || config.authMode) {
+        return {
+            authMode: config.authMode ?? 'unknown',
+            authScope: config.authScope,
+            authUserId: config.authUserId,
+            authUserName: config.authUserName,
+            source: 'config',
+        }
+    }
+    return { authMode: 'unknown', source: 'config' }
 }
 
 function toAccountFields(account: TwistAccount): {

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -91,6 +91,77 @@ describe('validateConfigForDoctor', () => {
         const issues = validateConfigForDoctor({ updateChannel: 'pre-release' })
         expect(issues.some((i) => i.includes('unrecognized'))).toBe(false)
     })
+
+    it('accepts a well-formed v2 schema (config_version, defaultUserId, users[])', () => {
+        const issues = validateConfigForDoctor({
+            config_version: 2,
+            defaultUserId: '42',
+            users: [
+                {
+                    id: '42',
+                    name: 'Ada',
+                    authMode: 'read-write',
+                    authScope: 'user:read',
+                },
+                { id: '99', name: 'Bob' },
+            ],
+        })
+        expect(issues).toEqual([])
+    })
+
+    it('rejects config_version that is not an integer', () => {
+        expect(validateConfigForDoctor({ config_version: 'two' })).toContain(
+            'config_version must be an integer',
+        )
+        expect(validateConfigForDoctor({ config_version: 2.5 })).toContain(
+            'config_version must be an integer',
+        )
+    })
+
+    it('rejects defaultUserId that is not a string', () => {
+        expect(validateConfigForDoctor({ defaultUserId: 42 })).toContain(
+            'defaultUserId must be a string',
+        )
+    })
+
+    it('rejects users that is not an array', () => {
+        expect(validateConfigForDoctor({ users: { id: '42' } })).toContain('users must be an array')
+    })
+
+    it('rejects malformed StoredUser entries (missing required keys + wrong types)', () => {
+        const issues = validateConfigForDoctor({
+            users: [
+                { id: 42, name: 'Ada' }, // numeric id (must be string)
+                { id: '99', name: 5 }, // numeric name (must be string)
+                'not-an-object',
+            ],
+        })
+        expect(issues).toContain('users[0].id must be a string')
+        expect(issues).toContain('users[1].name must be a string')
+        expect(issues).toContain('users[2] must be an object')
+    })
+
+    it('rejects unknown keys on a StoredUser', () => {
+        const issues = validateConfigForDoctor({
+            users: [{ id: '42', name: 'Ada', somethingElse: true }],
+        })
+        expect(issues).toContain('users[0] contains unrecognized key "somethingElse"')
+    })
+
+    it('rejects an invalid StoredUser.authMode', () => {
+        const issues = validateConfigForDoctor({
+            users: [{ id: '42', name: 'Ada', authMode: 'bogus' }],
+        })
+        expect(issues).toContain('users[0].authMode must be one of: read-only, read-write, unknown')
+    })
+
+    it('rejects non-string StoredUser.authScope and StoredUser.token', () => {
+        const issues = validateConfigForDoctor({
+            users: [{ id: '42', name: 'Ada', authScope: 1, token: false }],
+        })
+        expect(issues).toContain('users[0].authScope must be a string')
+        expect(issues).toContain('users[0].token must be a string')
+    })
 })
 
 describe('persistence-seam translation', () => {

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -97,70 +97,48 @@ describe('validateConfigForDoctor', () => {
             config_version: 2,
             defaultUserId: '42',
             users: [
-                {
-                    id: '42',
-                    name: 'Ada',
-                    authMode: 'read-write',
-                    authScope: 'user:read',
-                },
+                { id: '42', name: 'Ada', authMode: 'read-write', authScope: 'user:read' },
                 { id: '99', name: 'Bob' },
             ],
         })
         expect(issues).toEqual([])
     })
 
-    it('rejects config_version that is not an integer', () => {
+    it('rejects malformed top-level v2 fields', () => {
         expect(validateConfigForDoctor({ config_version: 'two' })).toContain(
             'config_version must be an integer',
         )
         expect(validateConfigForDoctor({ config_version: 2.5 })).toContain(
             'config_version must be an integer',
         )
-    })
-
-    it('rejects defaultUserId that is not a string', () => {
         expect(validateConfigForDoctor({ defaultUserId: 42 })).toContain(
             'defaultUserId must be a string',
         )
-    })
-
-    it('rejects users that is not an array', () => {
         expect(validateConfigForDoctor({ users: { id: '42' } })).toContain('users must be an array')
     })
 
-    it('rejects malformed StoredUser entries (missing required keys + wrong types)', () => {
+    it('rejects malformed StoredUser entries (shape, types, unknown keys, invalid authMode)', () => {
         const issues = validateConfigForDoctor({
             users: [
-                { id: 42, name: 'Ada' }, // numeric id (must be string)
-                { id: '99', name: 5 }, // numeric name (must be string)
+                { id: 42, name: 'Ada' },
+                { id: '99', name: 5 },
                 'not-an-object',
+                { id: '7', name: 'Carl', somethingElse: true },
+                { id: '8', name: 'Dora', authMode: 'bogus' },
+                { id: '9', name: 'Eve', authScope: 1, token: false },
             ],
         })
-        expect(issues).toContain('users[0].id must be a string')
-        expect(issues).toContain('users[1].name must be a string')
-        expect(issues).toContain('users[2] must be an object')
-    })
-
-    it('rejects unknown keys on a StoredUser', () => {
-        const issues = validateConfigForDoctor({
-            users: [{ id: '42', name: 'Ada', somethingElse: true }],
-        })
-        expect(issues).toContain('users[0] contains unrecognized key "somethingElse"')
-    })
-
-    it('rejects an invalid StoredUser.authMode', () => {
-        const issues = validateConfigForDoctor({
-            users: [{ id: '42', name: 'Ada', authMode: 'bogus' }],
-        })
-        expect(issues).toContain('users[0].authMode must be one of: read-only, read-write, unknown')
-    })
-
-    it('rejects non-string StoredUser.authScope and StoredUser.token', () => {
-        const issues = validateConfigForDoctor({
-            users: [{ id: '42', name: 'Ada', authScope: 1, token: false }],
-        })
-        expect(issues).toContain('users[0].authScope must be a string')
-        expect(issues).toContain('users[0].token must be a string')
+        expect(issues).toEqual(
+            expect.arrayContaining([
+                'users[0].id must be a string',
+                'users[1].name must be a string',
+                'users[2] must be an object',
+                'users[3] contains unrecognized key "somethingElse"',
+                'users[4].authMode must be one of: read-only, read-write, unknown',
+                'users[5].authScope must be a string',
+                'users[5].token must be a string',
+            ]),
+        )
     })
 })
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -68,7 +68,7 @@ export interface UserSettings {
  * id. `token` is a plaintext fallback persisted only when the keyring is
  * unavailable at write time.
  */
-export interface StoredUser {
+export type StoredUser = {
     id: string
     name: string
     authMode?: AuthMode

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,13 @@ import { CliError } from './errors.js'
 const APP_NAME = 'twist-cli'
 
 /**
+ * On-disk schema version. Bumped when the persisted layout changes in a way
+ * that needs a one-time migration. `migrateLegacyAuth` writes this to disk
+ * once the v1→v2 move has completed; it is a one-way gate (no rollback).
+ */
+export const CONFIG_VERSION = 2 as const
+
+/**
  * Resolve the canonical config path lazily. Computing on each call (instead of
  * caching at module load) keeps the path responsive to vitest's `vi.doMock`
  * for `node:os` — which only reliably reaches cli-core's compiled `homedir()`
@@ -36,6 +43,18 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     // see `fromDiskShape` / `toDiskShape` for the persistence-seam translation.
     'update_channel',
     'userSettings',
+    // v2 schema (multi-account auth)
+    'config_version',
+    'users',
+    'defaultUserId',
+])
+
+const KNOWN_STORED_USER_KEYS: ReadonlySet<string> = new Set([
+    'id',
+    'name',
+    'authMode',
+    'authScope',
+    'token',
 ])
 
 const KNOWN_USER_SETTINGS_KEYS: ReadonlySet<string> = new Set(['unarchiveNewThreads'])
@@ -47,12 +66,32 @@ export interface UserSettings {
     unarchiveNewThreads?: boolean
 }
 
+/**
+ * One row of the v2 `users[]` array. `id` is the stringified numeric Twist
+ * user id (same value `TwistAccount.id` carries in memory), `name` is the
+ * display name. `token` is the plaintext fallback only — populated when the
+ * OS keyring was unavailable at write time; absent in the happy path.
+ */
+export interface StoredUser {
+    id: string
+    name: string
+    authMode?: AuthMode
+    authScope?: string
+    token?: string
+}
+
 export interface Config {
+    // v2 (multi-account)
+    // One-way version gate. `=== CONFIG_VERSION` after `migrateLegacyAuth` runs.
+    config_version?: number
+    users?: StoredUser[]
+    defaultUserId?: string
+
+    // v1 — read-only after migration; `migrateLegacyAuth` cleans these up.
     // Legacy plaintext token storage retained for migration and secure-store fallback only.
     token?: string
     // Non-secret state used to finish logout after transient secure-store failures.
     pendingSecureStoreClear?: boolean
-    currentWorkspace?: number
     // Auth metadata persisted alongside the token to track OAuth scope.
     authMode?: AuthMode
     authScope?: string
@@ -61,6 +100,9 @@ export interface Config {
     // real `TwistAccount` without re-fetching the session user.
     authUserId?: number
     authUserName?: string
+
+    // Unrelated (unchanged across schema versions)
+    currentWorkspace?: number
     updateChannel?: UpdateChannel
     userSettings?: UserSettings
 }
@@ -223,6 +265,61 @@ export function validateConfigForDoctor(config: Record<string, unknown>): string
             !UPDATE_CHANNELS.has(config.update_channel as UpdateChannel))
     ) {
         issues.push('update_channel must be one of: stable, pre-release')
+    }
+
+    if (
+        config.config_version !== undefined &&
+        (typeof config.config_version !== 'number' || !Number.isInteger(config.config_version))
+    ) {
+        issues.push('config_version must be an integer')
+    }
+
+    if (config.defaultUserId !== undefined && typeof config.defaultUserId !== 'string') {
+        issues.push('defaultUserId must be a string')
+    }
+
+    if (config.users !== undefined) {
+        if (!Array.isArray(config.users)) {
+            issues.push('users must be an array')
+        } else {
+            for (let i = 0; i < config.users.length; i++) {
+                const user = config.users[i]
+                if (user === null || typeof user !== 'object' || Array.isArray(user)) {
+                    issues.push(`users[${i}] must be an object`)
+                    continue
+                }
+                const userRecord = user as Record<string, unknown>
+                for (const key of Object.keys(userRecord)) {
+                    if (!KNOWN_STORED_USER_KEYS.has(key)) {
+                        issues.push(`users[${i}] contains unrecognized key "${key}"`)
+                    }
+                }
+                if (typeof userRecord.id !== 'string') {
+                    issues.push(`users[${i}].id must be a string`)
+                }
+                if (typeof userRecord.name !== 'string') {
+                    issues.push(`users[${i}].name must be a string`)
+                }
+                if (
+                    userRecord.authMode !== undefined &&
+                    (typeof userRecord.authMode !== 'string' ||
+                        !AUTH_MODES.has(userRecord.authMode as AuthMode))
+                ) {
+                    issues.push(
+                        `users[${i}].authMode must be one of: read-only, read-write, unknown`,
+                    )
+                }
+                if (
+                    userRecord.authScope !== undefined &&
+                    typeof userRecord.authScope !== 'string'
+                ) {
+                    issues.push(`users[${i}].authScope must be a string`)
+                }
+                if (userRecord.token !== undefined && typeof userRecord.token !== 'string') {
+                    issues.push(`users[${i}].token must be a string`)
+                }
+            }
+        }
     }
 
     if (config.userSettings !== undefined) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,9 +10,8 @@ import { CliError } from './errors.js'
 const APP_NAME = 'twist-cli'
 
 /**
- * On-disk schema version. Bumped when the persisted layout changes in a way
- * that needs a one-time migration. `migrateLegacyAuth` writes this to disk
- * once the v1→v2 move has completed; it is a one-way gate (no rollback).
+ * Current on-disk schema version. Bumped when the persisted layout requires
+ * a one-time migration. One-way gate — no rollback.
  */
 export const CONFIG_VERSION = 2 as const
 
@@ -38,12 +37,10 @@ const KNOWN_CONFIG_KEYS: ReadonlySet<string> = new Set([
     'authUserId',
     'authUserName',
     'updateChannel',
-    // Snake_case alias persisted on disk so cli-core's update command can read
-    // it directly. The in-memory `Config` type only exposes `updateChannel` —
-    // see `fromDiskShape` / `toDiskShape` for the persistence-seam translation.
+    // Snake_case alias on disk for cli-core's update command; the in-memory
+    // `Config` exposes only `updateChannel` (see `fromDiskShape`/`toDiskShape`).
     'update_channel',
     'userSettings',
-    // v2 schema (multi-account auth)
     'config_version',
     'users',
     'defaultUserId',
@@ -67,10 +64,9 @@ export interface UserSettings {
 }
 
 /**
- * One row of the v2 `users[]` array. `id` is the stringified numeric Twist
- * user id (same value `TwistAccount.id` carries in memory), `name` is the
- * display name. `token` is the plaintext fallback only — populated when the
- * OS keyring was unavailable at write time; absent in the happy path.
+ * One row of the `users[]` array. `id` is the stringified numeric Twist user
+ * id. `token` is a plaintext fallback persisted only when the keyring is
+ * unavailable at write time.
  */
 export interface StoredUser {
     id: string
@@ -81,27 +77,18 @@ export interface StoredUser {
 }
 
 export interface Config {
-    // v2 (multi-account)
-    // One-way version gate. `=== CONFIG_VERSION` after `migrateLegacyAuth` runs.
     config_version?: number
     users?: StoredUser[]
     defaultUserId?: string
 
-    // v1 — read-only after migration; `migrateLegacyAuth` cleans these up.
-    // Legacy plaintext token storage retained for migration and secure-store fallback only.
+    // Legacy single-user fields. Cleaned up by `migrateLegacyAuth`.
     token?: string
-    // Non-secret state used to finish logout after transient secure-store failures.
     pendingSecureStoreClear?: boolean
-    // Auth metadata persisted alongside the token to track OAuth scope.
     authMode?: AuthMode
     authScope?: string
-    // Identity of the authenticated user — captured after a successful OAuth
-    // login so the cli-core `TokenStore.active()` adapter can round-trip a
-    // real `TwistAccount` without re-fetching the session user.
     authUserId?: number
     authUserName?: string
 
-    // Unrelated (unchanged across schema versions)
     currentWorkspace?: number
     updateChannel?: UpdateChannel
     userSettings?: UserSettings

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -29,7 +29,6 @@ vi.mock('./config.js', async (importOriginal) => {
 })
 
 import type { MigrateLegacyAuthOptions } from '@doist/cli-core/auth'
-import { CONFIG_VERSION } from './config.js'
 import { runMigrateLegacyAuth } from './migrate-auth.js'
 
 type Opts = MigrateLegacyAuthOptions<{
@@ -58,8 +57,11 @@ describe('runMigrateLegacyAuth', () => {
         expect(options.silent).toBe(true)
     })
 
-    it('hasMigrated returns true once config_version reaches the current CONFIG_VERSION (one-way gate)', async () => {
-        mocks.getConfig.mockResolvedValueOnce({ config_version: CONFIG_VERSION })
+    it('hasMigrated returns true once config_version reaches 2 (one-way gate)', async () => {
+        // v1 → v2 migration only — the check uses a local schema version so a
+        // future v3 bump doesn't cause this helper to spuriously re-run.
+        mocks.getConfig.mockResolvedValueOnce({ config_version: 2 })
+        mocks.getConfig.mockResolvedValueOnce({ config_version: 3 })
         mocks.getConfig.mockResolvedValueOnce({ config_version: 1 })
         mocks.getConfig.mockResolvedValueOnce({})
 
@@ -67,17 +69,18 @@ describe('runMigrateLegacyAuth', () => {
         const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
 
         expect(await options.hasMigrated()).toBe(true)
+        expect(await options.hasMigrated()).toBe(true)
         expect(await options.hasMigrated()).toBe(false)
         expect(await options.hasMigrated()).toBe(false)
     })
 
-    it('markMigrated writes config_version = CONFIG_VERSION', async () => {
+    it('markMigrated writes config_version = 2 exactly (decoupled from any future CONFIG_VERSION bump)', async () => {
         await runMigrateLegacyAuth({ silent: true })
         const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
 
         await options.markMigrated()
 
-        expect(mocks.updateConfig).toHaveBeenCalledWith({ config_version: CONFIG_VERSION })
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ config_version: 2 })
     })
 
     it('loadLegacyPlaintextToken returns trimmed config.token, or null when blank/absent', async () => {
@@ -108,6 +111,33 @@ describe('runMigrateLegacyAuth', () => {
             authScope: 'user:read',
         })
         expect(mocks.twistApiCtor).toHaveBeenCalledWith('tk_legacy')
+    })
+
+    it('identifyAccount runs the API call and the local getConfig() concurrently', async () => {
+        // The two reads are independent; firing them sequentially adds an
+        // avoidable round-trip on every postinstall migration. Resolve the
+        // API call first and assert getConfig was already in flight by then.
+        let resolveApi: (value: { id: number; name: string }) => void = () => {}
+        const apiPromise = new Promise<{ id: number; name: string }>((res) => {
+            resolveApi = res
+        })
+        mocks.getSessionUserMock.mockReturnValueOnce(apiPromise)
+        mocks.getConfig.mockResolvedValueOnce({ authMode: 'read-only', authScope: 'user:read' })
+
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        const identifyPromise = options.identifyAccount('tk_legacy')
+        // getConfig should have been kicked off before we resolved the API.
+        expect(mocks.getConfig).toHaveBeenCalledTimes(1)
+        resolveApi({ id: 42, name: 'Ada' })
+
+        await expect(identifyPromise).resolves.toEqual({
+            id: '42',
+            label: 'Ada',
+            authMode: 'read-only',
+            authScope: 'user:read',
+        })
     })
 
     it('identifyAccount falls back to unknown/empty metadata for `tw auth token` users with no authMode on disk', async () => {

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -38,6 +38,12 @@ type Opts = MigrateLegacyAuthOptions<{
     authScope: string
 }>
 
+/** Trigger the wrapper and hand back the options it passed to cli-core. */
+async function captureOptions(): Promise<Opts> {
+    await runMigrateLegacyAuth({ silent: true })
+    return mocks.migrateLegacyAuth.mock.calls.at(-1)![0] as Opts
+}
+
 describe('runMigrateLegacyAuth', () => {
     beforeEach(() => {
         mocks.migrateLegacyAuth.mockReset().mockResolvedValue({ status: 'no-legacy-state' })
@@ -48,9 +54,7 @@ describe('runMigrateLegacyAuth', () => {
     })
 
     it('passes twist-cli wiring to cli-core: serviceName, legacy api-token slot, silent flag, no accountForUser override', async () => {
-        await runMigrateLegacyAuth({ silent: true })
-
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+        const options = await captureOptions()
         expect(options.serviceName).toBe('twist-cli')
         expect(options.legacyAccount).toBe('api-token')
         expect(options.accountForUser).toBeUndefined()
@@ -62,9 +66,7 @@ describe('runMigrateLegacyAuth', () => {
         mocks.getConfig.mockResolvedValueOnce({ config_version: 3 })
         mocks.getConfig.mockResolvedValueOnce({ config_version: 1 })
         mocks.getConfig.mockResolvedValueOnce({})
-
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+        const options = await captureOptions()
 
         expect(await options.hasMigrated()).toBe(true)
         expect(await options.hasMigrated()).toBe(true)
@@ -73,17 +75,13 @@ describe('runMigrateLegacyAuth', () => {
     })
 
     it('markMigrated writes config_version = 2 (decoupled from the exported CONFIG_VERSION)', async () => {
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
-
+        const options = await captureOptions()
         await options.markMigrated()
-
         expect(mocks.updateConfig).toHaveBeenCalledWith({ config_version: 2 })
     })
 
     it('loadLegacyPlaintextToken returns trimmed config.token, or null when blank/absent', async () => {
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+        const options = await captureOptions()
 
         mocks.getConfig.mockResolvedValueOnce({ token: '  tk_legacy  ' })
         expect(await options.loadLegacyPlaintextToken()).toBe('tk_legacy')
@@ -98,9 +96,7 @@ describe('runMigrateLegacyAuth', () => {
     it('identifyAccount resolves a TwistAccount from a raw TwistApi + v1 auth metadata on disk', async () => {
         mocks.getSessionUserMock.mockResolvedValue({ id: 42, name: 'Ada' })
         mocks.getConfig.mockResolvedValue({ authMode: 'read-write', authScope: 'user:read' })
-
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+        const options = await captureOptions()
 
         expect(await options.identifyAccount('tk_legacy')).toEqual({
             id: '42',
@@ -117,31 +113,15 @@ describe('runMigrateLegacyAuth', () => {
             resolveApi = res
         })
         mocks.getSessionUserMock.mockReturnValueOnce(apiPromise)
-        mocks.getConfig.mockResolvedValueOnce({ authMode: 'read-only', authScope: 'user:read' })
-
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+        mocks.getConfig.mockResolvedValueOnce({})
+        const options = await captureOptions()
 
         const identifyPromise = options.identifyAccount('tk_legacy')
         expect(mocks.getConfig).toHaveBeenCalledTimes(1) // already in flight
-        resolveApi({ id: 42, name: 'Ada' })
+        resolveApi({ id: 7, name: 'Carl' })
 
+        // Empty config → authMode / authScope default to 'unknown' / ''.
         await expect(identifyPromise).resolves.toEqual({
-            id: '42',
-            label: 'Ada',
-            authMode: 'read-only',
-            authScope: 'user:read',
-        })
-    })
-
-    it('identifyAccount falls back to unknown/empty metadata for `tw auth token` users with no authMode on disk', async () => {
-        mocks.getSessionUserMock.mockResolvedValue({ id: 7, name: 'Carl' })
-        mocks.getConfig.mockResolvedValue({})
-
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
-
-        expect(await options.identifyAccount('tk_legacy')).toEqual({
             id: '7',
             label: 'Carl',
             authMode: 'unknown',
@@ -150,9 +130,7 @@ describe('runMigrateLegacyAuth', () => {
     })
 
     it('cleanupLegacyConfig clears every v1 flat field in a single updateConfig call', async () => {
-        await runMigrateLegacyAuth({ silent: true })
-        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
-
+        const options = await captureOptions()
         await options.cleanupLegacyConfig!()
 
         expect(mocks.updateConfig).toHaveBeenCalledWith({
@@ -163,18 +141,5 @@ describe('runMigrateLegacyAuth', () => {
             authUserName: undefined,
             pendingSecureStoreClear: undefined,
         })
-    })
-
-    it('returns the underlying MigrateAuthResult unchanged (no-legacy-state / already-migrated / skipped surface as-is)', async () => {
-        mocks.migrateLegacyAuth.mockResolvedValueOnce({ status: 'already-migrated' })
-        expect((await runMigrateLegacyAuth({ silent: true })).status).toBe('already-migrated')
-
-        mocks.migrateLegacyAuth.mockResolvedValueOnce({
-            status: 'skipped',
-            reason: 'identify-failed',
-            detail: 'offline',
-        })
-        const result = await runMigrateLegacyAuth({ silent: true })
-        expect(result).toEqual({ status: 'skipped', reason: 'identify-failed', detail: 'offline' })
     })
 })

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+    migrateLegacyAuth: vi.fn(),
+    createWrappedTwistClient: vi.fn(),
+    getConfig: vi.fn(),
+    updateConfig: vi.fn(),
+}))
+
+vi.mock('@doist/cli-core/auth', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@doist/cli-core/auth')>()
+    return { ...actual, migrateLegacyAuth: mocks.migrateLegacyAuth }
+})
+
+vi.mock('./api.js', () => ({ createWrappedTwistClient: mocks.createWrappedTwistClient }))
+
+vi.mock('./config.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./config.js')>()
+    return {
+        ...actual,
+        getConfig: mocks.getConfig,
+        updateConfig: mocks.updateConfig,
+    }
+})
+
+import type { MigrateLegacyAuthOptions } from '@doist/cli-core/auth'
+import { CONFIG_VERSION } from './config.js'
+import { runMigrateLegacyAuth } from './migrate-auth.js'
+
+type Opts = MigrateLegacyAuthOptions<{
+    id: string
+    label: string
+    authMode: 'read-only' | 'read-write' | 'unknown'
+    authScope: string
+}>
+
+describe('runMigrateLegacyAuth', () => {
+    beforeEach(() => {
+        mocks.migrateLegacyAuth.mockReset().mockResolvedValue({ status: 'no-legacy-state' })
+        mocks.createWrappedTwistClient.mockReset()
+        mocks.getConfig.mockReset()
+        mocks.updateConfig.mockReset().mockResolvedValue(undefined)
+    })
+
+    it('passes twist-cli wiring to cli-core: serviceName, the api-token legacy slot, silent flag, and no accountForUser override (cli-core default user-${id} is used)', async () => {
+        await runMigrateLegacyAuth({ silent: true })
+
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+        expect(options.serviceName).toBe('twist-cli')
+        expect(options.legacyAccount).toBe('api-token')
+        expect(options.accountForUser).toBeUndefined()
+        expect(options.silent).toBe(true)
+    })
+
+    it('hasMigrated returns true once config_version reaches the current CONFIG_VERSION (one-way gate)', async () => {
+        mocks.getConfig.mockResolvedValueOnce({ config_version: CONFIG_VERSION })
+        mocks.getConfig.mockResolvedValueOnce({ config_version: 1 })
+        mocks.getConfig.mockResolvedValueOnce({})
+
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        expect(await options.hasMigrated()).toBe(true)
+        expect(await options.hasMigrated()).toBe(false)
+        expect(await options.hasMigrated()).toBe(false)
+    })
+
+    it('markMigrated writes config_version = CONFIG_VERSION', async () => {
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        await options.markMigrated()
+
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ config_version: CONFIG_VERSION })
+    })
+
+    it('loadLegacyPlaintextToken returns trimmed config.token, or null when blank/absent', async () => {
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        mocks.getConfig.mockResolvedValueOnce({ token: '  tk_legacy  ' })
+        expect(await options.loadLegacyPlaintextToken()).toBe('tk_legacy')
+
+        mocks.getConfig.mockResolvedValueOnce({ token: '   ' })
+        expect(await options.loadLegacyPlaintextToken()).toBeNull()
+
+        mocks.getConfig.mockResolvedValueOnce({})
+        expect(await options.loadLegacyPlaintextToken()).toBeNull()
+    })
+
+    it('identifyAccount resolves a TwistAccount from the API + v1 auth metadata on disk', async () => {
+        const getSessionUser = vi.fn().mockResolvedValue({ id: 42, name: 'Ada' })
+        mocks.createWrappedTwistClient.mockReturnValue({
+            users: { getSessionUser },
+        } as unknown as ReturnType<typeof mocks.createWrappedTwistClient>)
+        mocks.getConfig.mockResolvedValue({ authMode: 'read-write', authScope: 'user:read' })
+
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        expect(await options.identifyAccount('tk_legacy')).toEqual({
+            id: '42',
+            label: 'Ada',
+            authMode: 'read-write',
+            authScope: 'user:read',
+        })
+        expect(mocks.createWrappedTwistClient).toHaveBeenCalledWith('tk_legacy')
+    })
+
+    it('identifyAccount falls back to unknown/empty metadata for `tw auth token` users with no authMode on disk', async () => {
+        mocks.createWrappedTwistClient.mockReturnValue({
+            users: { getSessionUser: vi.fn().mockResolvedValue({ id: 7, name: 'Carl' }) },
+        } as unknown as ReturnType<typeof mocks.createWrappedTwistClient>)
+        mocks.getConfig.mockResolvedValue({})
+
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        expect(await options.identifyAccount('tk_legacy')).toEqual({
+            id: '7',
+            label: 'Carl',
+            authMode: 'unknown',
+            authScope: '',
+        })
+    })
+
+    it('cleanupLegacyConfig clears every v1 flat field in a single updateConfig call', async () => {
+        await runMigrateLegacyAuth({ silent: true })
+        const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
+
+        await options.cleanupLegacyConfig!()
+
+        expect(mocks.updateConfig).toHaveBeenCalledWith({
+            token: undefined,
+            authMode: undefined,
+            authScope: undefined,
+            authUserId: undefined,
+            authUserName: undefined,
+            pendingSecureStoreClear: undefined,
+        })
+    })
+
+    it('returns the underlying MigrateAuthResult unchanged (no-legacy-state / already-migrated / skipped surface as-is)', async () => {
+        mocks.migrateLegacyAuth.mockResolvedValueOnce({ status: 'already-migrated' })
+        expect((await runMigrateLegacyAuth({ silent: true })).status).toBe('already-migrated')
+
+        mocks.migrateLegacyAuth.mockResolvedValueOnce({
+            status: 'skipped',
+            reason: 'identify-failed',
+            detail: 'offline',
+        })
+        const result = await runMigrateLegacyAuth({ silent: true })
+        expect(result).toEqual({ status: 'skipped', reason: 'identify-failed', detail: 'offline' })
+    })
+})

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -47,7 +47,7 @@ describe('runMigrateLegacyAuth', () => {
         mocks.updateConfig.mockReset().mockResolvedValue(undefined)
     })
 
-    it('passes twist-cli wiring to cli-core: serviceName, the api-token legacy slot, silent flag, and no accountForUser override (cli-core default user-${id} is used)', async () => {
+    it('passes twist-cli wiring to cli-core: serviceName, legacy api-token slot, silent flag, no accountForUser override', async () => {
         await runMigrateLegacyAuth({ silent: true })
 
         const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
@@ -57,9 +57,7 @@ describe('runMigrateLegacyAuth', () => {
         expect(options.silent).toBe(true)
     })
 
-    it('hasMigrated returns true once config_version reaches 2 (one-way gate)', async () => {
-        // v1 → v2 migration only — the check uses a local schema version so a
-        // future v3 bump doesn't cause this helper to spuriously re-run.
+    it('hasMigrated returns true once config_version reaches 2 (one-way gate; >= 2 so future bumps still count)', async () => {
         mocks.getConfig.mockResolvedValueOnce({ config_version: 2 })
         mocks.getConfig.mockResolvedValueOnce({ config_version: 3 })
         mocks.getConfig.mockResolvedValueOnce({ config_version: 1 })
@@ -74,7 +72,7 @@ describe('runMigrateLegacyAuth', () => {
         expect(await options.hasMigrated()).toBe(false)
     })
 
-    it('markMigrated writes config_version = 2 exactly (decoupled from any future CONFIG_VERSION bump)', async () => {
+    it('markMigrated writes config_version = 2 (decoupled from the exported CONFIG_VERSION)', async () => {
         await runMigrateLegacyAuth({ silent: true })
         const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
 
@@ -97,7 +95,7 @@ describe('runMigrateLegacyAuth', () => {
         expect(await options.loadLegacyPlaintextToken()).toBeNull()
     })
 
-    it('identifyAccount resolves a TwistAccount from a raw TwistApi + v1 auth metadata on disk (no spinner-wrapped client — keeps migration outside the runtime auth graph)', async () => {
+    it('identifyAccount resolves a TwistAccount from a raw TwistApi + v1 auth metadata on disk', async () => {
         mocks.getSessionUserMock.mockResolvedValue({ id: 42, name: 'Ada' })
         mocks.getConfig.mockResolvedValue({ authMode: 'read-write', authScope: 'user:read' })
 
@@ -114,9 +112,6 @@ describe('runMigrateLegacyAuth', () => {
     })
 
     it('identifyAccount runs the API call and the local getConfig() concurrently', async () => {
-        // The two reads are independent; firing them sequentially adds an
-        // avoidable round-trip on every postinstall migration. Resolve the
-        // API call first and assert getConfig was already in flight by then.
         let resolveApi: (value: { id: number; name: string }) => void = () => {}
         const apiPromise = new Promise<{ id: number; name: string }>((res) => {
             resolveApi = res
@@ -128,8 +123,7 @@ describe('runMigrateLegacyAuth', () => {
         const options = mocks.migrateLegacyAuth.mock.calls[0][0] as Opts
 
         const identifyPromise = options.identifyAccount('tk_legacy')
-        // getConfig should have been kicked off before we resolved the API.
-        expect(mocks.getConfig).toHaveBeenCalledTimes(1)
+        expect(mocks.getConfig).toHaveBeenCalledTimes(1) // already in flight
         resolveApi({ id: 42, name: 'Ada' })
 
         await expect(identifyPromise).resolves.toEqual({

--- a/src/lib/migrate-auth.test.ts
+++ b/src/lib/migrate-auth.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
     migrateLegacyAuth: vi.fn(),
-    createWrappedTwistClient: vi.fn(),
+    twistApiCtor: vi.fn(),
+    getSessionUserMock: vi.fn(),
     getConfig: vi.fn(),
     updateConfig: vi.fn(),
 }))
@@ -12,7 +13,11 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
     return { ...actual, migrateLegacyAuth: mocks.migrateLegacyAuth }
 })
 
-vi.mock('./api.js', () => ({ createWrappedTwistClient: mocks.createWrappedTwistClient }))
+vi.mock('@doist/twist-sdk', () => ({
+    TwistApi: mocks.twistApiCtor.mockImplementation(function (this: object, _token: string) {
+        Object.assign(this, { users: { getSessionUser: mocks.getSessionUserMock } })
+    }),
+}))
 
 vi.mock('./config.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('./config.js')>()
@@ -37,7 +42,8 @@ type Opts = MigrateLegacyAuthOptions<{
 describe('runMigrateLegacyAuth', () => {
     beforeEach(() => {
         mocks.migrateLegacyAuth.mockReset().mockResolvedValue({ status: 'no-legacy-state' })
-        mocks.createWrappedTwistClient.mockReset()
+        mocks.twistApiCtor.mockClear()
+        mocks.getSessionUserMock.mockReset()
         mocks.getConfig.mockReset()
         mocks.updateConfig.mockReset().mockResolvedValue(undefined)
     })
@@ -88,11 +94,8 @@ describe('runMigrateLegacyAuth', () => {
         expect(await options.loadLegacyPlaintextToken()).toBeNull()
     })
 
-    it('identifyAccount resolves a TwistAccount from the API + v1 auth metadata on disk', async () => {
-        const getSessionUser = vi.fn().mockResolvedValue({ id: 42, name: 'Ada' })
-        mocks.createWrappedTwistClient.mockReturnValue({
-            users: { getSessionUser },
-        } as unknown as ReturnType<typeof mocks.createWrappedTwistClient>)
+    it('identifyAccount resolves a TwistAccount from a raw TwistApi + v1 auth metadata on disk (no spinner-wrapped client — keeps migration outside the runtime auth graph)', async () => {
+        mocks.getSessionUserMock.mockResolvedValue({ id: 42, name: 'Ada' })
         mocks.getConfig.mockResolvedValue({ authMode: 'read-write', authScope: 'user:read' })
 
         await runMigrateLegacyAuth({ silent: true })
@@ -104,13 +107,11 @@ describe('runMigrateLegacyAuth', () => {
             authMode: 'read-write',
             authScope: 'user:read',
         })
-        expect(mocks.createWrappedTwistClient).toHaveBeenCalledWith('tk_legacy')
+        expect(mocks.twistApiCtor).toHaveBeenCalledWith('tk_legacy')
     })
 
     it('identifyAccount falls back to unknown/empty metadata for `tw auth token` users with no authMode on disk', async () => {
-        mocks.createWrappedTwistClient.mockReturnValue({
-            users: { getSessionUser: vi.fn().mockResolvedValue({ id: 7, name: 'Carl' }) },
-        } as unknown as ReturnType<typeof mocks.createWrappedTwistClient>)
+        mocks.getSessionUserMock.mockResolvedValue({ id: 7, name: 'Carl' })
         mocks.getConfig.mockResolvedValue({})
 
         await runMigrateLegacyAuth({ silent: true })

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -1,0 +1,66 @@
+import { type MigrateAuthResult, migrateLegacyAuth } from '@doist/cli-core/auth'
+import { createWrappedTwistClient } from './api.js'
+import type { TwistAccount } from './auth-provider.js'
+import { CONFIG_VERSION, getConfig, updateConfig } from './config.js'
+import { createTwistUserRecordStore } from './user-records.js'
+
+const SERVICE_NAME = 'twist-cli'
+// Legacy pre-γ1 keyring slot. cli-core's `migrateLegacyAuth` deletes the secret
+// stored under this slug after a successful migration. After γ1, the runtime
+// uses cli-core's default `user-${id}` slug.
+const LEGACY_KEYRING_ACCOUNT = 'api-token'
+
+/**
+ * One-time v1 → v2 auth state migration. Both wakeup paths (postinstall + the
+ * lazy hook inside `createTwistTokenStore`) call this with `silent: true` so a
+ * regular `tw` invocation doesn't print a banner on the cold-cache run. The
+ * underlying cli-core helper is idempotent — `hasMigrated()` short-circuits
+ * once the durable marker is on disk.
+ */
+export async function runMigrateLegacyAuth(
+    options: { silent: boolean } = { silent: true },
+): Promise<MigrateAuthResult<TwistAccount>> {
+    return migrateLegacyAuth<TwistAccount>({
+        serviceName: SERVICE_NAME,
+        legacyAccount: LEGACY_KEYRING_ACCOUNT,
+        userRecords: createTwistUserRecordStore(),
+        hasMigrated: async () => {
+            const config = await getConfig()
+            return config.config_version === CONFIG_VERSION
+        },
+        markMigrated: async () => {
+            await updateConfig({ config_version: CONFIG_VERSION })
+        },
+        loadLegacyPlaintextToken: async () => {
+            const config = await getConfig()
+            return config.token?.trim() || null
+        },
+        identifyAccount: async (token) => {
+            const client = createWrappedTwistClient(token)
+            const user = await client.users.getSessionUser()
+            const config = await getConfig()
+            // Promote the v1 auth metadata onto the v2 account if it's there;
+            // legacy `tw auth token` users have no `authMode` / `authScope`,
+            // so we fall through to `'unknown'` / `''`, the same defaults
+            // `validateToken` would have written.
+            return {
+                id: String(user.id),
+                label: user.name,
+                authMode: config.authMode ?? 'unknown',
+                authScope: config.authScope ?? '',
+            }
+        },
+        cleanupLegacyConfig: async () => {
+            await updateConfig({
+                token: undefined,
+                authMode: undefined,
+                authScope: undefined,
+                authUserId: undefined,
+                authUserName: undefined,
+                pendingSecureStoreClear: undefined,
+            })
+        },
+        silent: options.silent,
+        logPrefix: 'twist-cli',
+    })
+}

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -1,15 +1,18 @@
 import { type MigrateAuthResult, migrateLegacyAuth } from '@doist/cli-core/auth'
 import { TwistApi } from '@doist/twist-sdk'
+import { LEGACY_KEYRING_ACCOUNT, SECURE_STORE_SERVICE } from './auth-constants.js'
 import type { TwistAccount } from './auth-provider.js'
-import { CONFIG_VERSION, getConfig, updateConfig } from './config.js'
+import { getConfig, updateConfig } from './config.js'
 import { toTwistAccount } from './twist-account.js'
 import { createTwistUserRecordStore } from './user-records.js'
 
-const SERVICE_NAME = 'twist-cli'
-// Legacy pre-γ1 keyring slot. cli-core's `migrateLegacyAuth` deletes the secret
-// stored under this slug after a successful migration. After γ1, the runtime
-// uses cli-core's default `user-${id}` slug.
-const LEGACY_KEYRING_ACCOUNT = 'api-token'
+/**
+ * Schema version this migration targets. Kept local (not the exported
+ * `CONFIG_VERSION` from `config.ts`) so a future schema bump to v3 doesn't
+ * cause this v1→v2 helper to spuriously re-run for already-migrated users:
+ * `hasMigrated()` reads `>= 2`, `markMigrated()` writes exactly `2`.
+ */
+const V2_SCHEMA_VERSION = 2
 
 /**
  * One-time v1 → v2 auth state migration. Both wakeup paths (postinstall + the
@@ -25,23 +28,27 @@ export async function runMigrateLegacyAuth(
     options: { silent: boolean } = { silent: true },
 ): Promise<MigrateAuthResult<TwistAccount>> {
     return migrateLegacyAuth<TwistAccount>({
-        serviceName: SERVICE_NAME,
+        serviceName: SECURE_STORE_SERVICE,
         legacyAccount: LEGACY_KEYRING_ACCOUNT,
         userRecords: createTwistUserRecordStore(),
         hasMigrated: async () => {
             const config = await getConfig()
-            return config.config_version === CONFIG_VERSION
+            return (config.config_version ?? 0) >= V2_SCHEMA_VERSION
         },
         markMigrated: async () => {
-            await updateConfig({ config_version: CONFIG_VERSION })
+            await updateConfig({ config_version: V2_SCHEMA_VERSION })
         },
         loadLegacyPlaintextToken: async () => {
             const config = await getConfig()
             return config.token?.trim() || null
         },
         identifyAccount: async (token) => {
-            const user = await new TwistApi(token).users.getSessionUser()
-            const config = await getConfig()
+            // Network call + config read are independent — fire them together
+            // to shave a round trip off the first-run / postinstall path.
+            const [user, config] = await Promise.all([
+                new TwistApi(token).users.getSessionUser(),
+                getConfig(),
+            ])
             // Legacy `tw auth token` users have no `authMode` / `authScope` on
             // disk; `toTwistAccount` falls through to the same defaults
             // `validateToken` would have written.

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -7,22 +7,19 @@ import { toTwistAccount } from './twist-account.js'
 import { createTwistUserRecordStore } from './user-records.js'
 
 /**
- * Schema version this migration targets. Kept local (not the exported
- * `CONFIG_VERSION` from `config.ts`) so a future schema bump to v3 doesn't
- * cause this v1→v2 helper to spuriously re-run for already-migrated users:
- * `hasMigrated()` reads `>= 2`, `markMigrated()` writes exactly `2`.
+ * Pinned to this migration's target schema. Decoupled from the exported
+ * `CONFIG_VERSION` so a future bump doesn't make this helper re-run for
+ * users who are already on v2 or beyond.
  */
 const V2_SCHEMA_VERSION = 2
 
 /**
- * One-time v1 → v2 auth state migration. Both wakeup paths (postinstall + the
- * lazy hook inside `createTwistTokenStore`) call this with `silent: true` so a
- * regular `tw` invocation doesn't print a banner on the cold-cache run. The
- * underlying cli-core helper is idempotent — `hasMigrated()` short-circuits
- * once the durable marker is on disk.
+ * One-time migration of v1 auth state into the v2 `users[]` shape. Called
+ * by postinstall and by the lazy hook in `createTwistTokenStore`. Idempotent
+ * via the `config_version` marker.
  *
- * Talks to the Twist API via a raw `TwistApi` (not `createWrappedTwistClient`)
- * to keep migration outside the runtime auth / token-store module graph.
+ * Uses raw `TwistApi` rather than `createWrappedTwistClient` to keep this
+ * module out of the runtime auth/token-store import graph.
  */
 export async function runMigrateLegacyAuth(
     options: { silent: boolean } = { silent: true },
@@ -43,15 +40,10 @@ export async function runMigrateLegacyAuth(
             return config.token?.trim() || null
         },
         identifyAccount: async (token) => {
-            // Network call + config read are independent — fire them together
-            // to shave a round trip off the first-run / postinstall path.
             const [user, config] = await Promise.all([
                 new TwistApi(token).users.getSessionUser(),
                 getConfig(),
             ])
-            // Legacy `tw auth token` users have no `authMode` / `authScope` on
-            // disk; `toTwistAccount` falls through to the same defaults
-            // `validateToken` would have written.
             return toTwistAccount(user, {
                 authMode: config.authMode,
                 authScope: config.authScope,

--- a/src/lib/migrate-auth.ts
+++ b/src/lib/migrate-auth.ts
@@ -1,7 +1,8 @@
 import { type MigrateAuthResult, migrateLegacyAuth } from '@doist/cli-core/auth'
-import { createWrappedTwistClient } from './api.js'
+import { TwistApi } from '@doist/twist-sdk'
 import type { TwistAccount } from './auth-provider.js'
 import { CONFIG_VERSION, getConfig, updateConfig } from './config.js'
+import { toTwistAccount } from './twist-account.js'
 import { createTwistUserRecordStore } from './user-records.js'
 
 const SERVICE_NAME = 'twist-cli'
@@ -16,6 +17,9 @@ const LEGACY_KEYRING_ACCOUNT = 'api-token'
  * regular `tw` invocation doesn't print a banner on the cold-cache run. The
  * underlying cli-core helper is idempotent — `hasMigrated()` short-circuits
  * once the durable marker is on disk.
+ *
+ * Talks to the Twist API via a raw `TwistApi` (not `createWrappedTwistClient`)
+ * to keep migration outside the runtime auth / token-store module graph.
  */
 export async function runMigrateLegacyAuth(
     options: { silent: boolean } = { silent: true },
@@ -36,19 +40,15 @@ export async function runMigrateLegacyAuth(
             return config.token?.trim() || null
         },
         identifyAccount: async (token) => {
-            const client = createWrappedTwistClient(token)
-            const user = await client.users.getSessionUser()
+            const user = await new TwistApi(token).users.getSessionUser()
             const config = await getConfig()
-            // Promote the v1 auth metadata onto the v2 account if it's there;
-            // legacy `tw auth token` users have no `authMode` / `authScope`,
-            // so we fall through to `'unknown'` / `''`, the same defaults
+            // Legacy `tw auth token` users have no `authMode` / `authScope` on
+            // disk; `toTwistAccount` falls through to the same defaults
             // `validateToken` would have written.
-            return {
-                id: String(user.id),
-                label: user.name,
-                authMode: config.authMode ?? 'unknown',
-                authScope: config.authScope ?? '',
-            }
+            return toTwistAccount(user, {
+                authMode: config.authMode,
+                authScope: config.authScope,
+            })
         },
         cleanupLegacyConfig: async () => {
             await updateConfig({

--- a/src/lib/twist-account.ts
+++ b/src/lib/twist-account.ts
@@ -2,9 +2,31 @@ import type { TwistAccount } from './auth-provider.js'
 import type { AuthMode } from './config.js'
 
 /**
+ * Lower-level factory: applies the canonical `authMode` / `authScope`
+ * defaults (`'unknown'` / `''`) to whatever id/label the caller already
+ * has. Used by every code path that constructs a `TwistAccount` —
+ * OAuth `validateToken`, `migrateLegacyAuth`'s `identifyAccount`, the
+ * user-records read-side, and the offline legacy fallback — so the
+ * defaults can't drift between them.
+ */
+export function makeTwistAccount(input: {
+    id: string
+    label: string
+    authMode?: AuthMode
+    authScope?: string
+}): TwistAccount {
+    return {
+        id: input.id,
+        label: input.label,
+        authMode: input.authMode ?? 'unknown',
+        authScope: input.authScope ?? '',
+    }
+}
+
+/**
  * Build a `TwistAccount` from a Twist `getSessionUser` payload plus optional
- * auth metadata. Used by both the OAuth `validateToken` path and the
- * legacy-auth migration path so they can't drift on default values.
+ * auth metadata. Thin convenience wrapper around `makeTwistAccount` for the
+ * common case where the caller has a fresh session-user response.
  *
  * Lives in its own module so `migrate-auth.ts` can import this helper
  * without pulling in `auth-provider.ts`'s runtime graph (which would
@@ -14,10 +36,10 @@ export function toTwistAccount(
     sessionUser: { id: number; name: string },
     metadata: { authMode?: AuthMode; authScope?: string } = {},
 ): TwistAccount {
-    return {
+    return makeTwistAccount({
         id: String(sessionUser.id),
         label: sessionUser.name,
-        authMode: metadata.authMode ?? 'unknown',
-        authScope: metadata.authScope ?? '',
-    }
+        authMode: metadata.authMode,
+        authScope: metadata.authScope,
+    })
 }

--- a/src/lib/twist-account.ts
+++ b/src/lib/twist-account.ts
@@ -1,14 +1,7 @@
 import type { TwistAccount } from './auth-provider.js'
 import type { AuthMode } from './config.js'
 
-/**
- * Lower-level factory: applies the canonical `authMode` / `authScope`
- * defaults (`'unknown'` / `''`) to whatever id/label the caller already
- * has. Used by every code path that constructs a `TwistAccount` —
- * OAuth `validateToken`, `migrateLegacyAuth`'s `identifyAccount`, the
- * user-records read-side, and the offline legacy fallback — so the
- * defaults can't drift between them.
- */
+/** Canonical `TwistAccount` factory. Applies the `'unknown'` / `''` defaults. */
 export function makeTwistAccount(input: {
     id: string
     label: string
@@ -24,13 +17,9 @@ export function makeTwistAccount(input: {
 }
 
 /**
- * Build a `TwistAccount` from a Twist `getSessionUser` payload plus optional
- * auth metadata. Thin convenience wrapper around `makeTwistAccount` for the
- * common case where the caller has a fresh session-user response.
- *
- * Lives in its own module so `migrate-auth.ts` can import this helper
- * without pulling in `auth-provider.ts`'s runtime graph (which would
- * re-introduce a cycle).
+ * Adapt a Twist `getSessionUser` payload to a `TwistAccount`. Lives in its
+ * own module so `migrate-auth.ts` can import it without pulling in
+ * `auth-provider.ts`'s runtime graph.
  */
 export function toTwistAccount(
     sessionUser: { id: number; name: string },

--- a/src/lib/twist-account.ts
+++ b/src/lib/twist-account.ts
@@ -1,0 +1,23 @@
+import type { TwistAccount } from './auth-provider.js'
+import type { AuthMode } from './config.js'
+
+/**
+ * Build a `TwistAccount` from a Twist `getSessionUser` payload plus optional
+ * auth metadata. Used by both the OAuth `validateToken` path and the
+ * legacy-auth migration path so they can't drift on default values.
+ *
+ * Lives in its own module so `migrate-auth.ts` can import this helper
+ * without pulling in `auth-provider.ts`'s runtime graph (which would
+ * re-introduce a cycle).
+ */
+export function toTwistAccount(
+    sessionUser: { id: number; name: string },
+    metadata: { authMode?: AuthMode; authScope?: string } = {},
+): TwistAccount {
+    return {
+        id: String(sessionUser.id),
+        label: sessionUser.name,
+        authMode: metadata.authMode ?? 'unknown',
+        authScope: metadata.authScope ?? '',
+    }
+}

--- a/src/lib/user-records.test.ts
+++ b/src/lib/user-records.test.ts
@@ -14,16 +14,29 @@ vi.mock('./config.js', async (importOriginal) => {
     }
 })
 
-import type { Config } from './config.js'
+import type { Config, StoredUser } from './config.js'
 import { createTwistUserRecordStore } from './user-records.js'
 
-const STORED_CONFIG: Config = {
-    token: 'tk_stored_1234567890',
+const ADA: StoredUser = {
+    id: '42',
+    name: 'Ada',
     authMode: 'read-write',
     authScope: 'user:read',
-    authUserId: 42,
-    authUserName: 'Ada',
-    currentWorkspace: 7,
+}
+
+const BOB: StoredUser = {
+    id: '99',
+    name: 'Bob',
+    authMode: 'read-only',
+    authScope: 'user:read',
+}
+
+const ADA_RECORD = {
+    account: { id: '42', label: 'Ada', authMode: 'read-write' as const, authScope: 'user:read' },
+}
+
+const BOB_RECORD = {
+    account: { id: '99', label: 'Bob', authMode: 'read-only' as const, authScope: 'user:read' },
 }
 
 describe('createTwistUserRecordStore', () => {
@@ -32,94 +45,126 @@ describe('createTwistUserRecordStore', () => {
         mocks.updateConfig.mockReset().mockResolvedValue(undefined)
     })
 
-    it('round-trips a record through upsert + list', async () => {
-        mocks.getConfig.mockResolvedValue({ currentWorkspace: 7 })
-        const store = createTwistUserRecordStore()
-        const record = {
-            account: {
-                id: '42',
-                label: 'Ada',
-                authMode: 'read-write' as const,
-                authScope: 'user:read',
-            },
-            fallbackToken: 'tk_stored_1234567890',
-        }
+    it('list returns empty when no users[] is persisted', async () => {
+        mocks.getConfig.mockResolvedValue({ currentWorkspace: 7 } satisfies Config)
 
-        await store.upsert(record)
-        // Simulate the just-written state so the subsequent list reads it back.
-        mocks.getConfig.mockResolvedValue({
-            currentWorkspace: 7,
-            ...mocks.updateConfig.mock.calls[0][0],
-        })
-
-        expect(await store.list()).toEqual([record])
+        expect(await createTwistUserRecordStore().list()).toEqual([])
     })
 
-    it('strips the token on upsert when fallbackToken is absent (cli-core replace-not-merge)', async () => {
-        // Without this, a stale plaintext token would survive a successful
-        // keyring-backed write and the runtime would prefer it over the
-        // fresh keyring value.
-        mocks.getConfig.mockResolvedValue(STORED_CONFIG)
+    it('list returns one record per StoredUser, surfacing token as fallbackToken', async () => {
+        mocks.getConfig.mockResolvedValue({
+            users: [{ ...ADA, token: 'tk_ada' }, BOB],
+        } satisfies Config)
+
+        expect(await createTwistUserRecordStore().list()).toEqual([
+            { ...ADA_RECORD, fallbackToken: 'tk_ada' },
+            BOB_RECORD,
+        ])
+    })
+
+    it('upsert appends a new record when the id is not yet stored', async () => {
+        mocks.getConfig.mockResolvedValue({ users: [ADA] } satisfies Config)
+
+        await createTwistUserRecordStore().upsert(BOB_RECORD)
+
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ users: [ADA, BOB] })
+    })
+
+    it('upsert replaces (not merges) when the id matches: stale token cleared when fallbackToken absent', async () => {
+        mocks.getConfig.mockResolvedValue({
+            users: [{ ...ADA, token: 'tk_stale' }],
+        } satisfies Config)
+
+        await createTwistUserRecordStore().upsert(ADA_RECORD)
+
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ users: [ADA] })
+    })
+
+    it('upsert preserves order of other users when replacing in the middle', async () => {
+        const carl: StoredUser = { id: '7', name: 'Carl', authMode: 'unknown', authScope: '' }
+        mocks.getConfig.mockResolvedValue({ users: [ADA, carl, BOB] } satisfies Config)
 
         await createTwistUserRecordStore().upsert({
-            account: {
-                id: '42',
-                label: 'Ada',
-                authMode: 'read-write',
-                authScope: 'user:read',
-            },
+            account: { id: '7', label: 'Carl', authMode: 'unknown', authScope: '' },
+            fallbackToken: 'tk_carl_new',
         })
 
-        expect(mocks.updateConfig.mock.calls[0][0].token).toBeUndefined()
+        expect(mocks.updateConfig).toHaveBeenCalledWith({
+            users: [ADA, { ...carl, token: 'tk_carl_new' }, BOB],
+        })
     })
 
-    it('synthesises a record with empty id for legacy token-only users (no authUserId)', async () => {
-        // `tw auth token <token>` users have `authMode` but no `authUserId`.
-        // Returning `[]` here would leave their keyring entry orphaned once
-        // PR β wires the adapter into `KeyringTokenStore`.
+    it('remove drops the matching entry and leaves others in place', async () => {
+        mocks.getConfig.mockResolvedValue({ users: [ADA, BOB] } satisfies Config)
+
+        await createTwistUserRecordStore().remove('42')
+
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ users: [BOB] })
+    })
+
+    it('remove clears defaultUserId when the removed record was the default', async () => {
         mocks.getConfig.mockResolvedValue({
-            token: 'tk_legacy_token_value',
-            authMode: 'unknown',
-            currentWorkspace: 7,
-        })
-
-        const [record] = await createTwistUserRecordStore().list()
-
-        expect(record.account.id).toBe('')
-        expect(record.account.authMode).toBe('unknown')
-        expect(record.fallbackToken).toBe('tk_legacy_token_value')
-    })
-
-    it('remove clears all auth fields when the id matches', async () => {
-        mocks.getConfig.mockResolvedValue(STORED_CONFIG)
+            users: [ADA, BOB],
+            defaultUserId: '42',
+        } satisfies Config)
 
         await createTwistUserRecordStore().remove('42')
 
         expect(mocks.updateConfig).toHaveBeenCalledWith({
-            authUserId: undefined,
-            authUserName: undefined,
-            authMode: undefined,
-            authScope: undefined,
-            token: undefined,
+            users: [BOB],
+            defaultUserId: undefined,
         })
     })
 
-    it('remove is a no-op when the id does not match (skips disk write entirely)', async () => {
-        mocks.getConfig.mockResolvedValue(STORED_CONFIG)
+    it('remove leaves defaultUserId untouched when the removed record was not the default', async () => {
+        mocks.getConfig.mockResolvedValue({
+            users: [ADA, BOB],
+            defaultUserId: '99',
+        } satisfies Config)
+
+        await createTwistUserRecordStore().remove('42')
+
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ users: [BOB] })
+    })
+
+    it('remove is a no-op when the id does not match any stored user', async () => {
+        mocks.getConfig.mockResolvedValue({ users: [ADA] } satisfies Config)
 
         await createTwistUserRecordStore().remove('999')
 
         expect(mocks.updateConfig).not.toHaveBeenCalled()
     })
 
-    it('setDefaultId is a no-op for the single-user adapter (no stale orphans, no phantom writes)', async () => {
-        mocks.getConfig.mockResolvedValue(STORED_CONFIG)
+    it('getDefaultId reads config.defaultUserId, returning null when absent', async () => {
+        mocks.getConfig.mockResolvedValueOnce({ users: [ADA] } satisfies Config)
+        expect(await createTwistUserRecordStore().getDefaultId()).toBeNull()
+
+        mocks.getConfig.mockResolvedValueOnce({
+            users: [ADA],
+            defaultUserId: '42',
+        } satisfies Config)
+        expect(await createTwistUserRecordStore().getDefaultId()).toBe('42')
+    })
+
+    it('setDefaultId writes defaultUserId (and clears it when passed null)', async () => {
         const store = createTwistUserRecordStore()
 
-        await store.setDefaultId(null) // would orphan token + name
-        await store.setDefaultId('999') // empty/mismatched ref would synthesise a phantom record
-        await store.setDefaultId('42') // matching ref is already the only record
+        await store.setDefaultId('42')
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ defaultUserId: '42' })
 
-        expect(mocks.updateConfig).not.toHaveBeenCalled()
+        await store.setDefaultId(null)
+        expect(mocks.updateConfig).toHaveBeenCalledWith({ defaultUserId: undefined })
+    })
+
+    it('round-trips a record through upsert + list (single-user case)', async () => {
+        mocks.getConfig.mockResolvedValueOnce({ currentWorkspace: 7 } satisfies Config)
+        const store = createTwistUserRecordStore()
+        const record = { ...ADA_RECORD, fallbackToken: 'tk_stored_1234567890' }
+
+        await store.upsert(record)
+        const writtenUsers = mocks.updateConfig.mock.calls[0][0].users as StoredUser[]
+        mocks.getConfig.mockResolvedValueOnce({ currentWorkspace: 7, users: writtenUsers })
+
+        expect(await store.list()).toEqual([record])
     })
 })

--- a/src/lib/user-records.test.ts
+++ b/src/lib/user-records.test.ts
@@ -155,16 +155,4 @@ describe('createTwistUserRecordStore', () => {
         await store.setDefaultId(null)
         expect(mocks.updateConfig).toHaveBeenCalledWith({ defaultUserId: undefined })
     })
-
-    it('round-trips a record through upsert + list (single-user case)', async () => {
-        mocks.getConfig.mockResolvedValueOnce({ currentWorkspace: 7 } satisfies Config)
-        const store = createTwistUserRecordStore()
-        const record = { ...ADA_RECORD, fallbackToken: 'tk_stored_1234567890' }
-
-        await store.upsert(record)
-        const writtenUsers = mocks.updateConfig.mock.calls[0][0].users as StoredUser[]
-        mocks.getConfig.mockResolvedValueOnce({ currentWorkspace: 7, users: writtenUsers })
-
-        expect(await store.list()).toEqual([record])
-    })
 })

--- a/src/lib/user-records.ts
+++ b/src/lib/user-records.ts
@@ -1,6 +1,6 @@
 import type { UserRecord, UserRecordStore } from '@doist/cli-core/auth'
 import type { TwistAccount } from './auth-provider.js'
-import { type StoredUser, getConfig, updateConfig } from './config.js'
+import { type Config, type StoredUser, getConfig, updateConfig } from './config.js'
 
 /**
  * v2 adapter — reads/writes the `users[]` array in `config.json`. Multi-account
@@ -48,6 +48,21 @@ export function createTwistUserRecordStore(): UserRecordStore<TwistAccount> {
             await updateConfig({ defaultUserId: id ?? undefined })
         },
     }
+}
+
+/**
+ * Resolve the active (default-or-first) `UserRecord` directly from an
+ * already-loaded `Config` — avoids the double `getConfig()` that
+ * `store.list()` + `store.getDefaultId()` would otherwise incur, and gives
+ * callers one canonical place to derive the default. Returns `null` when no
+ * users are stored.
+ */
+export function getDefaultUserRecord(config: Config): UserRecord<TwistAccount> | null {
+    const users = config.users ?? []
+    if (users.length === 0) return null
+    const defaultId = config.defaultUserId
+    const user = (defaultId && users.find((u) => u.id === defaultId)) || users[0]
+    return toRecord(user)
 }
 
 function toRecord(user: StoredUser): UserRecord<TwistAccount> {

--- a/src/lib/user-records.ts
+++ b/src/lib/user-records.ts
@@ -4,15 +4,9 @@ import { type Config, type StoredUser, getConfig, updateConfig } from './config.
 import { makeTwistAccount } from './twist-account.js'
 
 /**
- * v2 adapter — reads/writes the `users[]` array in `config.json`. Multi-account
- * capable: `list()` returns one `UserRecord<TwistAccount>` per stored user;
- * `upsert` replaces or appends keyed by `account.id`; `setDefaultId` writes
- * `defaultUserId`. `migrateLegacyAuth` (see `migrate-auth.ts`) is responsible
- * for promoting v1 flat fields into this shape on first run.
- *
- * `token` on a `StoredUser` is surfaced as `fallbackToken` (cli-core's name
- * for the plaintext copy persisted only when the keyring is unreachable at
- * write time).
+ * `UserRecordStore` adapter over `config.users[]`. `StoredUser.token` is
+ * surfaced as `fallbackToken` — cli-core's name for the plaintext copy
+ * persisted only when the keyring is unreachable.
  */
 export function createTwistUserRecordStore(): UserRecordStore<TwistAccount> {
     return {
@@ -52,11 +46,8 @@ export function createTwistUserRecordStore(): UserRecordStore<TwistAccount> {
 }
 
 /**
- * Resolve the active (default-or-first) `UserRecord` directly from an
- * already-loaded `Config` — avoids the double `getConfig()` that
- * `store.list()` + `store.getDefaultId()` would otherwise incur, and gives
- * callers one canonical place to derive the default. Returns `null` when no
- * users are stored.
+ * Resolve the default-or-first `UserRecord` from an already-loaded config.
+ * Returns `null` when no users are stored.
  */
 export function getDefaultUserRecord(config: Config): UserRecord<TwistAccount> | null {
     const users = config.users ?? []
@@ -80,9 +71,8 @@ function toRecord(user: StoredUser): UserRecord<TwistAccount> {
 }
 
 function fromRecord(record: UserRecord<TwistAccount>): StoredUser {
-    // REPLACE semantics (cli-core contract): absent / blank `fallbackToken`
-    // strips the plaintext slot so a stale token can't survive a fresh
-    // keyring-backed write.
+    // Replace, don't merge: an absent `fallbackToken` strips the plaintext
+    // slot so it can't shadow a fresh keyring-backed write. cli-core contract.
     const trimmed = record.fallbackToken?.trim()
     const next: StoredUser = {
         id: record.account.id,

--- a/src/lib/user-records.ts
+++ b/src/lib/user-records.ts
@@ -1,6 +1,7 @@
 import type { UserRecord, UserRecordStore } from '@doist/cli-core/auth'
 import type { TwistAccount } from './auth-provider.js'
 import { type Config, type StoredUser, getConfig, updateConfig } from './config.js'
+import { makeTwistAccount } from './twist-account.js'
 
 /**
  * v2 adapter — reads/writes the `users[]` array in `config.json`. Multi-account
@@ -66,12 +67,12 @@ export function getDefaultUserRecord(config: Config): UserRecord<TwistAccount> |
 }
 
 function toRecord(user: StoredUser): UserRecord<TwistAccount> {
-    const account: TwistAccount = {
+    const account = makeTwistAccount({
         id: user.id,
         label: user.name,
-        authMode: user.authMode ?? 'unknown',
-        authScope: user.authScope ?? '',
-    }
+        authMode: user.authMode,
+        authScope: user.authScope,
+    })
     const trimmed = user.token?.trim()
     const record: UserRecord<TwistAccount> = { account }
     if (trimmed) record.fallbackToken = trimmed

--- a/src/lib/user-records.ts
+++ b/src/lib/user-records.ts
@@ -1,107 +1,79 @@
 import type { UserRecord, UserRecordStore } from '@doist/cli-core/auth'
 import type { TwistAccount } from './auth-provider.js'
-import { type Config, getConfig, updateConfig } from './config.js'
+import { type StoredUser, getConfig, updateConfig } from './config.js'
 
 /**
- * Adapt twist's current flat config fields (`authUserId` / `authUserName` /
- * `authMode` / `authScope` / `token`) into cli-core's `UserRecordStore`
- * interface. Single-user today: `list()` returns at most one record, derived
- * from those fields; `upsert` and `remove` write or strip them. The shape
- * stays exactly as it is on disk — no v1→v2 migration here.
+ * v2 adapter — reads/writes the `users[]` array in `config.json`. Multi-account
+ * capable: `list()` returns one `UserRecord<TwistAccount>` per stored user;
+ * `upsert` replaces or appends keyed by `account.id`; `setDefaultId` writes
+ * `defaultUserId`. `migrateLegacyAuth` (see `migrate-auth.ts`) is responsible
+ * for promoting v1 flat fields into this shape on first run.
  *
- * `token` is surfaced as `fallbackToken` (cli-core's name for the plaintext
- * copy persisted when the OS keyring is unreachable at write time).
- *
- * Legacy `tw auth token` users have no `authUserId` but do have `authMode`
- * (and usually a `token`); `buildRecords` synthesises a record with
- * `account.id = ''` for them so PR β's `KeyringTokenStore` can still find
- * and read their keyring entry instead of treating them as logged-out.
+ * `token` on a `StoredUser` is surfaced as `fallbackToken` (cli-core's name
+ * for the plaintext copy persisted only when the keyring is unreachable at
+ * write time).
  */
 export function createTwistUserRecordStore(): UserRecordStore<TwistAccount> {
     return {
         async list() {
-            return buildRecords(await getConfig())
+            const config = await getConfig()
+            return (config.users ?? []).map(toRecord)
         },
         async upsert(record) {
-            await updateConfig(applyUpsert(record))
+            const config = await getConfig()
+            const existing = config.users ?? []
+            const next = fromRecord(record)
+            const index = existing.findIndex((u) => u.id === record.account.id)
+            const users =
+                index >= 0
+                    ? [...existing.slice(0, index), next, ...existing.slice(index + 1)]
+                    : [...existing, next]
+            await updateConfig({ users })
         },
         async remove(id) {
             const config = await getConfig()
-            const next = applyRemove(config, id)
-            if (next === config) return
-            await updateConfig(next)
+            const existing = config.users ?? []
+            const index = existing.findIndex((u) => u.id === id)
+            if (index < 0) return
+            const users = [...existing.slice(0, index), ...existing.slice(index + 1)]
+            const updates: { users: StoredUser[]; defaultUserId?: undefined } = { users }
+            if (config.defaultUserId === id) updates.defaultUserId = undefined
+            await updateConfig(updates)
         },
         async getDefaultId() {
-            const [record] = buildRecords(await getConfig())
-            return record ? record.account.id : null
+            const config = await getConfig()
+            return config.defaultUserId ?? null
         },
         async setDefaultId(id) {
-            const config = await getConfig()
-            const next = applySetDefault(config, id)
-            if (next === config) return
-            await updateConfig(next)
+            await updateConfig({ defaultUserId: id ?? undefined })
         },
     }
 }
 
-function buildRecords(config: Config): UserRecord<TwistAccount>[] {
-    // Truly empty: no identity AND no auth metadata AND no plaintext token.
-    if (
-        config.authUserId === undefined &&
-        config.authMode === undefined &&
-        config.token === undefined
-    ) {
-        return []
-    }
+function toRecord(user: StoredUser): UserRecord<TwistAccount> {
     const account: TwistAccount = {
-        id: config.authUserId !== undefined ? String(config.authUserId) : '',
-        label: config.authUserName ?? '',
-        authMode: config.authMode ?? 'unknown',
-        authScope: config.authScope ?? '',
+        id: user.id,
+        label: user.name,
+        authMode: user.authMode ?? 'unknown',
+        authScope: user.authScope ?? '',
     }
+    const trimmed = user.token?.trim()
     const record: UserRecord<TwistAccount> = { account }
-    const trimmed = config.token?.trim()
     if (trimmed) record.fallbackToken = trimmed
-    return [record]
+    return record
 }
 
-function applyUpsert(record: UserRecord<TwistAccount>): Partial<Config> {
-    const userId = Number(record.account.id)
+function fromRecord(record: UserRecord<TwistAccount>): StoredUser {
+    // REPLACE semantics (cli-core contract): absent / blank `fallbackToken`
+    // strips the plaintext slot so a stale token can't survive a fresh
+    // keyring-backed write.
     const trimmed = record.fallbackToken?.trim()
-    return {
-        // Empty / non-numeric account.id (the legacy token-only case) writes
-        // `undefined` so the key drops from disk on serialisation; numeric
-        // ids round-trip as `number`.
-        authUserId: Number.isFinite(userId) && userId > 0 ? userId : undefined,
-        authUserName: record.account.label,
+    const next: StoredUser = {
+        id: record.account.id,
+        name: record.account.label,
         authMode: record.account.authMode,
         authScope: record.account.authScope,
-        // REPLACE semantics: absent / blank `fallbackToken` clears the slot.
-        token: trimmed && trimmed.length > 0 ? trimmed : undefined,
     }
-}
-
-function applyRemove(config: Config, id: string): Config | Partial<Config> {
-    const records = buildRecords(config)
-    if (records.length === 0 || records[0].account.id !== id) return config
-    return {
-        authUserId: undefined,
-        authUserName: undefined,
-        authMode: undefined,
-        authScope: undefined,
-        token: undefined,
-    }
-}
-
-function applySetDefault(config: Config, id: string | null): Config | Partial<Config> {
-    // Single-user adapter can't represent "stored but not default"; the only
-    // meaningful default is the one identity already on disk, so both
-    // `setDefaultId(null)` and `setDefaultId(<x>)` on an empty config are
-    // no-ops (the matching-id path is also a no-op because the record is
-    // already the default by virtue of being the only one).
-    if (id === null) return config
-    const records = buildRecords(config)
-    if (records.length === 0) return config
-    if (records[0].account.id !== id) return config
-    return config
+    if (trimmed && trimmed.length > 0) next.token = trimmed
+    return next
 }

--- a/src/postinstall.test.ts
+++ b/src/postinstall.test.ts
@@ -4,6 +4,10 @@ vi.mock('./lib/skills/update-installed.js', () => ({
     updateAllInstalledSkills: vi.fn().mockResolvedValue({ updated: [], skipped: [], errors: [] }),
 }))
 
+vi.mock('./lib/migrate-auth.js', () => ({
+    runMigrateLegacyAuth: vi.fn().mockResolvedValue({ status: 'no-legacy-state' }),
+}))
+
 describe('postinstall', () => {
     beforeEach(() => {
         vi.resetModules()
@@ -15,9 +19,21 @@ describe('postinstall', () => {
         expect(updateAllInstalledSkills).toHaveBeenCalledWith({ local: false })
     })
 
-    it('swallows errors', async () => {
+    it('swallows errors from updateAllInstalledSkills', async () => {
         const { updateAllInstalledSkills } = await import('./lib/skills/update-installed.js')
         vi.mocked(updateAllInstalledSkills).mockRejectedValueOnce(new Error('fail'))
+        await expect(import('./postinstall.js')).resolves.not.toThrow()
+    })
+
+    it('invokes runMigrateLegacyAuth({ silent: true }) on import', async () => {
+        const { runMigrateLegacyAuth } = await import('./lib/migrate-auth.js')
+        await import('./postinstall.js')
+        expect(runMigrateLegacyAuth).toHaveBeenCalledWith({ silent: true })
+    })
+
+    it('swallows errors from runMigrateLegacyAuth so a broken migration never blocks npm install', async () => {
+        const { runMigrateLegacyAuth } = await import('./lib/migrate-auth.js')
+        vi.mocked(runMigrateLegacyAuth).mockRejectedValueOnce(new Error('migration boom'))
         await expect(import('./postinstall.js')).resolves.not.toThrow()
     })
 })

--- a/src/postinstall.test.ts
+++ b/src/postinstall.test.ts
@@ -31,7 +31,7 @@ describe('postinstall', () => {
         expect(runMigrateLegacyAuth).toHaveBeenCalledWith({ silent: true })
     })
 
-    it('swallows errors from runMigrateLegacyAuth so a broken migration never blocks npm install', async () => {
+    it('swallows errors from runMigrateLegacyAuth so it never blocks npm install', async () => {
         const { runMigrateLegacyAuth } = await import('./lib/migrate-auth.js')
         vi.mocked(runMigrateLegacyAuth).mockRejectedValueOnce(new Error('migration boom'))
         await expect(import('./postinstall.js')).resolves.not.toThrow()

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,8 +1,7 @@
 import { runMigrateLegacyAuth } from './lib/migrate-auth.js'
 import { updateAllInstalledSkills } from './lib/skills/update-installed.js'
 
-// Each runs independently — failures must not break `npm install`. The lazy
-// fallback inside `createTwistTokenStore` covers users who installed with
-// `--ignore-scripts` or whose postinstall silently failed.
+// Failures must not break `npm install`. `createTwistTokenStore` re-runs the
+// migration lazily for users who installed with `--ignore-scripts`.
 updateAllInstalledSkills({ local: false }).catch(() => {})
 runMigrateLegacyAuth({ silent: true }).catch(() => {})

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,3 +1,8 @@
+import { runMigrateLegacyAuth } from './lib/migrate-auth.js'
 import { updateAllInstalledSkills } from './lib/skills/update-installed.js'
 
+// Each runs independently — failures must not break `npm install`. The lazy
+// fallback inside `createTwistTokenStore` covers users who installed with
+// `--ignore-scripts` or whose postinstall silently failed.
 updateAllInstalledSkills({ local: false }).catch(() => {})
+runMigrateLegacyAuth({ silent: true }).catch(() => {})


### PR DESCRIPTION
## Summary

Moves twist's on-disk auth state from flat scalar fields (`authUserId` / `authUserName` / `authMode` / `authScope` / `token`) into a versioned `users[]` array, transparently for existing installs.

Single-account installs look identical to the user after upgrade — same `tw auth status`, same workflows. The runtime is now multi-account capable internally (`tw auth login` twice creates two records); user-facing commands to manage stored accounts will follow separately.

## What's in

- **Schema v2** in `config.ts`: `CONFIG_VERSION = 2`, `StoredUser` type, `users[]` / `defaultUserId` / `config_version` fields + `validateConfigForDoctor` coverage
- **`UserRecordStore` rewrite** over `users[]` (true multi-record `list` / `upsert` / `remove`; `setDefaultId` persists; removal unpins the default)
- **Drop the `accountForUser='api-token'` override** — cli-core's default `user-${id}` slug is used; `migrateLegacyAuth` handles the in-place move from the old single-account slot
- **New `migrate-auth.ts`** wrapping cli-core's `migrateLegacyAuth` with twist callbacks (`hasMigrated` / `markMigrated` via `config_version` ≥ 2; `identifyAccount` via a raw `TwistApi` so migration sits outside the runtime auth graph; cleanup of v1 flat fields)
- **Postinstall hook** invokes migration silently; `createTwistTokenStore` also runs a memoised lazy `ensureMigrated()` so `--ignore-scripts` installs migrate on first CLI invocation
- **Offline-upgrade safety** — when `migrateLegacyAuth` can't complete (e.g. offline `identifyAccount`):
  - `active()` falls back to the legacy keyring slot + plaintext `config.token`, honouring `--user <ref>` against the synthetic account so it can't accidentally resolve to a different user
  - `set()` / `clear()` first discharge the legacy state on disk so manual `tw auth token <new>` / `tw auth logout` aren't shadowed by a stale v1 token on the next read
  - `getAuthMetadata` falls back to the v1 flat fields so a legacy `read-only` token still triggers `ensureWriteAllowed`'s local guard
  - `getActiveTokenSource` reports `'config-file'` when the legacy plaintext slot is still on disk, so doctor / config-view surfaces the security-relevant state
- **Shared helpers** in `auth-constants.ts` (`SECURE_STORE_SERVICE`, `LEGACY_KEYRING_ACCOUNT`) and `twist-account.ts` (`makeTwistAccount` / `toTwistAccount`) so the OAuth, migration, user-records, and legacy-fallback paths can't drift on account shape or storage slugs

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 622/622 pass
- [x] `npm run build`
- [x] Manual upgrade smoke: v1 install (token in `twist-cli` / `api-token` keyring slot, flat fields in `config.json`) → run `npm install` → `tw auth status` still authenticates; `config.json` now has `config_version: 2`, `users: [...]`, `defaultUserId: '<id>'`; legacy keyring slot empty; new `twist-cli` / `user-<id>` slot has the token
- [ ] Manual `--ignore-scripts` path: skip postinstall, run `tw auth status` — lazy fallback migrates on first invocation
- [x] Manual idempotence: re-run `tw auth status` — `hasMigrated()` short-circuits, no work happens
- [x] macOS keyring inspection: `security find-generic-password -s twist-cli -a user-<id>` ✓; `security find-generic-password -s twist-cli -a api-token` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)