### PR TITLE
fix(users): filter removed members from `tw users` by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "license": "MIT",
             "dependencies": {
                 "@doist/cli-core": "0.24.0",
-                "@doist/twist-sdk": "2.7.0",
+                "@doist/twist-sdk": "2.8.1",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -182,9 +182,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.7.0.tgz",
-            "integrity": "sha512-hcwmmkTDrxwS4/RLTFBlt5O/pLKs+QeL6a7izU8NcPdCqw/GlzRaLbO/Gpl5w+gsEfaUdBQ91ogyKaszxpGggw==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.8.1.tgz",
+            "integrity": "sha512-FfBEI/9EyxPQGHU3SZ7aXW/l5x6Ric+7lcLye5VuNFzS24ws4iDqmKddWks+LF8bQitTjIC03Kbd8aX1AM2ZOQ==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",
@@ -198,10 +198,9 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-            "dev": true,
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -210,10 +209,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-            "dev": true,
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -224,7 +222,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
             "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1036,7 +1033,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
             "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1208,9 +1204,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.126.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-            "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+            "version": "0.132.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+            "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
             "devOptional": true,
             "license": "MIT",
             "funding": {
@@ -1344,6 +1340,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1361,6 +1360,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1378,6 +1380,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1395,6 +1400,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1412,6 +1420,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1429,6 +1440,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1446,6 +1460,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1463,6 +1480,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1667,6 +1687,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1684,6 +1707,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1701,6 +1727,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1718,6 +1747,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1735,6 +1767,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1752,6 +1787,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1769,6 +1807,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1786,6 +1827,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1924,13 +1968,12 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+            "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1941,13 +1984,12 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+            "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1958,13 +2000,12 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+            "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1975,13 +2016,12 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+            "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1992,13 +2032,12 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-            "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+            "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2009,13 +2048,15 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+            "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2026,13 +2067,15 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-            "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+            "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2043,13 +2086,15 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+            "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2060,13 +2105,15 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+            "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2077,13 +2124,15 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-            "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+            "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2094,13 +2143,15 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-            "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+            "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2111,13 +2162,12 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-            "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+            "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2128,18 +2178,17 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-            "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+            "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
             "cpu": [
                 "wasm32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.9.2",
-                "@emnapi/runtime": "1.9.2",
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
                 "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
@@ -2147,13 +2196,12 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-            "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+            "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2164,13 +2212,12 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-            "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+            "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2181,9 +2228,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-            "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -2948,10 +2995,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-            "dev": true,
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2977,9 +3023,9 @@
             "license": "MIT"
         },
         "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -2993,7 +3039,7 @@
             "version": "25.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
             "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
@@ -4565,7 +4611,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -5480,7 +5525,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5501,7 +5545,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5522,7 +5565,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5543,7 +5585,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5564,7 +5605,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5585,7 +5625,9 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5606,7 +5648,9 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5627,7 +5671,9 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5648,7 +5694,9 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5669,7 +5717,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5690,7 +5737,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6075,9 +6121,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "devOptional": true,
             "funding": [
                 {
@@ -8635,9 +8681,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.10",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "devOptional": true,
             "funding": [
                 {
@@ -8655,7 +8701,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -8915,14 +8961,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.16",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-            "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+            "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.126.0",
-                "@rolldown/pluginutils": "1.0.0-rc.16"
+                "@oxc-project/types": "=0.132.0",
+                "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -8931,21 +8977,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+                "@rolldown/binding-android-arm64": "1.0.2",
+                "@rolldown/binding-darwin-arm64": "1.0.2",
+                "@rolldown/binding-darwin-x64": "1.0.2",
+                "@rolldown/binding-freebsd-x64": "1.0.2",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+                "@rolldown/binding-linux-arm64-musl": "1.0.2",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-musl": "1.0.2",
+                "@rolldown/binding-openharmony-arm64": "1.0.2",
+                "@rolldown/binding-wasm32-wasi": "1.0.2",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+                "@rolldown/binding-win32-x64-msvc": "1.0.2"
             }
         },
         "node_modules/run-applescript": {
@@ -10100,7 +10146,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
             "license": "0BSD",
             "optional": true
         },
@@ -10182,7 +10227,7 @@
             "version": "7.24.6",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
             "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/unicode-emoji-modifier-base": {
@@ -10300,16 +10345,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-            "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+            "version": "8.0.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+            "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.10",
-                "rolldown": "1.0.0-rc.16",
+                "postcss": "^8.5.15",
+                "rolldown": "1.0.2",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {
@@ -10326,7 +10371,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.0",
+                "@vitejs/devtools": "^0.1.18",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ],
     "dependencies": {
         "@doist/cli-core": "0.24.0",
-        "@doist/twist-sdk": "2.7.0",
+        "@doist/twist-sdk": "2.8.1",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -204,8 +204,9 @@ tw search "query" --all          # Fetch all result pages
 tw user                          # Show current user info
 tw user --json                   # JSON output
 tw user --json --full            # Include all fields in JSON output
-tw users                         # List workspace users
+tw users                         # List active workspace users
 tw users --search <text>         # Filter by name/email
+tw users --include-removed       # Include users removed from the workspace
 tw channels                      # List active joined workspace channels (alias of: tw channel list)
 tw channels --state all          # Include archived joined channels too
 tw channels --scope discoverable # Active public channels you can see but have not joined

--- a/src/commands/user.test.ts
+++ b/src/commands/user.test.ts
@@ -88,17 +88,45 @@ describe('user --json', () => {
         expect(jsonOutput).not.toHaveProperty('shortName')
     })
 
-    it('omits removed users by default and passes includeRemoved: undefined', async () => {
-        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([
-            {
-                id: 1,
-                name: 'Active',
-                email: 'a@x',
-                userType: 'USER',
-                bot: false,
-                removed: false,
-            },
-        ])
+    it('outputs full user fields with --full', async () => {
+        const program = createProgram()
+        const consoleSpy = captureConsole()
+
+        await program.parseAsync(['node', 'tw', 'user', '--json', '--full'])
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1)
+        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(jsonOutput).toHaveProperty('lang', 'en')
+        expect(jsonOutput).toHaveProperty('shortName', 'Jane')
+        expect(jsonOutput).toHaveProperty('defaultWorkspace', 1)
+    })
+})
+
+describe('tw users --include-removed', () => {
+    const active = {
+        id: 1,
+        name: 'Active',
+        email: 'a@x',
+        userType: 'USER',
+        bot: false,
+        removed: false,
+    }
+    const removed = {
+        id: 2,
+        name: 'Ghost',
+        email: 'ghost@x',
+        userType: 'GUEST',
+        bot: false,
+        removed: true,
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+    })
+
+    it('passes includeRemoved: undefined by default so the SDK applies its default filter', async () => {
+        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([active])
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
@@ -111,37 +139,34 @@ describe('user --json', () => {
     })
 
     it('passes includeRemoved: true and annotates removed users in text output', async () => {
-        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([
-            {
-                id: 2,
-                name: 'Ghost',
-                email: 'ghost@x',
-                userType: 'GUEST',
-                bot: false,
-                removed: true,
-            },
-        ])
+        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([active, removed])
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await program.parseAsync(['node', 'tw', 'users', '--include-removed'])
 
         expect(apiMocks.getWorkspaceUsers).toHaveBeenCalledWith(1, { includeRemoved: true })
-        expect(consoleSpy.mock.calls.flat().join('\n')).toMatch(/\[removed\]/)
+        const lines = consoleSpy.mock.calls.flat().join('\n')
+        expect(lines).toMatch(/id:2.*Ghost.*\[removed\]/)
+        expect(lines).not.toMatch(/id:1.*Active.*\[removed\]/)
 
         consoleSpy.mockRestore()
     })
 
-    it('outputs full user fields with --full', async () => {
+    it('surfaces removed in curated --json output without --full', async () => {
+        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([active, removed])
         const program = createProgram()
-        const consoleSpy = captureConsole()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-        await program.parseAsync(['node', 'tw', 'user', '--json', '--full'])
+        await program.parseAsync(['node', 'tw', 'users', '--include-removed', '--json'])
 
-        expect(consoleSpy).toHaveBeenCalledTimes(1)
-        const jsonOutput = JSON.parse(consoleSpy.mock.calls[0][0])
-        expect(jsonOutput).toHaveProperty('lang', 'en')
-        expect(jsonOutput).toHaveProperty('shortName', 'Jane')
-        expect(jsonOutput).toHaveProperty('defaultWorkspace', 1)
+        const parsed = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(parsed).toHaveLength(2)
+        expect(parsed[0]).toMatchObject({ id: 1, removed: false })
+        expect(parsed[1]).toMatchObject({ id: 2, removed: true })
+        // Curated, not --full: shortName must not leak in.
+        expect(parsed[0]).not.toHaveProperty('shortName')
+
+        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/user.test.ts
+++ b/src/commands/user.test.ts
@@ -88,6 +88,50 @@ describe('user --json', () => {
         expect(jsonOutput).not.toHaveProperty('shortName')
     })
 
+    it('omits removed users by default and passes includeRemoved: undefined', async () => {
+        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([
+            {
+                id: 1,
+                name: 'Active',
+                email: 'a@x',
+                userType: 'USER',
+                bot: false,
+                removed: false,
+            },
+        ])
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'users'])
+
+        expect(apiMocks.getWorkspaceUsers).toHaveBeenCalledWith(1, { includeRemoved: undefined })
+        expect(consoleSpy.mock.calls.flat().join('\n')).not.toMatch(/\[removed\]/)
+
+        consoleSpy.mockRestore()
+    })
+
+    it('passes includeRemoved: true and annotates removed users in text output', async () => {
+        apiMocks.getWorkspaceUsers.mockResolvedValueOnce([
+            {
+                id: 2,
+                name: 'Ghost',
+                email: 'ghost@x',
+                userType: 'GUEST',
+                bot: false,
+                removed: true,
+            },
+        ])
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'users', '--include-removed'])
+
+        expect(apiMocks.getWorkspaceUsers).toHaveBeenCalledWith(1, { includeRemoved: true })
+        expect(consoleSpy.mock.calls.flat().join('\n')).toMatch(/\[removed\]/)
+
+        consoleSpy.mockRestore()
+    })
+
     it('outputs full user fields with --full', async () => {
         const program = createProgram()
         const consoleSpy = captureConsole()

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -6,7 +6,7 @@ import type { ViewOptions } from '../lib/options.js'
 import { colors, formatJson, formatNdjson, printEmpty } from '../lib/output.js'
 import { resolveWorkspaceRef } from '../lib/refs.js'
 
-type UsersOptions = ViewOptions & { workspace?: string; search?: string }
+type UsersOptions = ViewOptions & { workspace?: string; search?: string; includeRemoved?: boolean }
 
 async function showCurrentUser(options: ViewOptions): Promise<void> {
     const user = await getSessionUser()
@@ -44,7 +44,7 @@ async function listUsers(workspaceRef: string | undefined, options: UsersOptions
         workspaceId = await getCurrentWorkspaceId()
     }
 
-    let users = await getWorkspaceUsers(workspaceId)
+    let users = await getWorkspaceUsers(workspaceId, { includeRemoved: options.includeRemoved })
 
     if (options.search) {
         const search = options.search.toLowerCase()
@@ -74,7 +74,8 @@ async function listUsers(workspaceRef: string | undefined, options: UsersOptions
         const email = u.email ? colors.timestamp(`<${u.email}>`) : ''
         const type = colors.channel(`[${u.userType}]`)
         const bot = u.bot ? chalk.yellow(' [bot]') : ''
-        console.log(`${id}  ${name} ${email} ${type}${bot}`)
+        const removed = u.removed ? chalk.red(' [removed]') : ''
+        console.log(`${id}  ${name} ${email} ${type}${bot}${removed}`)
     }
 }
 
@@ -98,6 +99,7 @@ Examples:
         .description('List users in a workspace')
         .option('--workspace <ref>', 'Workspace ID or name')
         .option('--search <text>', 'Filter by name/email')
+        .option('--include-removed', 'Include users who have been removed from the workspace')
         .option('--json', 'Output as JSON')
         .option('--ndjson', 'Output as newline-delimited JSON')
         .option('--full', 'Include all fields in JSON output')
@@ -106,7 +108,8 @@ Examples:
             `
 Examples:
   tw users
-  tw users --search "Jane" --json`,
+  tw users --search "Jane" --json
+  tw users --include-removed`,
         )
         .action(listUsers)
 }

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the SDK so we can observe how `getWorkspaceUsers` invokes
+// `client.workspaceUsers.getWorkspaceUsers`. The real filtering of
+// removed users lives in the SDK (≥2.8.1), so the contract this test
+// guards is "we pass `includeRemoved` through unchanged."
+const getWorkspaceUsersMock = vi.hoisted(() => vi.fn().mockResolvedValue([]))
+
+vi.mock('@doist/twist-sdk', () => ({
+    TwistApi: class {
+        workspaceUsers = { getWorkspaceUsers: getWorkspaceUsersMock }
+    },
+}))
+
+vi.mock('./auth.js', () => ({
+    getApiToken: vi.fn().mockResolvedValue('test-token'),
+}))
+
+vi.mock('./permissions.js', () => ({
+    ensureWriteAllowed: vi.fn(),
+    isMutatingMethod: vi.fn().mockReturnValue(false),
+}))
+
+vi.mock('./spinner.js', () => ({
+    withSpinner: <T>(_label: unknown, fn: () => Promise<T>) => fn(),
+}))
+
+vi.mock('./progress.js', () => ({
+    getProgressTracker: () => ({ isEnabled: () => false, emitApiCall: vi.fn() }),
+}))
+
+import { getWorkspaceUsers } from './api.js'
+
+describe('getWorkspaceUsers', () => {
+    beforeEach(() => {
+        getWorkspaceUsersMock.mockClear()
+    })
+
+    it('passes includeRemoved: undefined by default so the SDK applies its default filter', async () => {
+        await getWorkspaceUsers(1585)
+        expect(getWorkspaceUsersMock).toHaveBeenCalledWith({
+            workspaceId: 1585,
+            includeRemoved: undefined,
+        })
+    })
+
+    it('forwards includeRemoved: true to the SDK', async () => {
+        await getWorkspaceUsers(1585, { includeRemoved: true })
+        expect(getWorkspaceUsersMock).toHaveBeenCalledWith({
+            workspaceId: 1585,
+            includeRemoved: true,
+        })
+    })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -303,9 +303,14 @@ export async function getSessionUser(): Promise<User> {
     return sessionUserCache
 }
 
-export async function getWorkspaceUsers(workspaceId: number): Promise<WorkspaceUser[]> {
+export async function getWorkspaceUsers(
+    workspaceId: number,
+    options: { includeRemoved?: boolean } = {},
+): Promise<WorkspaceUser[]> {
     const client = await getTwistClient()
-    return client.workspaceUsers.getWorkspaceUsers({ workspaceId })
+    const users = await client.workspaceUsers.getWorkspaceUsers({ workspaceId })
+    if (options.includeRemoved) return users
+    return users.filter((u) => !u.removed)
 }
 
 export async function getWorkspaceGroups(workspaceId: number): Promise<Group[]> {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -308,9 +308,10 @@ export async function getWorkspaceUsers(
     options: { includeRemoved?: boolean } = {},
 ): Promise<WorkspaceUser[]> {
     const client = await getTwistClient()
-    const users = await client.workspaceUsers.getWorkspaceUsers({ workspaceId })
-    if (options.includeRemoved) return users
-    return users.filter((u) => !u.removed)
+    return client.workspaceUsers.getWorkspaceUsers({
+        workspaceId,
+        includeRemoved: options.includeRemoved,
+    })
 }
 
 export async function getWorkspaceGroups(workspaceId: number): Promise<Group[]> {

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -58,7 +58,15 @@ const MESSAGE_ESSENTIAL_FIELDS = [
 
 const WORKSPACE_ESSENTIAL_FIELDS = ['id', 'name', 'creator', 'plan'] as const
 
-const USER_ESSENTIAL_FIELDS = ['id', 'name', 'email', 'timezone', 'userType', 'awayMode'] as const
+const USER_ESSENTIAL_FIELDS = [
+    'id',
+    'name',
+    'email',
+    'timezone',
+    'userType',
+    'awayMode',
+    'removed',
+] as const
 
 const CHANNEL_ESSENTIAL_FIELDS = ['id', 'name', 'workspaceId'] as const
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -208,8 +208,9 @@ tw search "query" --all          # Fetch all result pages
 tw user                          # Show current user info
 tw user --json                   # JSON output
 tw user --json --full            # Include all fields in JSON output
-tw users                         # List workspace users
+tw users                         # List active workspace users
 tw users --search <text>         # Filter by name/email
+tw users --include-removed       # Include users removed from the workspace
 tw channels                      # List active joined workspace channels (alias of: tw channel list)
 tw channels --state all          # Include archived joined channels too
 tw channels --scope discoverable # Active public channels you can see but have not joined


### PR DESCRIPTION
## Summary

`tw users` was listing users who had been **removed** from the workspace. In `Doist` (ws:1585) this meant 554 entries returned for what is actually a 146-member workspace, polluting `tw users [--json]` output and silently breaking `resolveUserRefs` — any command that takes a name/email user ref (`tw channel add`, `tw groups add-user`, etc.) could resolve to a tombstoned user and then 403 from the backend with `User N is not part of workspace`.

Root cause: Twist's v4 `workspace_users/get?id=<wsid>` endpoint returns both active and removed members with a `removed: boolean` flag. The SDK's `WorkspaceUserSchema` already exposes that field — the CLI just wasn't reading it. The curated `--json` formatter also stripped it, so the staleness was invisible.

Reproducer (before the fix):

```
$ tw users 1585 --json --full | jq '[.[] | select(.removed)] | length'
408
$ tw users 1585 --json | jq '. | map(select(.id == 2342 or .id == 2343))'
[
  { "id": 2342, "name": "Test User1",  "userType": "GUEST" },
  { "id": 2343, "name": "Test User 2", "userType": "USER"  }
]
$ # Both above are removed members; adding them to a channel returns 403
$ # "User 2342 is not part of workspace 1585"
```

After the fix:

```
$ tw users 1585 --json | jq '. | length'
146
$ tw users 1585 --json --include-removed | jq '. | length'
554
$ tw users 1585 --include-removed --search "Test User1"
id:2342  Test User1 <test1@doist.io> [GUEST] [removed]
```

## Changes

| Layer | File | Notes |
|---|---|---|
| API helper | `src/lib/api.ts` | `getWorkspaceUsers(workspaceId, { includeRemoved? })` filters `removed === true` by default. One filter, fixes `tw users`, `resolveUserRefs` ([src/lib/refs.ts](https://github.com/Doist/twist-cli/blob/lmjabreu/confident-lalande-769bec/src/lib/refs.ts)), and `resolveNotifyIds` ([src/commands/thread/helpers.ts](https://github.com/Doist/twist-cli/blob/lmjabreu/confident-lalande-769bec/src/commands/thread/helpers.ts)) in one shot. |
| Command | `src/commands/user.ts` | New `--include-removed` flag. Human output appends a red `[removed]` chip. |
| JSON | `src/lib/output.ts` | Added `removed` to `USER_ESSENTIAL_FIELDS` so callers can distinguish the two states without `--full`. |
| Tests | `src/commands/user.test.ts` | Two new tests: default omits removed users, flag passes through and chip renders. |

`getUserById`-based callers (e.g. `tw groups view`) were already correct because they only fetch ids that the group's `userIds` list references — removed users aren't there.

## Why a flag, not always filter

Audit/recovery cases occasionally do want the historical roster (e.g. "who used to be in here?"). `--include-removed` covers that without making the common case noisy.

## Side discoveries

None. Scope was kept tight to the diagnosed bug.

## Checks

- [x] `npm run type-check`
- [x] `npm run lint:check`
- [x] `npm test` — 653/653 (2 new)
- [x] Manual end-to-end against workspace 1585 (Doist) — counts above

Follow-up to side-discovery #3 in #244.