### PR TITLE
feat(auth): adopt cli-core createDcrProvider for OAuth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,14 @@
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@doist/cli-core": "0.16.1",
+                "@doist/cli-core": "0.20.0",
                 "@doist/twist-sdk": "2.7.0",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
                 "marked": "18.0.3",
                 "marked-terminal-renderer": "2.2.0",
+                "oauth4webapi": "3.8.6",
                 "open": "11.0.0"
             },
             "bin": {
@@ -137,9 +138,9 @@
             }
         },
         "node_modules/@doist/cli-core": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.16.1.tgz",
-            "integrity": "sha512-OoHWYM8Rv+eoPhVR1BUMwFIejZGk5Wyxheva4Cp9x3zTh4RURE+OIJ03G95oBegbXCA2O9LRtZZ9Ww0D6vU1dQ==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.20.0.tgz",
+            "integrity": "sha512-18Mh68yoVND+kKKtFHggEqR+eLqA9gl5jSUOFE0uqjbHBzOAb6VBzwvYVocceZaVRxF3j/Pu+Rbkpwta5Lkvww==",
             "license": "MIT",
             "dependencies": {
                 "chalk": "5.6.2",
@@ -155,6 +156,7 @@
                 "commander": ">=14",
                 "marked": ">=18",
                 "marked-terminal-renderer": ">=2",
+                "oauth4webapi": ">=3",
                 "open": ">=10",
                 "vitest": ">=4.1"
             },
