### PR TITLE
feat(channel): add create, delete, archive, unarchive subcommands

### DIFF
--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -217,14 +217,16 @@ tw channel threads <ref> --since 2026-01-01 # Filter by last-updated date (ISO)
 tw channel threads <ref> --limit 20         # Max threads per page (default: 50)
 tw channel threads <ref> --limit 20 --cursor <cursor-from-prev> # Paginate
 tw channel threads <ref> --json  # { results, nextCursor } with isUnread + url
-tw channel create "Name"         # Create a new (public) channel in the current workspace
+tw channel create "Name"         # Create a new (public) channel in the default/current workspace
+tw channel create "Name" --workspace <ref>       # Target a different workspace
 tw channel create "Name" --private               # Create a private channel
 tw channel create "Name" --description "..."     # Set channel description
-tw channel create "Name" --json --full           # Output created channel as JSON
+tw channel create "Name" --json --full           # Output created channel as JSON (all fields)
 tw channel delete <channel-ref> --yes            # Delete a channel (requires --yes; usually admin-only on Twist)
+tw channel delete <ref> --workspace <ref> --yes  # Target a different workspace
 tw channel delete <ref> --dry-run                # Preview deletion
-tw channel archive <channel-ref>                 # Archive a channel
-tw channel unarchive id:<id>                     # Unarchive a channel (use id:/numeric ref for archived channels)
+tw channel archive <channel-ref>                 # Archive a channel (no-op if already archived)
+tw channel unarchive id:<id>                     # Unarchive a channel (pass id:/numeric ref for archived channels)
 tw channel members <channel-ref>                       # List members + groups whose membership ⊆ channel
 tw channel members <channel-ref> --json                # JSON with id, name, members, groupsFullyInChannel
 tw channel members add <channel-ref> <ref...>          # Add users and/or group:<ref> (group expansion is one-shot)

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -217,6 +217,14 @@ tw channel threads <ref> --since 2026-01-01 # Filter by last-updated date (ISO)
 tw channel threads <ref> --limit 20         # Max threads per page (default: 50)
 tw channel threads <ref> --limit 20 --cursor <cursor-from-prev> # Paginate
 tw channel threads <ref> --json  # { results, nextCursor } with isUnread + url
+tw channel create "Name"         # Create a new (public) channel in the current workspace
+tw channel create "Name" --private               # Create a private channel
+tw channel create "Name" --description "..."     # Set channel description
+tw channel create "Name" --json --full           # Output created channel as JSON
+tw channel delete <channel-ref> --yes            # Delete a channel (requires --yes; usually admin-only on Twist)
+tw channel delete <ref> --dry-run                # Preview deletion
+tw channel archive <channel-ref>                 # Archive a channel
+tw channel unarchive id:<id>                     # Unarchive a channel (use id:/numeric ref for archived channels)
 tw channel members <channel-ref>                       # List members + groups whose membership ⊆ channel
 tw channel members <channel-ref> --json                # JSON with id, name, members, groupsFullyInChannel
 tw channel members add <channel-ref> <ref...>          # Add users and/or group:<ref> (group expansion is one-shot)

--- a/src/commands/channel/archive.ts
+++ b/src/commands/channel/archive.ts
@@ -1,0 +1,56 @@
+import { archiveChannel, getCurrentWorkspaceId, unarchiveChannel } from '../../lib/api.js'
+import type { MutationOptions } from '../../lib/options.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
+import { resolveChannelRef } from '../../lib/refs.js'
+
+type ArchiveChannelOptions = MutationOptions
+
+export async function archiveChannelCommand(
+    ref: string,
+    options: ArchiveChannelOptions,
+): Promise<void> {
+    const workspaceId = await getCurrentWorkspaceId()
+    const channel = await resolveChannelRef(ref, workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('archive channel', {
+            Channel: `${channel.name} (id:${channel.id})`,
+            'Currently archived': channel.archived ? 'yes' : 'no',
+        })
+        return
+    }
+
+    await archiveChannel(channel.id)
+
+    if (options.json) {
+        console.log(formatJson({ id: channel.id, archived: true }))
+        return
+    }
+
+    console.log(`Channel "${channel.name}" (id:${channel.id}) archived.`)
+}
+
+export async function unarchiveChannelCommand(
+    ref: string,
+    options: ArchiveChannelOptions,
+): Promise<void> {
+    const workspaceId = await getCurrentWorkspaceId()
+    const channel = await resolveChannelRef(ref, workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('unarchive channel', {
+            Channel: `${channel.name} (id:${channel.id})`,
+            'Currently archived': channel.archived ? 'yes' : 'no',
+        })
+        return
+    }
+
+    await unarchiveChannel(channel.id)
+
+    if (options.json) {
+        console.log(formatJson({ id: channel.id, archived: false }))
+        return
+    }
+
+    console.log(`Channel "${channel.name}" (id:${channel.id}) unarchived.`)
+}

