### PR TITLE
refactor(errors): centralize 403 FORBIDDEN translation in wrapResult

### DIFF
--- a/src/commands/channel/channel.test.ts
+++ b/src/commands/channel/channel.test.ts
@@ -608,17 +608,6 @@ describe('tw channel delete', () => {
         expect(apiMocks.getCurrentWorkspaceId).not.toHaveBeenCalled()
     })
 
-    it('translates a 403 from the API into a FORBIDDEN CliError', async () => {
-        const { TwistRequestError } = await import('@doist/twist-sdk')
-        const apiError = new TwistRequestError('Request failed with status 403', 403, {})
-        apiMocks.deleteChannel.mockRejectedValueOnce(apiError)
-        const program = createProgram()
-
-        await expect(
-            program.parseAsync(['node', 'tw', 'channel', 'delete', 'Engineering', '--yes']),
-        ).rejects.toMatchObject({ code: 'FORBIDDEN' })
-    })
-
     it('outputs JSON result with --yes --json', async () => {
         const program = createProgram()
         const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/src/commands/channel/delete.ts
+++ b/src/commands/channel/delete.ts
@@ -1,4 +1,3 @@
-import { TwistRequestError } from '@doist/twist-sdk'
 import { deleteChannel, getCurrentWorkspaceId } from '../../lib/api.js'
 import { CliError } from '../../lib/errors.js'
 import type { MutationOptions } from '../../lib/options.js'
@@ -37,21 +36,7 @@ export async function deleteChannelCommand(
         return
     }
 
-    try {
-        await deleteChannel(channel.id)
-    } catch (error) {
-        if (error instanceof TwistRequestError && error.httpStatusCode === 403) {
-            throw new CliError(
-                'FORBIDDEN',
-                `Twist refused to delete "${channel.name}" (id:${channel.id}): 403 Forbidden.`,
-                [
-                    'Channel deletion is typically restricted to workspace admins',
-                    'Ask a workspace admin to delete it, or use the Twist web UI',
-                ],
-            )
-        }
-        throw error
-    }
+    await deleteChannel(channel.id)
 
     if (options.json) {
         console.log(formatJson({ id: channel.id, deleted: true }))

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,3 +1,4 @@
+import { TwistRequestError } from '@doist/twist-sdk'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Hoisted mocks — shared across both describe blocks.
@@ -82,10 +83,7 @@ describe('wrapResult — central 403 translation', () => {
 
     it('translates a plain 403 into a FORBIDDEN CliError', async () => {
         sdkMocks.deleteChannel.mockRejectedValueOnce(
-            Object.assign(new Error('Request failed with status 403'), {
-                httpStatusCode: 403,
-                responseData: {},
-            }),
+            new TwistRequestError('Request failed with status 403', 403, {}),
         )
 
         const { createWrappedTwistClient } = await import('./api.js')
@@ -93,14 +91,18 @@ describe('wrapResult — central 403 translation', () => {
 
         await expect(client.channels.deleteChannel(500)).rejects.toMatchObject({
             code: 'FORBIDDEN',
+            message: 'Twist refused this action: 403 Forbidden.',
+            hints: [
+                'You may not have permission for this action',
+                'Contact your workspace admin, or re-authenticate with `tw auth login` if your token looks wrong',
+            ],
         })
     })
 
     it('prefers INSUFFICIENT_SCOPE over FORBIDDEN when error_string indicates scope', async () => {
         sdkMocks.deleteChannel.mockRejectedValueOnce(
-            Object.assign(new Error('Request failed with status 403'), {
-                httpStatusCode: 403,
-                responseData: { error_string: 'Insufficient scope provided: channels:write' },
+            new TwistRequestError('Request failed with status 403', 403, {
+                error_string: 'Insufficient scope provided: channels:write',
             }),
         )
 
@@ -109,22 +111,18 @@ describe('wrapResult — central 403 translation', () => {
 
         await expect(client.channels.deleteChannel(500)).rejects.toMatchObject({
             code: 'INSUFFICIENT_SCOPE',
+            message: 'This action requires permissions your current token does not have.',
+            hints: ['Run `tw auth login` to re-authenticate with the required scopes'],
         })
     })
 
     it('passes non-403 errors through untranslated', async () => {
-        sdkMocks.deleteChannel.mockRejectedValueOnce(
-            Object.assign(new Error('Request failed with status 500'), {
-                httpStatusCode: 500,
-                responseData: {},
-            }),
-        )
+        const originalError = new TwistRequestError('Request failed with status 500', 500, {})
+        sdkMocks.deleteChannel.mockRejectedValueOnce(originalError)
 
         const { createWrappedTwistClient } = await import('./api.js')
         const client = createWrappedTwistClient('test-token')
 
-        await expect(client.channels.deleteChannel(500)).rejects.toThrow(
-            'Request failed with status 500',
-        )
+        await expect(client.channels.deleteChannel(500)).rejects.toBe(originalError)
     })
 })

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,19 +1,34 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock the SDK so we can observe how `getWorkspaceUsers` invokes
-// `client.workspaceUsers.getWorkspaceUsers`. The real filtering of
-// removed users lives in the SDK (≥2.8.1), so the contract this test
-// guards is "we pass `includeRemoved` through unchanged."
+// Hoisted mocks — shared across both describe blocks.
 const getWorkspaceUsersMock = vi.hoisted(() => vi.fn().mockResolvedValue([]))
-
-vi.mock('@doist/twist-sdk', () => ({
-    TwistApi: class {
-        workspaceUsers = { getWorkspaceUsers: getWorkspaceUsersMock }
-    },
+const sdkMocks = vi.hoisted(() => ({
+    deleteChannel: vi.fn(),
 }))
+
+vi.mock('@doist/twist-sdk', () => {
+    class TwistApi {
+        channels = { deleteChannel: sdkMocks.deleteChannel }
+        workspaceUsers = { getWorkspaceUsers: getWorkspaceUsersMock }
+        constructor(_token?: string) {}
+    }
+    return {
+        TwistApi,
+        TwistRequestError: class TwistRequestError extends Error {
+            constructor(
+                message: string,
+                public httpStatusCode: number,
+                public responseData?: unknown,
+            ) {
+                super(message)
+            }
+        },
+    }
+})
 
 vi.mock('./auth.js', () => ({
     getApiToken: vi.fn().mockResolvedValue('test-token'),
+    getAuthMetadata: vi.fn().mockResolvedValue({ authMode: 'full' }),
 }))
 
 vi.mock('./permissions.js', () => ({
@@ -30,6 +45,10 @@ vi.mock('./progress.js', () => ({
 }))
 
 import { getWorkspaceUsers } from './api.js'
+
+// ─── getWorkspaceUsers ────────────────────────────────────────────────────────
+// The SDK (≥2.8.1) filters removed users itself; the contract this test guards
+// is "we pass `includeRemoved` through unchanged."
 
 describe('getWorkspaceUsers', () => {
     beforeEach(() => {
@@ -50,5 +69,62 @@ describe('getWorkspaceUsers', () => {
             workspaceId: 1585,
             includeRemoved: true,
         })
+    })
+})
+
+// ─── wrapResult — central 403 translation ────────────────────────────────────
+
+describe('wrapResult — central 403 translation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.resetModules()
+    })
+
+    it('translates a plain 403 into a FORBIDDEN CliError', async () => {
+        sdkMocks.deleteChannel.mockRejectedValueOnce(
+            Object.assign(new Error('Request failed with status 403'), {
+                httpStatusCode: 403,
+                responseData: {},
+            }),
+        )
+
+        const { createWrappedTwistClient } = await import('./api.js')
+        const client = createWrappedTwistClient('test-token')
+
+        await expect(client.channels.deleteChannel(500)).rejects.toMatchObject({
+            code: 'FORBIDDEN',
+        })
+    })
+
+    it('prefers INSUFFICIENT_SCOPE over FORBIDDEN when error_string indicates scope', async () => {
+        sdkMocks.deleteChannel.mockRejectedValueOnce(
+            Object.assign(new Error('Request failed with status 403'), {
+                httpStatusCode: 403,
+                responseData: { error_string: 'Insufficient scope provided: channels:write' },
+            }),
+        )
+
+        const { createWrappedTwistClient } = await import('./api.js')
+        const client = createWrappedTwistClient('test-token')
+
+        await expect(client.channels.deleteChannel(500)).rejects.toMatchObject({
+            code: 'INSUFFICIENT_SCOPE',
+        })
+    })
+
+    it('passes non-403 errors through untranslated', async () => {
+        sdkMocks.deleteChannel.mockRejectedValueOnce(
+            Object.assign(new Error('Request failed with status 500'), {
+                httpStatusCode: 500,
+                responseData: {},
+            }),
+        )
+
+        const { createWrappedTwistClient } = await import('./api.js')
+        const client = createWrappedTwistClient('test-token')
+
+        await expect(client.channels.deleteChannel(500)).rejects.toThrow(
+            'Request failed with status 500',
+        )
     })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,7 +10,7 @@ import {
 } from '@doist/twist-sdk'
 import { getApiToken } from './auth.js'
 import { getConfig, updateConfig } from './config.js'
-import { CliError, isInsufficientScope } from './errors.js'
+import { CliError, isForbidden, isInsufficientScope } from './errors.js'
 import { ensureWriteAllowed, isMutatingMethod } from './permissions.js'
 import { getProgressTracker } from './progress.js'
 import { withSpinner } from './spinner.js'
@@ -196,6 +196,12 @@ function wrapResult(
                     'This action requires permissions your current token does not have.',
                     ['Run `tw auth login` to re-authenticate with the required scopes'],
                 )
+            }
+            if (isForbidden(error)) {
+                throw new CliError('FORBIDDEN', 'Twist refused this action: 403 Forbidden.', [
+                    'You may not have permission for this action — workspace admins can perform it',
+                    'Or re-authenticate with `tw auth login` if your scopes look wrong',
+                ])
             }
             throw error
         })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -199,8 +199,8 @@ function wrapResult(
             }
             if (isForbidden(error)) {
                 throw new CliError('FORBIDDEN', 'Twist refused this action: 403 Forbidden.', [
-                    'You may not have permission for this action — workspace admins can perform it',
-                    'Or re-authenticate with `tw auth login` if your scopes look wrong',
+                    'You may not have permission for this action',
+                    'Contact your workspace admin, or re-authenticate with `tw auth login` if your token looks wrong',
                 ])
             }
             throw error

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,7 +1,7 @@
 import { TwistRequestError } from '@doist/twist-sdk'
 import { describe, expect, it } from 'vitest'
 
-import { isInsufficientScope } from './errors.js'
+import { isForbidden, isInsufficientScope } from './errors.js'
 
 describe('isInsufficientScope', () => {
     it('returns true for a 403 with "Insufficient scope" error_string', () => {
@@ -36,5 +36,50 @@ describe('isInsufficientScope', () => {
         expect(isInsufficientScope(null)).toBe(false)
         expect(isInsufficientScope(undefined)).toBe(false)
         expect(isInsufficientScope('string')).toBe(false)
+    })
+})
+
+describe('isForbidden', () => {
+    it('returns true for any 403 — even without responseData', () => {
+        const error = new TwistRequestError('Request failed with status 403', 403, undefined)
+        expect(isForbidden(error)).toBe(true)
+    })
+
+    it('returns true for a 403 with an arbitrary error_string', () => {
+        const error = new TwistRequestError('Request failed with status 403', 403, {
+            error_code: 100,
+            error_string: 'Access denied',
+        })
+        expect(isForbidden(error)).toBe(true)
+    })
+
+    it('returns false for non-403 status codes', () => {
+        expect(isForbidden(new TwistRequestError('Request failed with status 401', 401, {}))).toBe(
+            false,
+        )
+        expect(isForbidden(new TwistRequestError('Request failed with status 404', 404, {}))).toBe(
+            false,
+        )
+        expect(isForbidden(new TwistRequestError('Request failed with status 500', 500, {}))).toBe(
+            false,
+        )
+    })
+
+    it('returns false for plain errors and non-object values', () => {
+        expect(isForbidden(new Error('something'))).toBe(false)
+        expect(isForbidden(null)).toBe(false)
+        expect(isForbidden(undefined)).toBe(false)
+        expect(isForbidden('string')).toBe(false)
+    })
+
+    // Precedence: both predicates fire on a scope 403, so callers must test
+    // isInsufficientScope first (the central handler in api.ts does).
+    it('fires alongside isInsufficientScope for an "Insufficient scope" 403', () => {
+        const error = new TwistRequestError('Request failed with status 403', 403, {
+            error_code: 109,
+            error_string: 'Insufficient scope provided: user:write',
+        })
+        expect(isInsufficientScope(error)).toBe(true)
+        expect(isForbidden(error)).toBe(true)
     })
 })

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -88,6 +88,21 @@ export function isInsufficientScope(error: unknown): boolean {
 }
 
 /**
+ * Check whether an error is any Twist API 403 response.
+ *
+ * Precedence: callers must test `isInsufficientScope` first so OAuth-scope
+ * 403s keep their dedicated `INSUFFICIENT_SCOPE` code and hints; `isForbidden`
+ * is the catch-all fallback for plain workspace-permission 403s.
+ */
+export function isForbidden(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null || !('httpStatusCode' in error)) {
+        return false
+    }
+    const { httpStatusCode } = error as { httpStatusCode: number }
+    return httpStatusCode === 403
+}
+
+/**
  * Twist-flavoured CliError that preserves the historical positional
  * `(code, message, hints?, type?)` signature used across hundreds of call
  * sites. Internally it forwards to the cli-core options-object form.

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -63,25 +63,27 @@ export type ErrorCode =
     // Escape hatch for dynamic codes
     | (string & {})
 
+function hasTwistStatusCode(error: unknown, status: number): boolean {
+    return (
+        typeof error === 'object' &&
+        error !== null &&
+        'httpStatusCode' in error &&
+        (error as { httpStatusCode: number }).httpStatusCode === status
+    )
+}
+
 /**
  * Check whether an error is a Twist API 403 "Insufficient scope" response.
  * Works with any error shaped like TwistRequestError (httpStatusCode + responseData).
  */
 export function isInsufficientScope(error: unknown): boolean {
-    if (
-        typeof error !== 'object' ||
-        error === null ||
-        !('httpStatusCode' in error) ||
-        !('responseData' in error)
-    ) {
+    if (!hasTwistStatusCode(error, 403) || !('responseData' in (error as object))) {
         return false
     }
-    const { httpStatusCode, responseData } = error as {
-        httpStatusCode: number
+    const { responseData } = error as {
         responseData: { error_string?: string } | undefined
     }
     return (
-        httpStatusCode === 403 &&
         typeof responseData?.error_string === 'string' &&
         responseData.error_string.includes('Insufficient scope')
     )
@@ -95,11 +97,7 @@ export function isInsufficientScope(error: unknown): boolean {
  * is the catch-all fallback for plain workspace-permission 403s.
  */
 export function isForbidden(error: unknown): boolean {
-    if (typeof error !== 'object' || error === null || !('httpStatusCode' in error)) {
-        return false
-    }
-    const { httpStatusCode } = error as { httpStatusCode: number }
-    return httpStatusCode === 403
+    return hasTwistStatusCode(error, 403)
 }
 
 /**

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -63,12 +63,13 @@ export type ErrorCode =
     // Escape hatch for dynamic codes
     | (string & {})
 
-function hasTwistStatusCode(error: unknown, status: number): boolean {
+function hasTwistStatusCode(error: unknown, status: number): error is { httpStatusCode: number } {
     return (
         typeof error === 'object' &&
         error !== null &&
         'httpStatusCode' in error &&
-        (error as { httpStatusCode: number }).httpStatusCode === status
+        typeof error.httpStatusCode === 'number' &&
+        error.httpStatusCode === status
     )
 }
 
@@ -77,15 +78,15 @@ function hasTwistStatusCode(error: unknown, status: number): boolean {
  * Works with any error shaped like TwistRequestError (httpStatusCode + responseData).
  */
 export function isInsufficientScope(error: unknown): boolean {
-    if (!hasTwistStatusCode(error, 403) || !('responseData' in (error as object))) {
-        return false
-    }
-    const { responseData } = error as {
-        responseData: { error_string?: string } | undefined
-    }
+    if (!hasTwistStatusCode(error, 403)) return false
+    if (!('responseData' in error)) return false
+    const data = error.responseData
     return (
-        typeof responseData?.error_string === 'string' &&
-        responseData.error_string.includes('Insufficient scope')
+        typeof data === 'object' &&
+        data !== null &&
+        'error_string' in data &&
+        typeof data.error_string === 'string' &&
+        data.error_string.includes('Insufficient scope')
     )
 }
 


### PR DESCRIPTION
## Summary

- Lift the local `isForbidden` helper from `src/commands/channel/delete.ts` into the central `wrapResult` handler in `src/lib/api.ts`. Every SDK call now gets uniform 403 → `CliError('FORBIDDEN')` translation, not just channel deletion. Future commands (kick user, group delete, etc.) inherit the friendly message for free.
- New `isForbidden(error)` predicate in `src/lib/errors.ts` sits next to `isInsufficientScope`. Both delegate to a shared `hasTwistStatusCode(error, status)` type predicate so the shape narrowing lives in one place, with no `as` casts. JSDoc documents the precedence rule: callers must test `isInsufficientScope` first so OAuth-scope 403s keep their dedicated `INSUFFICIENT_SCOPE` code and hints; `isForbidden` is the catch-all.
- FORBIDDEN end-to-end translation test in `src/lib/api.test.ts` exercises the real proxy + `wrapResult` flow by mocking `@doist/twist-sdk`. Covers FORBIDDEN translation, INSUFFICIENT_SCOPE precedence, and non-403 pass-through (asserted by object identity, not just message).

**Hint copy is call-agnostic.** The central message reads `Twist refused this action: 403 Forbidden.` with hints `You may not have permission for this action` and `Contact your workspace admin, or re-authenticate with \`tw auth login\` if your token looks wrong`. #246's local message included the channel name; uniform coverage is the deliberate tradeoff. If per-command flavour matters later, we can plumb the spinner config's command name into the central message.

**Follow-ups (not this PR):** the same central-translation pattern should eventually cover 404 (`NOT_FOUND`-style with resource hint), 429 (rate-limit with retry-after), and 5xx (transient retry with backoff). Each warrants its own PR with its own behaviour decision. Batch responses (`assertBatchData` / `getOptionalBatchData`) also bypass `wrapResult` and would need a separate 403 check; tracked for the same follow-up.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` (710 passed)
- [x] Manual smoke: `tw channel delete id:837190 --yes` against the parked admin-only channel surfaces the new friendly FORBIDDEN message (verified after `tw channel unarchive`, then re-archived).