@@ -166,6 +168,9 @@
                     "optional": true
                 },
                 "marked-terminal-renderer": {
+                    "optional": true
+                },
+                "oauth4webapi": {
                     "optional": true
                 },
                 "open": {
@@ -8083,6 +8088,15 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/oauth4webapi": {
+            "version": "3.8.6",
+            "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+            "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
             }
         },
         "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -50,13 +50,14 @@
         "CHANGELOG.md"
     ],
     "dependencies": {
-        "@doist/cli-core": "0.16.1",
+        "@doist/cli-core": "0.20.0",
         "@doist/twist-sdk": "2.7.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",
         "marked": "18.0.3",
         "marked-terminal-renderer": "2.2.0",
+        "oauth4webapi": "3.8.6",
         "open": "11.0.0"
     },
     "devDependencies": {

--- a/src/commands/auth/auth.test.ts
+++ b/src/commands/auth/auth.test.ts
@@ -437,6 +437,10 @@ describe('auth command', () => {
                     return [{ account: SNAPSHOT_ACCOUNT, isDefault: true }]
                 },
                 async setDefault() {},
+                async setBundle() {},
+                async activeBundle() {
+                    return { account: SNAPSHOT_ACCOUNT, bundle: { accessToken: 'snapshot_token' } }
+                },
                 getLastStorageResult: () => undefined,
                 getLastClearResult: () => undefined,
             }
@@ -535,6 +539,10 @@ describe('auth command', () => {
                     return []
                 },
                 async setDefault() {},
+                async setBundle() {},
+                async activeBundle() {
+                    return null
+                },
                 getLastStorageResult: () => undefined,
                 getLastClearResult: () => undefined,
             }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -4,7 +4,7 @@ import type { Command } from 'commander'
 import { renderError, renderSuccess } from '../../lib/auth-pages.js'
 import {
     createTwistAuthProvider,
-    scopesForReadOnly,
+    getScopes,
     type TwistTokenStore,
 } from '../../lib/auth-provider.js'
 import { logTokenStorageResult } from './helpers.js'
@@ -18,7 +18,7 @@ export function attachTwistLoginCommand(parent: Command, store: TwistTokenStore)
         provider,
         store,
         preferredPort: PREFERRED_CALLBACK_PORT,
-        resolveScopes: ({ readOnly }) => scopesForReadOnly(readOnly),
+        resolveScopes: ({ readOnly }) => getScopes(readOnly),
         renderSuccess,
         renderError,
         onSuccess({ view, account }) {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -4,8 +4,7 @@ import type { Command } from 'commander'
 import { renderError, renderSuccess } from '../../lib/auth-pages.js'
 import {
     createTwistAuthProvider,
-    READ_ONLY_SCOPES,
-    READ_WRITE_SCOPES,
+    scopesForReadOnly,
     type TwistTokenStore,
 } from '../../lib/auth-provider.js'
 import { logTokenStorageResult } from './helpers.js'
@@ -19,7 +18,7 @@ export function attachTwistLoginCommand(parent: Command, store: TwistTokenStore)
         provider,
         store,
         preferredPort: PREFERRED_CALLBACK_PORT,
-        resolveScopes: ({ readOnly }) => (readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES),
+        resolveScopes: ({ readOnly }) => scopesForReadOnly(readOnly),
         renderSuccess,
         renderError,
         onSuccess({ view, account }) {

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -56,16 +56,12 @@ vi.mock('./config.js', async (importOriginal) => {
 
 import { createWrappedTwistClient } from './api.js'
 import {
-    AUTHORIZATION_URL,
     createTwistAuthProvider,
     matchTwistAccount,
     READ_ONLY_SCOPES,
     READ_WRITE_SCOPES,
-    REGISTRATION_URL,
-    TOKEN_URL,
 } from './auth-provider.js'
 
-const REDIRECT_URI = 'http://127.0.0.1:8766/callback'
 const mockCreateClient = vi.mocked(createWrappedTwistClient)
 const TOKEN_ENV_VAR = 'TWIST_API_TOKEN'
 
@@ -89,8 +85,6 @@ const LEGACY_CONFIG = {
     authScope: 'user:read',
 }
 
-const json = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status })
-
 /** Reset the module-level migration memo for each test by re-importing. */
 async function loadCreateTwistTokenStore(): Promise<
     typeof import('./auth-provider.js').createTwistTokenStore
@@ -101,129 +95,23 @@ async function loadCreateTwistTokenStore(): Promise<
 }
 
 describe('createTwistAuthProvider', () => {
-    let fetchSpy: ReturnType<typeof vi.spyOn>
-    beforeEach(() => {
-        fetchSpy = vi.spyOn(globalThis, 'fetch')
-    })
     afterEach(() => {
         vi.restoreAllMocks()
     })
 
-    it('prepare POSTs the DCR payload and surfaces clientId/clientSecret on the handshake', async () => {
-        fetchSpy.mockResolvedValue(json({ client_id: 'twd_abc', client_secret: 'shh' }))
-
-        const result = await createTwistAuthProvider().prepare!({
-            redirectUri: REDIRECT_URI,
-            flags: {},
-        })
-
-        const [url, init] = fetchSpy.mock.calls[0]
-        expect(url).toBe(REGISTRATION_URL)
-        expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
-            client_name: 'Twist CLI',
-            redirect_uris: [REDIRECT_URI],
-            token_endpoint_auth_method: 'client_secret_basic',
-        })
-        expect(result.handshake).toEqual({ clientId: 'twd_abc', clientSecret: 'shh' })
-    })
-
-    it('prepare rewraps fetch rejections + bad responses as AUTH_FAILED', async () => {
-        const provider = createTwistAuthProvider()
-        const ctx = { redirectUri: REDIRECT_URI, flags: {} }
-
-        fetchSpy.mockRejectedValueOnce(new TypeError('fetch failed'))
-        await expect(provider.prepare!(ctx)).rejects.toMatchObject({ code: 'AUTH_FAILED' })
-
-        fetchSpy.mockResolvedValueOnce(new Response('boom', { status: 500 }))
-        await expect(provider.prepare!(ctx)).rejects.toMatchObject({ code: 'AUTH_FAILED' })
-
-        fetchSpy.mockResolvedValueOnce(json({ client_id: 'only' }))
-        await expect(provider.prepare!(ctx)).rejects.toMatchObject({ code: 'AUTH_FAILED' })
-    })
-
-    it('authorize builds the twist URL with PKCE params and threads verifier + authMode forward', async () => {
-        const result = await createTwistAuthProvider().authorize({
-            redirectUri: REDIRECT_URI,
-            state: 'state-xyz',
-            scopes: READ_WRITE_SCOPES,
-            readOnly: false,
-            flags: {},
-            handshake: { clientId: 'twd_abc', clientSecret: 'shh' },
-        })
-
-        const url = new URL(result.authorizeUrl)
-        expect(result.authorizeUrl.startsWith(AUTHORIZATION_URL)).toBe(true)
-        expect(url.searchParams.get('client_id')).toBe('twd_abc')
-        expect(url.searchParams.get('code_challenge_method')).toBe('S256')
-        expect(url.searchParams.get('code_challenge')).toBeTruthy()
-        expect(url.searchParams.get('scope')).toBe(READ_WRITE_SCOPES.join(' '))
-
-        const hs = result.handshake as Record<string, unknown>
-        expect((hs.codeVerifier as string).length).toBeGreaterThan(40)
-        expect(hs.authMode).toBe('read-write')
-    })
-
-    it('authorize marks authMode read-only when readOnly is true', async () => {
-        const result = await createTwistAuthProvider().authorize({
-            redirectUri: REDIRECT_URI,
-            state: 's',
-            scopes: READ_ONLY_SCOPES,
-            readOnly: true,
-            flags: {},
-            handshake: { clientId: 'c', clientSecret: 's' },
-        })
-        expect((result.handshake as Record<string, unknown>).authMode).toBe('read-only')
-    })
-
-    it('exchangeCode POSTs to the token endpoint with HTTP Basic auth and the PKCE verifier', async () => {
-        fetchSpy.mockResolvedValue(json({ access_token: 'tk_123' }))
-
-        const result = await createTwistAuthProvider().exchangeCode({
-            code: 'auth-code',
-            state: 's',
-            redirectUri: REDIRECT_URI,
-            handshake: { clientId: 'twd_abc', clientSecret: 'shh', codeVerifier: 'verif-1' },
-        })
-
-        expect(result).toEqual({ accessToken: 'tk_123' })
-        const [url, init] = fetchSpy.mock.calls[0]
-        expect(url).toBe(TOKEN_URL)
-        const headers = (init as RequestInit).headers as Record<string, string>
-        expect(headers.Authorization).toBe(`Basic ${Buffer.from('twd_abc:shh').toString('base64')}`)
-        const body = new URLSearchParams((init as RequestInit).body as string)
-        expect(body.get('code')).toBe('auth-code')
-        expect(body.get('code_verifier')).toBe('verif-1')
-    })
-
-    it('exchangeCode rewraps fetch rejections, bad responses, and missing-verifier as AUTH_FAILED', async () => {
-        const provider = createTwistAuthProvider()
-        const goodHs = { clientId: 'a', clientSecret: 'b', codeVerifier: 'v' }
-        const base = { code: 'c', state: 's', redirectUri: REDIRECT_URI }
-
-        fetchSpy.mockRejectedValueOnce(new TypeError('fetch failed'))
-        await expect(provider.exchangeCode({ ...base, handshake: goodHs })).rejects.toMatchObject({
-            code: 'AUTH_FAILED',
-        })
-
-        fetchSpy.mockResolvedValueOnce(new Response('nope', { status: 400 }))
-        await expect(provider.exchangeCode({ ...base, handshake: goodHs })).rejects.toMatchObject({
-            code: 'AUTH_FAILED',
-        })
-
-        // Guard: missing verifier means authorize() was never run — never hits fetch.
-        await expect(
-            provider.exchangeCode({ ...base, handshake: { clientId: 'a', clientSecret: 'b' } }),
-        ).rejects.toMatchObject({ code: 'AUTH_FAILED' })
-    })
-
-    it('validateToken fetches getSessionUser with the new token and returns a narrow TwistAccount', async () => {
+    // Registration / authorize / token-exchange mechanics now live in cli-core's
+    // createDcrProvider (covered by its own suite). The only twist-specific
+    // behaviour is `validate`: probe getSessionUser, then derive authMode +
+    // authScope from the folded `readOnly` (the scope set is a pure function of
+    // it — see resolveScopes in login.ts).
+    it('validate builds a TwistAccount, deriving read-write mode + scopes from the handshake', async () => {
         mockCreateClient.mockReturnValue({
             users: { getSessionUser: vi.fn().mockResolvedValue({ id: 42, name: 'Ada' }) },
         } as unknown as ReturnType<typeof createWrappedTwistClient>)
 
-        const account = await createTwistAuthProvider().validateToken({
+        const account = await createTwistAuthProvider().validateToken!({
             token: 'tk_new',
-            handshake: { authMode: 'read-write', authScope: 'user:read' },
+            handshake: { readOnly: false },
         })
 
         expect(mockCreateClient).toHaveBeenCalledWith('tk_new')
@@ -231,8 +119,22 @@ describe('createTwistAuthProvider', () => {
             id: '42',
             label: 'Ada',
             authMode: 'read-write',
-            authScope: 'user:read',
+            authScope: READ_WRITE_SCOPES.join(' '),
         })
+    })
+
+    it('validate derives read-only mode + scopes when the handshake carries readOnly', async () => {
+        mockCreateClient.mockReturnValue({
+            users: { getSessionUser: vi.fn().mockResolvedValue({ id: 7, name: 'Lin' }) },
+        } as unknown as ReturnType<typeof createWrappedTwistClient>)
+
+        const account = await createTwistAuthProvider().validateToken!({
+            token: 'tk_ro',
+            handshake: { readOnly: true },
+        })
+
+        expect(account.authMode).toBe('read-only')
+        expect(account.authScope).toBe(READ_ONLY_SCOPES.join(' '))
     })
 })
 

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -11,10 +11,12 @@ vi.mock('./migrate-auth.js', () => migrateMocks)
 const keyringMocks = vi.hoisted(() => ({
     createKeyringTokenStore: vi.fn(),
     createSecureStore: vi.fn(),
+    createDcrProvider: vi.fn(),
     secureStoreGetSecret: vi.fn(),
     secureStoreDeleteSecret: vi.fn(),
     inner: {
         active: vi.fn(),
+        activeBundle: vi.fn(),
         set: vi.fn(),
         clear: vi.fn(),
         list: vi.fn(),
@@ -32,10 +34,16 @@ vi.mock('@doist/cli-core/auth', async (importOriginal) => {
         setSecret: vi.fn(),
         deleteSecret: keyringMocks.secureStoreDeleteSecret,
     }))
+    // Delegate to the real factory so the returned provider works, while
+    // capturing the options createTwistAuthProvider passes (asserted below).
+    keyringMocks.createDcrProvider.mockImplementation((options) =>
+        actual.createDcrProvider(options),
+    )
     return {
         ...actual,
         createKeyringTokenStore: keyringMocks.createKeyringTokenStore,
         createSecureStore: keyringMocks.createSecureStore,
+        createDcrProvider: keyringMocks.createDcrProvider,
     }
 })
 
@@ -95,8 +103,16 @@ async function loadCreateTwistTokenStore(): Promise<
 }
 
 describe('createTwistAuthProvider', () => {
+    // clearAllMocks (not restoreAllMocks) so the createDcrProvider delegating
+    // implementation set in the module mock survives between tests.
     afterEach(() => {
-        vi.restoreAllMocks()
+        vi.clearAllMocks()
+    })
+
+    it('registers with client_secret_post so underscore client_ids survive token-endpoint auth', () => {
+        createTwistAuthProvider()
+        const options = keyringMocks.createDcrProvider.mock.calls.at(-1)?.[0]
+        expect(options.clientMetadata.tokenEndpointAuthMethod).toBe('client_secret_post')
     })
 
     // Registration / authorize / token-exchange mechanics now live in cli-core's
@@ -136,6 +152,13 @@ describe('createTwistAuthProvider', () => {
         expect(account.authMode).toBe('read-only')
         expect(account.authScope).toBe(READ_ONLY_SCOPES.join(' '))
     })
+
+    it('validate fails closed (AUTH_FAILED) when the handshake has no boolean readOnly flag', async () => {
+        // Guards ensureWriteAllowed: a missing flag must not silently become read-write.
+        await expect(
+            createTwistAuthProvider().validateToken!({ token: 'tk', handshake: {} }),
+        ).rejects.toMatchObject({ code: 'AUTH_FAILED' })
+    })
 })
 
 describe('createTwistTokenStore', () => {
@@ -145,6 +168,7 @@ describe('createTwistTokenStore', () => {
         keyringMocks.secureStoreGetSecret.mockReset().mockResolvedValue(null)
         keyringMocks.secureStoreDeleteSecret.mockReset().mockResolvedValue(true)
         keyringMocks.inner.active.mockReset()
+        keyringMocks.inner.activeBundle.mockReset().mockResolvedValue(null)
         keyringMocks.inner.set.mockReset().mockResolvedValue(undefined)
         keyringMocks.inner.clear.mockReset().mockResolvedValue(undefined)
         keyringMocks.inner.list.mockReset().mockResolvedValue([])
@@ -184,6 +208,36 @@ describe('createTwistTokenStore', () => {
         })
         expect(keyringMocks.inner.active).not.toHaveBeenCalled()
         expect(migrateMocks.runMigrateLegacyAuth).not.toHaveBeenCalled()
+    })
+
+    // cli-core's auth commands read the live credential via activeBundle(), so it
+    // must apply the same env-token + legacy overrides as active() — otherwise
+    // `tw auth status` mis-reports env-token / migration-pending users.
+    it('activeBundle() short-circuits to TWIST_API_TOKEN, wrapped as a bundle', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().activeBundle()
+
+        expect(snapshot).toEqual({
+            account: { id: '', label: '', authMode: 'unknown', authScope: '' },
+            bundle: { accessToken: 'env_token_value' },
+        })
+        expect(keyringMocks.inner.activeBundle).not.toHaveBeenCalled()
+    })
+
+    it('activeBundle() delegates to the v2 store when migration is conclusive', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue({ status: 'no-legacy-state' })
+        keyringMocks.inner.activeBundle.mockResolvedValue({
+            account: STORED_ACCOUNT,
+            bundle: { accessToken: 'tk_v2' },
+        })
+        const createTwistTokenStore = await loadCreateTwistTokenStore()
+
+        const snapshot = await createTwistTokenStore().activeBundle('42')
+
+        expect(snapshot).toEqual({ account: STORED_ACCOUNT, bundle: { accessToken: 'tk_v2' } })
+        expect(keyringMocks.inner.activeBundle).toHaveBeenCalledWith('42')
     })
 
     it('active() ignores TWIST_API_TOKEN when an explicit --user ref targets a stored account', async () => {

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -2,10 +2,9 @@ import {
     type AccountRef,
     type AuthAccount,
     type AuthProvider,
+    createDcrProvider,
     createKeyringTokenStore,
     createSecureStore,
-    deriveChallenge,
-    generateVerifier,
     type KeyringTokenStore,
     type MigrateAuthResult,
 } from '@doist/cli-core/auth'
@@ -76,192 +75,47 @@ export type TwistAccount = AuthAccount & {
 
 export type TwistTokenStore = KeyringTokenStore<TwistAccount>
 
-type TwistHandshake = Record<string, unknown> & {
-    clientId: string
-    clientSecret: string
-    codeVerifier?: string
-    authMode?: AuthMode
-    authScope?: string
-}
-
-function asHandshake(value: Record<string, unknown>): TwistHandshake {
-    return value as TwistHandshake
-}
-
-function authFailed(message: string, cause?: unknown): CliError {
-    const detail = cause instanceof Error && cause.message ? `: ${cause.message}` : ''
-    return new CliError('AUTH_FAILED', `${message}${detail}`, AUTH_HINTS)
-}
-
-async function registerDynamicClient(
-    redirectUri: string,
-): Promise<{ clientId: string; clientSecret: string }> {
-    let response: Response
-    try {
-        response = await fetch(REGISTRATION_URL, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-            body: JSON.stringify({
-                client_name: 'Twist CLI',
-                client_uri: 'https://github.com/doist/twist-cli',
-                redirect_uris: [redirectUri],
-                grant_types: ['authorization_code'],
-                response_types: ['code'],
-                token_endpoint_auth_method: 'client_secret_basic',
-                application_type: 'native',
-                logo_uri: LOGO_URI,
-            }),
-        })
-    } catch (error) {
-        if (error instanceof CliError) throw error
-        throw authFailed('Failed to register OAuth client', error)
-    }
-
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => '')
-        throw new CliError(
-            'AUTH_FAILED',
-            `Client registration failed: ${response.status} ${response.statusText} - ${errorText}`,
-            AUTH_HINTS,
-        )
-    }
-
-    let result: { client_id?: string; client_secret?: string }
-    try {
-        result = (await response.json()) as { client_id?: string; client_secret?: string }
-    } catch (error) {
-        throw authFailed('Invalid client registration response', error)
-    }
-
-    if (!result.client_id || !result.client_secret) {
-        throw new CliError(
-            'AUTH_FAILED',
-            'Invalid client registration response: missing client_id or client_secret',
-            AUTH_HINTS,
-        )
-    }
-
-    return { clientId: result.client_id, clientSecret: result.client_secret }
-}
-
+/**
+ * Twist's OAuth flow uses RFC 7591 Dynamic Client Registration: each login
+ * mints a fresh `client_id` / `client_secret`, then runs the standard PKCE
+ * authorize + token exchange (HTTP Basic auth on the token endpoint). cli-core's
+ * `createDcrProvider` drives all of that via `oauth4webapi`; the only
+ * twist-specific piece is `validate`, which probes `getSessionUser` and records
+ * the auth mode/scope the login was granted.
+ *
+ * `authMode` / `authScope` are derived from `handshake.readOnly` (folded in by
+ * `runOAuthFlow`) rather than threaded through `authorize`, because the scope
+ * set is itself a pure function of `readOnly` (see `resolveScopes` in login.ts).
+ */
 export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
-    return {
-        async prepare({ redirectUri }) {
-            const { clientId, clientSecret } = await registerDynamicClient(redirectUri)
-            const handshake: TwistHandshake = { clientId, clientSecret }
-            return { handshake }
+    return createDcrProvider<TwistAccount>({
+        registrationUrl: REGISTRATION_URL,
+        authorizeUrl: AUTHORIZATION_URL,
+        tokenUrl: TOKEN_URL,
+        clientMetadata: {
+            clientName: 'Twist CLI',
+            clientUri: 'https://github.com/doist/twist-cli',
+            logoUri: LOGO_URI,
+            applicationType: 'native',
+            // Twist client_ids contain `_` (e.g. `twd_…`). oauth4webapi's
+            // `client_secret_basic` form-url-encodes the Basic credential per
+            // RFC 6749 §2.3.1 (`_` → `%5F`), and Twist's token endpoint doesn't
+            // url-decode it, so the lookup fails with "client_id not found".
+            // `client_secret_post` sends the credential in the body via
+            // URLSearchParams, which preserves `_`, sidestepping the mismatch.
+            tokenEndpointAuthMethod: 'client_secret_post',
         },
-
-        async authorize({ redirectUri, state, scopes, readOnly, handshake }) {
-            const hs = asHandshake(handshake)
-            const codeVerifier = generateVerifier()
-            const codeChallenge = deriveChallenge(codeVerifier)
-            const authMode: AuthMode = readOnly ? 'read-only' : 'read-write'
-            const authScope = scopes.join(' ')
-
-            const params = new URLSearchParams({
-                client_id: hs.clientId,
-                response_type: 'code',
-                redirect_uri: redirectUri,
-                scope: authScope,
-                state,
-                code_challenge: codeChallenge,
-                code_challenge_method: 'S256',
-            })
-
-            const nextHandshake: TwistHandshake = {
-                ...hs,
-                codeVerifier,
-                authMode,
-                authScope,
-            }
-            return {
-                authorizeUrl: `${AUTHORIZATION_URL}?${params.toString()}`,
-                handshake: nextHandshake,
-            }
-        },
-
-        async exchangeCode({ code, redirectUri, handshake }) {
-            const hs = asHandshake(handshake)
-            if (!hs.codeVerifier) {
-                throw new CliError(
-                    'AUTH_FAILED',
-                    'Missing PKCE code verifier from authorize step',
-                    AUTH_HINTS,
-                )
-            }
-
-            const body = new URLSearchParams({
-                grant_type: 'authorization_code',
-                code,
-                redirect_uri: redirectUri,
-                code_verifier: hs.codeVerifier,
-            })
-
-            const credentials = btoa(`${hs.clientId}:${hs.clientSecret}`)
-
-            let response: Response
-            try {
-                response = await fetch(TOKEN_URL, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                        Accept: 'application/json',
-                        Authorization: `Basic ${credentials}`,
-                    },
-                    body: body.toString(),
-                })
-            } catch (error) {
-                if (error instanceof CliError) throw error
-                throw authFailed('Failed to exchange code for token', error)
-            }
-
-            if (!response.ok) {
-                const errorText = await response.text().catch(() => '')
-                throw new CliError(
-                    'AUTH_FAILED',
-                    `Token exchange failed: ${response.status} ${response.statusText} - ${errorText}`,
-                    AUTH_HINTS,
-                )
-            }
-
-            let data: {
-                access_token?: string
-                error?: string
-                error_description?: string
-            }
-            try {
-                data = (await response.json()) as typeof data
-            } catch (error) {
-                throw authFailed('Invalid token exchange response', error)
-            }
-
-            if (data.error) {
-                throw new CliError(
-                    'AUTH_FAILED',
-                    `OAuth error: ${data.error} - ${data.error_description ?? 'Unknown error'}`,
-                    AUTH_HINTS,
-                )
-            }
-
-            if (!data.access_token) {
-                throw new CliError(
-                    'AUTH_FAILED',
-                    'No access token received from OAuth server',
-                    AUTH_HINTS,
-                )
-            }
-
-            return { accessToken: data.access_token }
-        },
-
-        async validateToken({ token, handshake }) {
-            const hs = asHandshake(handshake)
+        errorHints: AUTH_HINTS,
+        async validate({ token, handshake }) {
+            const readOnly = Boolean(handshake.readOnly)
             const client = createWrappedTwistClient(token)
             const user = await client.users.getSessionUser()
-            return toTwistAccount(user, { authMode: hs.authMode, authScope: hs.authScope })
+            return toTwistAccount(user, {
+                authMode: readOnly ? 'read-only' : 'read-write',
+                authScope: (readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES).join(' '),
+            })
         },
-    }
+    })
 }
 
 /**

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -60,6 +60,16 @@ export const READ_ONLY_SCOPES = [
 const AUTH_HINTS = ['Try again: tw auth login', 'Or set TWIST_API_TOKEN environment variable']
 
 /**
+ * The scope set a login is granted, as a pure function of `--read-only`. Single
+ * source of truth shared by `attachTwistLoginCommand`'s `resolveScopes` (what we
+ * request at authorize) and the provider's `validate` (what we record on the
+ * account), so the two can't drift.
+ */
+export function scopesForReadOnly(readOnly: boolean): string[] {
+    return readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES
+}
+
+/**
  * Narrow account shape: only fields that round-trip through the local token
  * store. `id` is the stringified numeric Twist user id (so cli-core's
  * `AuthAccount.id` string contract holds), `label` is the user's display
@@ -107,12 +117,23 @@ export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
         },
         errorHints: AUTH_HINTS,
         async validate({ token, handshake }) {
-            const readOnly = Boolean(handshake.readOnly)
+            // `runOAuthFlow` folds a boolean `readOnly` into the handshake.
+            // Fail closed on a missing/malformed value rather than letting
+            // `Boolean(undefined)` silently grant read-write (which would relax
+            // the local `ensureWriteAllowed` guard).
+            const readOnly = handshake.readOnly
+            if (typeof readOnly !== 'boolean') {
+                throw new CliError(
+                    'AUTH_FAILED',
+                    'Internal: auth handshake missing the readOnly flag.',
+                    AUTH_HINTS,
+                )
+            }
             const client = createWrappedTwistClient(token)
             const user = await client.users.getSessionUser()
             return toTwistAccount(user, {
                 authMode: readOnly ? 'read-only' : 'read-write',
-                authScope: (readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES).join(' '),
+                authScope: scopesForReadOnly(readOnly).join(' '),
             })
         },
     })
@@ -239,6 +260,31 @@ export async function findAccountInStore(
     return match.account
 }
 
+/** Synthetic account for an env-token session (no stored identity). */
+const ENV_TOKEN_ACCOUNT: TwistAccount = { id: '', label: '', authMode: 'unknown', authScope: '' }
+
+/**
+ * Resolve the env-token / legacy-snapshot override that takes precedence over
+ * the v2 keyring store, or `null` to defer to it. Shared by the store's
+ * `active()` and `activeBundle()` so the two reads can't diverge.
+ */
+async function resolveOverrideSnapshot(
+    ref?: AccountRef,
+): Promise<{ token: string; account: TwistAccount } | null> {
+    if (ref === undefined) {
+        const envToken = process.env[TOKEN_ENV_VAR]
+        if (envToken) return { token: envToken, account: ENV_TOKEN_ACCOUNT }
+    }
+    const result = await ensureMigrated()
+    if (result === null || !migrationIsConclusive(result)) {
+        const legacy = await readLegacyTokenSnapshot()
+        if (legacy && (ref === undefined || matchTwistAccount(legacy.account, ref))) {
+            return legacy
+        }
+    }
+    return null
+}
+
 /**
  * `TWIST_API_TOKEN` short-circuits `active()` only when no explicit ref is
  * supplied — cli-core's `KeyringTokenStore` doesn't know about the env var,
@@ -266,23 +312,18 @@ export function createTwistTokenStore(): TwistTokenStore {
     }
     return Object.assign(Object.create(inner) as TwistTokenStore, {
         async active(ref?: AccountRef) {
-            if (ref === undefined) {
-                const envToken = process.env[TOKEN_ENV_VAR]
-                if (envToken) {
-                    return {
-                        token: envToken,
-                        account: { id: '', label: '', authMode: 'unknown', authScope: '' },
-                    }
-                }
+            return (await resolveOverrideSnapshot(ref)) ?? inner.active(ref)
+        },
+        // Mirror `active()`: cli-core's auth commands read the live credential
+        // through `activeBundle()` (it carries the refresh slot too), so the
+        // env-token + legacy fallbacks must apply here as well or `tw auth
+        // status` would report no token for those users.
+        async activeBundle(ref?: AccountRef) {
+            const override = await resolveOverrideSnapshot(ref)
+            if (override) {
+                return { account: override.account, bundle: { accessToken: override.token } }
             }
-            const result = await ensureMigrated()
-            if (result === null || !migrationIsConclusive(result)) {
-                const legacy = await readLegacyTokenSnapshot()
-                if (legacy && (ref === undefined || matchTwistAccount(legacy.account, ref))) {
-                    return legacy
-                }
-            }
-            return inner.active(ref)
+            return inner.activeBundle(ref)
         },
         async set(account: TwistAccount, token: string) {
             await maybeDischargeLegacy()

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -65,7 +65,7 @@ const AUTH_HINTS = ['Try again: tw auth login', 'Or set TWIST_API_TOKEN environm
  * request at authorize) and the provider's `validate` (what we record on the
  * account), so the two can't drift.
  */
-export function scopesForReadOnly(readOnly: boolean): string[] {
+export function getScopes(readOnly: boolean): string[] {
     return readOnly ? READ_ONLY_SCOPES : READ_WRITE_SCOPES
 }
 
@@ -133,7 +133,7 @@ export function createTwistAuthProvider(): AuthProvider<TwistAccount> {
             const user = await client.users.getSessionUser()
             return toTwistAccount(user, {
                 authMode: readOnly ? 'read-only' : 'read-write',
-                authScope: scopesForReadOnly(readOnly).join(' '),
+                authScope: getScopes(readOnly).join(' '),
             })
         },
     })


### PR DESCRIPTION
## Summary

- Replaces the bespoke ~170-LOC DCR `AuthProvider` (hand-rolled registration, PKCE authorize, HTTP Basic token exchange) with cli-core's `createDcrProvider`.
- Bumps `@doist/cli-core` `0.16.1 → 0.20.0` and adds `oauth4webapi@3.8.6` as a direct dependency (cli-core's optional peer dep, required by the DCR flow).
- `validate` now derives `authMode` / `authScope` from the `runOAuthFlow`-folded `handshake.readOnly` instead of values stashed during a hand-rolled `authorize` — the scope set is a pure function of `readOnly` (see `resolveScopes` in `login.ts`).
- Net **−221 LOC** in `auth-provider.ts` + tests.

## Why `client_secret_post` (not the default `client_secret_basic`)

Twist client_ids contain `_` (e.g. `twd_…`). oauth4webapi's `client_secret_basic` form-url-encodes the HTTP Basic credential per RFC 6749 §2.3.1, turning `_` into `%5F`. Twist's token endpoint doesn't url-decode the credential, so it looks up `twd%5F…` and returns `404 "Integration with client_id not found"`. `client_secret_post` sends the credential in the request **body** via `URLSearchParams`, which preserves the underscore, so the lookup succeeds. (The old bespoke code worked because it sent the credential raw; Twist accepts raw.)

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 645 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Live `tw auth login` against twist.com — full DCR registration + PKCE + token exchange + persist, verified against published cli-core `0.20.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)