--- a/src/commands/channel/archive.ts
+++ b/src/commands/channel/archive.ts
@@ -1,56 +1,57 @@
 import { archiveChannel, getCurrentWorkspaceId, unarchiveChannel } from '../../lib/api.js'
 import type { MutationOptions } from '../../lib/options.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
-import { resolveChannelRef } from '../../lib/refs.js'
+import { resolveChannelRef, resolveWorkspaceRef } from '../../lib/refs.js'
 
-type ArchiveChannelOptions = MutationOptions
+type ArchiveChannelOptions = MutationOptions & { workspace?: string }
 
-export async function archiveChannelCommand(
+async function setArchiveState(
     ref: string,
     options: ArchiveChannelOptions,
+    archive: boolean,
 ): Promise<void> {
-    const workspaceId = await getCurrentWorkspaceId()
+    const action = archive ? 'archive' : 'unarchive'
+    const workspaceId = options.workspace
+        ? (await resolveWorkspaceRef(options.workspace)).id
+        : await getCurrentWorkspaceId()
     const channel = await resolveChannelRef(ref, workspaceId)
 
     if (options.dryRun) {
-        printDryRun('archive channel', {
+        printDryRun(`${action} channel`, {
             Channel: `${channel.name} (id:${channel.id})`,
             'Currently archived': channel.archived ? 'yes' : 'no',
         })
         return
     }
 
-    await archiveChannel(channel.id)
+    if (channel.archived !== archive) {
+        if (archive) {
+            await archiveChannel(channel.id)
+        } else {
+            await unarchiveChannel(channel.id)
+        }
+    }
 
     if (options.json) {
-        console.log(formatJson({ id: channel.id, archived: true }))
+        console.log(formatJson({ id: channel.id, archived: archive }))
         return
     }
 
-    console.log(`Channel "${channel.name}" (id:${channel.id}) archived.`)
+    const verb = archive ? 'archived' : 'unarchived'
+    const noop = channel.archived === archive ? ' (already in target state)' : ''
+    console.log(`Channel "${channel.name}" (id:${channel.id}) ${verb}${noop}.`)
+}
+
+export async function archiveChannelCommand(
+    ref: string,
+    options: ArchiveChannelOptions,
+): Promise<void> {
+    await setArchiveState(ref, options, true)
 }
 
 export async function unarchiveChannelCommand(
     ref: string,
     options: ArchiveChannelOptions,
 ): Promise<void> {
-    const workspaceId = await getCurrentWorkspaceId()
-    const channel = await resolveChannelRef(ref, workspaceId)
-
-    if (options.dryRun) {
-        printDryRun('unarchive channel', {
-            Channel: `${channel.name} (id:${channel.id})`,
-            'Currently archived': channel.archived ? 'yes' : 'no',
-        })
-        return
-    }
-
-    await unarchiveChannel(channel.id)
-
-    if (options.json) {
-        console.log(formatJson({ id: channel.id, archived: false }))
-        return
-    }
-
-    console.log(`Channel "${channel.name}" (id:${channel.id}) unarchived.`)
+    await setArchiveState(ref, options, false)
 }

--- a/src/commands/channel/channel.test.ts
+++ b/src/commands/channel/channel.test.ts
@@ -412,7 +412,7 @@ describe('tw channel create', () => {
     it('resolves --workspace ref when provided', async () => {
         refsMocks.resolveWorkspaceRef.mockResolvedValue({ id: 42, name: 'Other' })
         const program = createProgram()
-        vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await program.parseAsync([
             'node',
@@ -431,6 +431,8 @@ describe('tw channel create', () => {
             description: undefined,
             public: true,
         })
+
+        consoleSpy.mockRestore()
     })
 
     it('passes --description and --private through to createChannel', async () => {
@@ -438,7 +440,7 @@ describe('tw channel create', () => {
             createChannel(999, 'Leadership', { public: false, description: 'Internal' }),
         )
         const program = createProgram()
-        vi.spyOn(console, 'log').mockImplementation(() => {})
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
         await program.parseAsync([
             'node',
@@ -457,6 +459,8 @@ describe('tw channel create', () => {
             description: 'Internal',
             public: false,
         })
+
+        consoleSpy.mockRestore()
     })
 
     it('does not call the API on --dry-run', async () => {
@@ -491,6 +495,30 @@ describe('tw channel create', () => {
         const output = JSON.parse(consoleSpy.mock.calls[0][0])
         expect(output.id).toBe(123)
         expect(output.name).toBe('Engineering')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('forwards --full so JSON output includes all channel fields', async () => {
+        apiMocks.createChannel.mockResolvedValue(
+            createChannel(123, 'Engineering', { description: 'Eng channel', creator: 9 }),
+        )
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'channel',
+            'create',
+            'Engineering',
+            '--json',
+            '--full',
+        ])
+
+        const output = JSON.parse(consoleSpy.mock.calls[0][0])
+        // The default-shape filter drops `public`/`creator`; --full keeps them.
+        expect(output).toMatchObject({ id: 123, name: 'Engineering', public: true, creator: 9 })
 
         consoleSpy.mockRestore()
     })
@@ -548,19 +576,41 @@ describe('tw channel delete', () => {
         consoleSpy.mockRestore()
     })
 
-    it('errors in --json mode without --yes', async () => {
+    it('does not delete when --yes is combined with --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'channel',
+            'delete',
+            'Engineering',
+            '--yes',
+            '--dry-run',
+        ])
+
+        expect(apiMocks.deleteChannel).not.toHaveBeenCalled()
+        const text = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(text).toContain('delete channel')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('errors in --json mode without --yes before doing any lookups', async () => {
         const program = createProgram()
         await expect(
             program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering', '--json']),
         ).rejects.toMatchObject({ code: 'MISSING_YES_FLAG' })
         expect(apiMocks.deleteChannel).not.toHaveBeenCalled()
+        // The guard fires before any ref/workspace resolution.
+        expect(refsMocks.resolveChannelRef).not.toHaveBeenCalled()
+        expect(apiMocks.getCurrentWorkspaceId).not.toHaveBeenCalled()
     })
 
     it('translates a 403 from the API into a FORBIDDEN CliError', async () => {
-        const apiError = Object.assign(new Error('Request failed with status 403'), {
-            httpStatusCode: 403,
-            responseData: {},
-        })
+        const { TwistRequestError } = await import('@doist/twist-sdk')
+        const apiError = new TwistRequestError('Request failed with status 403', 403, {})
         apiMocks.deleteChannel.mockRejectedValueOnce(apiError)
         const program = createProgram()
 
@@ -631,6 +681,21 @@ describe('tw channel archive', () => {
 
         const output = JSON.parse(consoleSpy.mock.calls[0][0])
         expect(output).toEqual({ id: 500, archived: true })
+
+        consoleSpy.mockRestore()
+    })
+
+    it('skips the API call when channel is already archived', async () => {
+        refsMocks.resolveChannelRef.mockResolvedValue(
+            createChannel(500, 'Engineering', { archived: true }),
+        )
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'archive', 'Engineering'])
+
+        expect(apiMocks.archiveChannel).not.toHaveBeenCalled()
+        expect(consoleSpy.mock.calls[0][0]).toContain('already in target state')
 
         consoleSpy.mockRestore()
     })

--- a/src/commands/channel/channel.test.ts
+++ b/src/commands/channel/channel.test.ts
@@ -8,6 +8,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const apiMocks = vi.hoisted(() => ({
     getTwistClient: vi.fn(),
     getCurrentWorkspaceId: vi.fn().mockResolvedValue(1),
+    createChannel: vi.fn(),
+    deleteChannel: vi.fn(),
+    archiveChannel: vi.fn(),
+    unarchiveChannel: vi.fn(),
 }))
 
 const refsMocks = vi.hoisted(() => ({
@@ -23,6 +27,10 @@ const globalArgsMocks = vi.hoisted(() => ({
 vi.mock('../../lib/api.js', () => ({
     getTwistClient: apiMocks.getTwistClient,
     getCurrentWorkspaceId: apiMocks.getCurrentWorkspaceId,
+    createChannel: apiMocks.createChannel,
+    deleteChannel: apiMocks.deleteChannel,
+    archiveChannel: apiMocks.archiveChannel,
+    unarchiveChannel: apiMocks.unarchiveChannel,
 }))
 
 vi.mock('../../lib/refs.js', () => ({
@@ -373,5 +381,305 @@ describe('channels list', () => {
         await expect(
             program.parseAsync(['node', 'tw', 'channels', '--state', 'invalid']),
         ).rejects.toHaveProperty('code', 'INVALID_STATE')
+    })
+})
+
+describe('tw channel create', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        apiMocks.createChannel.mockResolvedValue(createChannel(999, 'Engineering'))
+    })
+
+    it('creates a public channel by default in the current workspace', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'create', 'Engineering'])
+
+        expect(apiMocks.createChannel).toHaveBeenCalledWith({
+            workspaceId: 1,
+            name: 'Engineering',
+            description: undefined,
+            public: true,
+        })
+        expect(consoleSpy.mock.calls[0][0]).toContain('Engineering')
+        expect(consoleSpy.mock.calls[0][0]).toContain('public')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('resolves --workspace ref when provided', async () => {
+        refsMocks.resolveWorkspaceRef.mockResolvedValue({ id: 42, name: 'Other' })
+        const program = createProgram()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'channel',
+            'create',
+            'Engineering',
+            '--workspace',
+            'Other',
+        ])
+
+        expect(refsMocks.resolveWorkspaceRef).toHaveBeenCalledWith('Other')
+        expect(apiMocks.createChannel).toHaveBeenCalledWith({
+            workspaceId: 42,
+            name: 'Engineering',
+            description: undefined,
+            public: true,
+        })
+    })
+
+    it('passes --description and --private through to createChannel', async () => {
+        apiMocks.createChannel.mockResolvedValue(
+            createChannel(999, 'Leadership', { public: false, description: 'Internal' }),
+        )
+        const program = createProgram()
+        vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'channel',
+            'create',
+            'Leadership',
+            '--private',
+            '--description',
+            'Internal',
+        ])
+
+        expect(apiMocks.createChannel).toHaveBeenCalledWith({
+            workspaceId: 1,
+            name: 'Leadership',
+            description: 'Internal',
+            public: false,
+        })
+    })
+
+    it('does not call the API on --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'channel',
+            'create',
+            'Engineering',
+            '--private',
+            '--dry-run',
+        ])
+
+        expect(apiMocks.createChannel).not.toHaveBeenCalled()
+        const text = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(text).toContain('create channel')
+        expect(text).toContain('private')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs created channel as JSON', async () => {
+        apiMocks.createChannel.mockResolvedValue(createChannel(123, 'Engineering'))
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'create', 'Engineering', '--json'])
+
+        const output = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(output.id).toBe(123)
+        expect(output.name).toBe('Engineering')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('rejects an empty name', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'channel', 'create', '   ']),
+        ).rejects.toMatchObject({ code: 'INVALID_NAME' })
+    })
+})
+
+describe('tw channel delete', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        refsMocks.resolveChannelRef.mockResolvedValue(createChannel(500, 'Engineering'))
+    })
+
+    it('refuses to delete without --yes', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering'])
+
+        expect(apiMocks.deleteChannel).not.toHaveBeenCalled()
+        expect(consoleSpy.mock.calls.some((c) => String(c[0]).includes('Use --yes'))).toBe(true)
+
+        consoleSpy.mockRestore()
+    })
+
+    it('deletes when --yes is passed', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering', '--yes'])
+
+        expect(refsMocks.resolveChannelRef).toHaveBeenCalledWith('Engineering', 1)
+        expect(apiMocks.deleteChannel).toHaveBeenCalledWith(500)
+        expect(consoleSpy.mock.calls[0][0]).toContain('Engineering')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('does not delete on --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering', '--dry-run'])
+
+        expect(apiMocks.deleteChannel).not.toHaveBeenCalled()
+        const text = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(text).toContain('delete channel')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('errors in --json mode without --yes', async () => {
+        const program = createProgram()
+        await expect(
+            program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering', '--json']),
+        ).rejects.toMatchObject({ code: 'MISSING_YES_FLAG' })
+        expect(apiMocks.deleteChannel).not.toHaveBeenCalled()
+    })
+
+    it('translates a 403 from the API into a FORBIDDEN CliError', async () => {
+        const apiError = Object.assign(new Error('Request failed with status 403'), {
+            httpStatusCode: 403,
+            responseData: {},
+        })
+        apiMocks.deleteChannel.mockRejectedValueOnce(apiError)
+        const program = createProgram()
+
+        await expect(
+            program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering', '--yes']),
+        ).rejects.toMatchObject({ code: 'FORBIDDEN' })
+    })
+
+    it('outputs JSON result with --yes --json', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync([
+            'node',
+            'tw',
+            'channel',
+            'delete',
+            'Engineering',
+            '--yes',
+            '--json',
+        ])
+
+        const output = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(output).toEqual({ id: 500, deleted: true })
+
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('tw channel archive', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        refsMocks.resolveChannelRef.mockResolvedValue(createChannel(500, 'Engineering'))
+    })
+
+    it('archives the resolved channel', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'archive', 'Engineering'])
+
+        expect(refsMocks.resolveChannelRef).toHaveBeenCalledWith('Engineering', 1)
+        expect(apiMocks.archiveChannel).toHaveBeenCalledWith(500)
+        expect(consoleSpy.mock.calls[0][0]).toContain('archived')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('does not call the API on --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'archive', 'Engineering', '--dry-run'])
+
+        expect(apiMocks.archiveChannel).not.toHaveBeenCalled()
+        const text = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(text).toContain('archive channel')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'archive', 'Engineering', '--json'])
+
+        const output = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(output).toEqual({ id: 500, archived: true })
+
+        consoleSpy.mockRestore()
+    })
+})
+
+describe('tw channel unarchive', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        apiMocks.getCurrentWorkspaceId.mockResolvedValue(1)
+        refsMocks.resolveChannelRef.mockResolvedValue(
+            createChannel(500, 'Engineering', { archived: true }),
+        )
+    })
+
+    it('unarchives the resolved channel', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'unarchive', 'id:500'])
+
+        expect(refsMocks.resolveChannelRef).toHaveBeenCalledWith('id:500', 1)
+        expect(apiMocks.unarchiveChannel).toHaveBeenCalledWith(500)
+        expect(consoleSpy.mock.calls[0][0]).toContain('unarchived')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('does not call the API on --dry-run', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'unarchive', 'id:500', '--dry-run'])
+
+        expect(apiMocks.unarchiveChannel).not.toHaveBeenCalled()
+        const text = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n')
+        expect(text).toContain('unarchive channel')
+
+        consoleSpy.mockRestore()
+    })
+
+    it('outputs JSON with --json', async () => {
+        const program = createProgram()
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+        await program.parseAsync(['node', 'tw', 'channel', 'unarchive', 'id:500', '--json'])
+
+        const output = JSON.parse(consoleSpy.mock.calls[0][0])
+        expect(output).toEqual({ id: 500, archived: false })
+
+        consoleSpy.mockRestore()
     })
 })

--- a/src/commands/channel/create.ts
+++ b/src/commands/channel/create.ts
@@ -1,0 +1,51 @@
+import { createChannel, getCurrentWorkspaceId } from '../../lib/api.js'
+import { CliError } from '../../lib/errors.js'
+import type { MutationOptions } from '../../lib/options.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
+import { resolveWorkspaceRef } from '../../lib/refs.js'
+
+type CreateChannelOptions = MutationOptions & {
+    workspace?: string
+    description?: string
+    private?: boolean
+}
+
+export async function createChannelCommand(
+    name: string,
+    options: CreateChannelOptions,
+): Promise<void> {
+    if (!name || name.trim() === '') {
+        throw new CliError('INVALID_NAME', 'Channel name cannot be empty.')
+    }
+
+    const workspaceId = options.workspace
+        ? (await resolveWorkspaceRef(options.workspace)).id
+        : await getCurrentWorkspaceId()
+
+    const isPublic = options.private ? false : true
+
+    if (options.dryRun) {
+        printDryRun('create channel', {
+            Workspace: String(workspaceId),
+            Name: name,
+            Visibility: isPublic ? 'public' : 'private',
+            Description: options.description,
+        })
+        return
+    }
+
+    const channel = await createChannel({
+        workspaceId,
+        name,
+        description: options.description,
+        public: isPublic,
+    })
+
+    if (options.json) {
+        console.log(formatJson(channel, 'channel', options.full))
+        return
+    }
+
+    const visibility = channel.public ? 'public' : 'private'
+    console.log(`Channel "${channel.name}" (id:${channel.id}, ${visibility}) created.`)
+}

--- a/src/commands/channel/delete.ts
+++ b/src/commands/channel/delete.ts
@@ -1,25 +1,26 @@
+import { TwistRequestError } from '@doist/twist-sdk'
 import { deleteChannel, getCurrentWorkspaceId } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { MutationOptions } from '../../lib/options.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
-import { resolveChannelRef } from '../../lib/refs.js'
+import { resolveChannelRef, resolveWorkspaceRef } from '../../lib/refs.js'
 
-type DeleteChannelOptions = MutationOptions & { yes?: boolean }
-
-function isForbidden(error: unknown): boolean {
-    return (
-        typeof error === 'object' &&
-        error !== null &&
-        'httpStatusCode' in error &&
-        (error as { httpStatusCode: number }).httpStatusCode === 403
-    )
-}
+type DeleteChannelOptions = MutationOptions & { yes?: boolean; workspace?: string }
 
 export async function deleteChannelCommand(
     ref: string,
     options: DeleteChannelOptions,
 ): Promise<void> {
-    const workspaceId = await getCurrentWorkspaceId()
+    if (!options.yes && options.json && !options.dryRun) {
+        throw new CliError(
+            'MISSING_YES_FLAG',
+            '--yes is required to execute deletion in --json mode.',
+        )
+    }
+
+    const workspaceId = options.workspace
+        ? (await resolveWorkspaceRef(options.workspace)).id
+        : await getCurrentWorkspaceId()
     const channel = await resolveChannelRef(ref, workspaceId)
 
     if (options.dryRun) {
@@ -31,12 +32,6 @@ export async function deleteChannelCommand(
     }
 
     if (!options.yes) {
-        if (options.json) {
-            throw new CliError(
-                'MISSING_YES_FLAG',
-                '--yes is required to execute deletion in --json mode.',
-            )
-        }
         console.log(`Would delete: ${channel.name} (id:${channel.id})`)
         console.log('Use --yes to confirm.')
         return
@@ -45,7 +40,7 @@ export async function deleteChannelCommand(
     try {
         await deleteChannel(channel.id)
     } catch (error) {
-        if (isForbidden(error)) {
+        if (error instanceof TwistRequestError && error.httpStatusCode === 403) {
             throw new CliError(
                 'FORBIDDEN',
                 `Twist refused to delete "${channel.name}" (id:${channel.id}): 403 Forbidden.`,

--- a/src/commands/channel/delete.ts
+++ b/src/commands/channel/delete.ts
@@ -1,0 +1,67 @@
+import { deleteChannel, getCurrentWorkspaceId } from '../../lib/api.js'
+import { CliError } from '../../lib/errors.js'
+import type { MutationOptions } from '../../lib/options.js'
+import { formatJson, printDryRun } from '../../lib/output.js'
+import { resolveChannelRef } from '../../lib/refs.js'
+
+type DeleteChannelOptions = MutationOptions & { yes?: boolean }
+
+function isForbidden(error: unknown): boolean {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'httpStatusCode' in error &&
+        (error as { httpStatusCode: number }).httpStatusCode === 403
+    )
+}
+
+export async function deleteChannelCommand(
+    ref: string,
+    options: DeleteChannelOptions,
+): Promise<void> {
+    const workspaceId = await getCurrentWorkspaceId()
+    const channel = await resolveChannelRef(ref, workspaceId)
+
+    if (options.dryRun) {
+        printDryRun('delete channel', {
+            Channel: `${channel.name} (id:${channel.id})`,
+            Visibility: channel.public ? 'public' : 'private',
+        })
+        return
+    }
+
+    if (!options.yes) {
+        if (options.json) {
+            throw new CliError(
+                'MISSING_YES_FLAG',
+                '--yes is required to execute deletion in --json mode.',
+            )
+        }
+        console.log(`Would delete: ${channel.name} (id:${channel.id})`)
+        console.log('Use --yes to confirm.')
+        return
+    }
+
+    try {
+        await deleteChannel(channel.id)
+    } catch (error) {
+        if (isForbidden(error)) {
+            throw new CliError(
+                'FORBIDDEN',
+                `Twist refused to delete "${channel.name}" (id:${channel.id}): 403 Forbidden.`,
+                [
+                    'Channel deletion is typically restricted to workspace admins',
+                    'Ask a workspace admin to delete it, or use the Twist web UI',
+                ],
+            )
+        }
+        throw error
+    }
+
+    if (options.json) {
+        console.log(formatJson({ id: channel.id, deleted: true }))
+        return
+    }
+
+    console.log(`Channel "${channel.name}" (id:${channel.id}) deleted.`)
+}

--- a/src/commands/channel/index.ts
+++ b/src/commands/channel/index.ts
@@ -1,6 +1,9 @@
 import { Command, Option } from 'commander'
 import { withCaseInsensitiveChoices } from '../../lib/completion.js'
 import { addChannelMembers } from './add.js'
+import { archiveChannelCommand, unarchiveChannelCommand } from './archive.js'
+import { createChannelCommand } from './create.js'
+import { deleteChannelCommand } from './delete.js'
 import { listChannels } from './list.js'
 import { listChannelMembers } from './members.js'
 import { removeChannelMembers } from './remove.js'
@@ -90,6 +93,76 @@ Notes:
   and --unread are applied client-side; --archive-filter is applied server-side.`,
         )
         .action(showChannelThreads)
+
+    channel
+        .command('create <name>')
+        .description('Create a new channel')
+        .option('--workspace <ref>', 'Workspace ID or name')
+        .option('--description <text>', 'Channel description')
+        .option('--private', 'Create a private channel (default is public)')
+        .option('--dry-run', 'Show what would be created without creating')
+        .option('--json', 'Output created channel as JSON')
+        .option('--full', 'Include all fields in JSON output')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  tw channel create "Engineering"
+  tw channel create "Leadership" --private
+  tw channel create "Marketing" --description "Marketing team channel"
+  tw channel create "Design" --private --json`,
+        )
+        .action(createChannelCommand)
+
+    channel
+        .command('delete <channel-ref>')
+        .description('Permanently delete a channel')
+        .option('--yes', 'Confirm deletion')
+        .option('--dry-run', 'Show what would happen without executing')
+        .option('--json', 'Output result as JSON')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  tw channel delete 12345 --yes
+  tw channel delete "Engineering" --dry-run
+  tw channel delete id:12345 --yes --json`,
+        )
+        .action(deleteChannelCommand)
+
+    channel
+        .command('archive <channel-ref>')
+        .description('Archive a channel')
+        .option('--dry-run', 'Show what would happen without executing')
+        .option('--json', 'Output result as JSON')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  tw channel archive 12345
+  tw channel archive "Engineering" --json
+
+Notes:
+  Archived channels can be listed with: tw channels --state archived`,
+        )
+        .action(archiveChannelCommand)
+
+    channel
+        .command('unarchive <channel-ref>')
+        .description('Unarchive a channel')
+        .option('--dry-run', 'Show what would happen without executing')
+        .option('--json', 'Output result as JSON')
+        .addHelpText(
+            'after',
+            `
+Examples:
+  tw channel unarchive id:12345
+  tw channel unarchive 12345 --json
+
+Notes:
+  Name-ref resolution only finds active channels — pass id: or numeric ID for archived channels.`,
+        )
+        .action(unarchiveChannelCommand)
 
     const members = channel
         .command('members')

--- a/src/commands/channel/index.ts
+++ b/src/commands/channel/index.ts
@@ -117,6 +117,7 @@ Examples:
     channel
         .command('delete <channel-ref>')
         .description('Permanently delete a channel')
+        .option('--workspace <ref>', 'Workspace ID or name')
         .option('--yes', 'Confirm deletion')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
@@ -133,6 +134,7 @@ Examples:
     channel
         .command('archive <channel-ref>')
         .description('Archive a channel')
+        .option('--workspace <ref>', 'Workspace ID or name')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
         .addHelpText(
@@ -150,6 +152,7 @@ Notes:
     channel
         .command('unarchive <channel-ref>')
         .description('Unarchive a channel')
+        .option('--workspace <ref>', 'Workspace ID or name')
         .option('--dry-run', 'Show what would happen without executing')
         .option('--json', 'Output result as JSON')
         .addHelpText(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import {
     type BatchResponse,
     type Channel,
+    type CreateChannelArgs,
     type Group,
     TwistApi,
     type User,
@@ -346,12 +347,7 @@ export async function removeUsersFromGroup(id: number, userIds: number[]): Promi
     await client.groups.removeUsers({ id, userIds })
 }
 
-export async function createChannel(args: {
-    workspaceId: number
-    name: string
-    description?: string
-    public?: boolean
-}): Promise<Channel> {
+export async function createChannel(args: CreateChannelArgs): Promise<Channel> {
     const client = await getTwistClient()
     return client.channels.createChannel(args)
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import {
     type BatchResponse,
+    type Channel,
     type Group,
     TwistApi,
     type User,
@@ -52,6 +53,8 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         'channels.createChannel': { text: 'Creating channel...', color: 'green' },
         'channels.updateChannel': { text: 'Updating channel...', color: 'yellow' },
         'channels.deleteChannel': { text: 'Deleting channel...', color: 'yellow' },
+        'channels.archiveChannel': { text: 'Archiving channel...', color: 'yellow' },
+        'channels.unarchiveChannel': { text: 'Unarchiving channel...', color: 'yellow' },
         'channels.addUsers': { text: 'Adding users to channel...', color: 'green' },
         'channels.removeUsers': { text: 'Removing users from channel...', color: 'yellow' },
 
@@ -343,6 +346,31 @@ export async function removeUsersFromGroup(id: number, userIds: number[]): Promi
     await client.groups.removeUsers({ id, userIds })
 }
 
+export async function createChannel(args: {
+    workspaceId: number
+    name: string
+    description?: string
+    public?: boolean
+}): Promise<Channel> {
+    const client = await getTwistClient()
+    return client.channels.createChannel(args)
+}
+
+export async function deleteChannel(id: number): Promise<void> {
+    const client = await getTwistClient()
+    await client.channels.deleteChannel(id)
+}
+
+export async function archiveChannel(id: number): Promise<void> {
+    const client = await getTwistClient()
+    await client.channels.archiveChannel(id)
+}
+
+export async function unarchiveChannel(id: number): Promise<void> {
+    const client = await getTwistClient()
+    await client.channels.unarchiveChannel(id)
+}
+
 export async function addUsersToChannel(id: number, userIds: number[]): Promise<void> {
     const client = await getTwistClient()
     await client.channels.addUsers({ id, userIds })
@@ -451,4 +479,4 @@ export function buildOptionalBatchNameMap<T extends { id: number; name: string }
     return new Map(entries)
 }
 
-export type { Group, User, Workspace, WorkspaceUser }
+export type { Channel, Group, User, Workspace, WorkspaceUser }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -12,6 +12,7 @@ export type ErrorCode =
     // Auth & permissions
     | 'AUTH_FAILED'
     | 'AUTH_MIGRATION_PENDING'
+    | 'FORBIDDEN'
     | 'INSUFFICIENT_SCOPE'
     | 'INVALID_TOKEN'
     | 'NO_TOKEN'

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -221,6 +221,14 @@ tw channel threads <ref> --since 2026-01-01 # Filter by last-updated date (ISO)
 tw channel threads <ref> --limit 20         # Max threads per page (default: 50)
 tw channel threads <ref> --limit 20 --cursor <cursor-from-prev> # Paginate
 tw channel threads <ref> --json  # { results, nextCursor } with isUnread + url
+tw channel create "Name"         # Create a new (public) channel in the current workspace
+tw channel create "Name" --private               # Create a private channel
+tw channel create "Name" --description "..."     # Set channel description
+tw channel create "Name" --json --full           # Output created channel as JSON
+tw channel delete <channel-ref> --yes            # Delete a channel (requires --yes; usually admin-only on Twist)
+tw channel delete <ref> --dry-run                # Preview deletion
+tw channel archive <channel-ref>                 # Archive a channel
+tw channel unarchive id:<id>                     # Unarchive a channel (use id:/numeric ref for archived channels)
 tw channel members <channel-ref>                       # List members + groups whose membership ⊆ channel
 tw channel members <channel-ref> --json                # JSON with id, name, members, groupsFullyInChannel
 tw channel members add <channel-ref> <ref...>          # Add users and/or group:<ref> (group expansion is one-shot)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -221,14 +221,16 @@ tw channel threads <ref> --since 2026-01-01 # Filter by last-updated date (ISO)
 tw channel threads <ref> --limit 20         # Max threads per page (default: 50)
 tw channel threads <ref> --limit 20 --cursor <cursor-from-prev> # Paginate
 tw channel threads <ref> --json  # { results, nextCursor } with isUnread + url
-tw channel create "Name"         # Create a new (public) channel in the current workspace
+tw channel create "Name"         # Create a new (public) channel in the default/current workspace
+tw channel create "Name" --workspace <ref>       # Target a different workspace
 tw channel create "Name" --private               # Create a private channel
 tw channel create "Name" --description "..."     # Set channel description
-tw channel create "Name" --json --full           # Output created channel as JSON
+tw channel create "Name" --json --full           # Output created channel as JSON (all fields)
 tw channel delete <channel-ref> --yes            # Delete a channel (requires --yes; usually admin-only on Twist)
+tw channel delete <ref> --workspace <ref> --yes  # Target a different workspace
 tw channel delete <ref> --dry-run                # Preview deletion
-tw channel archive <channel-ref>                 # Archive a channel
-tw channel unarchive id:<id>                     # Unarchive a channel (use id:/numeric ref for archived channels)
+tw channel archive <channel-ref>                 # Archive a channel (no-op if already archived)
+tw channel unarchive id:<id>                     # Unarchive a channel (pass id:/numeric ref for archived channels)
 tw channel members <channel-ref>                       # List members + groups whose membership ⊆ channel
 tw channel members <channel-ref> --json                # JSON with id, name, members, groupsFullyInChannel
 tw channel members add <channel-ref> <ref...>          # Add users and/or group:<ref> (group expansion is one-shot)


### PR DESCRIPTION
## Summary

- Adds `tw channel create`, `tw channel delete`, `tw channel archive`, `tw channel unarchive` — wraps the four SDK endpoints that were already exposed but not surfaced in the CLI. Discovered as a gap while landing channel-membership commands in [#244](https://github.com/Doist/twist-cli/pull/244); end-to-end channel testing previously required the web UI.
- `create` supports `--workspace`, `--description`, `--private` (default public), `--dry-run`, `--json`, `--full`.
- `delete` requires `--yes` to mutate, with structured `MISSING_YES_FLAG` CliError in `--json` mode, and a clear `FORBIDDEN` CliError when the Twist API returns 403 (channel deletion is typically restricted to workspace admins).
- `archive` / `unarchive` mirror the same shape with `--dry-run` and `--json`.
- Skill quick-reference + `SKILL.md` regenerated.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` — 667/667 passing (17 new tests across the four commands)
- [x] Live smoke against the Doist workspace: create → verify in list → archive → list `--state archived` → unarchive → re-archive
- [x] Live-verified the `FORBIDDEN` error message on `delete --yes` (Twist returns 403 for non-admins, as expected)
- [ ] Live-verified successful `delete` — blocked by workspace admin policy; unit-tested only

🤖 Generated with [Claude Code](https://claude.com/claude-code)