### PR TITLE
fix(refs): resolve unjoined-but-public channels by name

### DIFF
--- a/src/lib/refs.test.ts
+++ b/src/lib/refs.test.ts
@@ -216,6 +216,17 @@ describe('resolveChannelRef', () => {
 
     const mockGetChannel = vi.fn()
     const mockGetChannels = vi.fn()
+    const mockGetPublicChannels = vi.fn()
+
+    /**
+     * For name refs, resolveChannelRef merges joined channels (getChannels — membership-scoped,
+     * includes both active + archived) with public channels (getPublicChannels — workspace-scoped,
+     * finds unjoined-but-public channels). Tests default both to empty unless overridden.
+     */
+    function mockChannelLists(joined: unknown[] = [], publicChannels: unknown[] = []) {
+        mockGetChannels.mockResolvedValue(joined)
+        mockGetPublicChannels.mockResolvedValue(publicChannels)
+    }
 
     beforeEach(() => {
         vi.clearAllMocks()
@@ -223,6 +234,9 @@ describe('resolveChannelRef', () => {
             channels: {
                 getChannel: mockGetChannel,
                 getChannels: mockGetChannels,
+            },
+            workspaces: {
+                getPublicChannels: mockGetPublicChannels,
             },
         })
     })
@@ -265,19 +279,20 @@ describe('resolveChannelRef', () => {
         expect(mockGetChannel).not.toHaveBeenCalled()
     })
 
-    it('resolves exact case-insensitive name match', async () => {
+    it('resolves exact case-insensitive name match against joined channels', async () => {
         const ch = createChannel(10, 'General')
-        mockGetChannels.mockResolvedValue([ch, createChannel(20, 'Leadership')])
+        mockChannelLists([ch, createChannel(20, 'Leadership')])
 
         const result = await resolveChannelRef('general', 1)
 
         expect(mockGetChannels).toHaveBeenCalledWith({ workspaceId: 1 })
+        expect(mockGetPublicChannels).toHaveBeenCalledWith(1)
         expect(result).toEqual(ch)
     })
 
     it('resolves unique substring name match', async () => {
         const ch = createChannel(30, 'Marketing')
-        mockGetChannels.mockResolvedValue([createChannel(10, 'General'), ch])
+        mockChannelLists([createChannel(10, 'General'), ch])
 
         const result = await resolveChannelRef('market', 1)
 
@@ -285,10 +300,7 @@ describe('resolveChannelRef', () => {
     })
 
     it('throws AMBIGUOUS_CHANNEL on multiple substring matches', async () => {
-        mockGetChannels.mockResolvedValue([
-            createChannel(10, 'Engineering'),
-            createChannel(20, 'Engineering-Ops'),
-        ])
+        mockChannelLists([createChannel(10, 'Engineering'), createChannel(20, 'Engineering-Ops')])
 
         await expect(resolveChannelRef('eng', 1)).rejects.toHaveProperty(
             'code',
@@ -297,11 +309,49 @@ describe('resolveChannelRef', () => {
     })
 
     it('throws CHANNEL_NOT_FOUND when no match', async () => {
-        mockGetChannels.mockResolvedValue([createChannel(10, 'General')])
+        mockChannelLists([createChannel(10, 'General')])
 
         await expect(resolveChannelRef('nope', 1)).rejects.toHaveProperty(
             'code',
             'CHANNEL_NOT_FOUND',
+        )
+    })
+
+    it('resolves unjoined-but-public channel by name', async () => {
+        const publicCh = createChannel(50, 'Old Public Channel')
+        mockChannelLists([createChannel(10, 'General')], [publicCh])
+
+        const result = await resolveChannelRef('Old Public Channel', 1)
+
+        expect(result).toEqual(publicCh)
+    })
+
+    it('resolves unjoined-but-public channel by substring', async () => {
+        const publicCh = createChannel(60, 'tw-cli-smoke-test-channel')
+        mockChannelLists([createChannel(10, 'General')], [publicCh])
+
+        const result = await resolveChannelRef('smoke-test', 1)
+
+        expect(result).toEqual(publicCh)
+    })
+
+    it('deduplicates channels appearing in both joined and public lists', async () => {
+        // A public channel the user has joined would appear in both. Resolution must not
+        // throw AMBIGUOUS_CHANNEL just because the same channel id shows up twice.
+        const joinedPublic = createChannel(70, 'Engineering', { public: true })
+        mockChannelLists([joinedPublic], [joinedPublic])
+
+        const result = await resolveChannelRef('Engineering', 1)
+
+        expect(result).toEqual(joinedPublic)
+    })
+
+    it('throws AMBIGUOUS_CHANNEL on substring matches spanning joined and public lists', async () => {
+        mockChannelLists([createChannel(10, 'Engineering')], [createChannel(20, 'Engineering-Ops')])
+
+        await expect(resolveChannelRef('eng', 1)).rejects.toHaveProperty(
+            'code',
+            'AMBIGUOUS_CHANNEL',
         )
     })
 })

--- a/src/lib/refs.test.ts
+++ b/src/lib/refs.test.ts
@@ -285,8 +285,6 @@ describe('resolveChannelRef', () => {
 
         const result = await resolveChannelRef('general', 1)
 
-        expect(mockGetChannels).toHaveBeenCalledWith({ workspaceId: 1 })
-        expect(mockGetPublicChannels).toHaveBeenCalledWith(1)
         expect(result).toEqual(ch)
     })
 
@@ -336,12 +334,14 @@ describe('resolveChannelRef', () => {
     })
 
     it('deduplicates channels appearing in both joined and public lists', async () => {
-        // A public channel the user has joined would appear in both. Resolution must not
-        // throw AMBIGUOUS_CHANNEL just because the same channel id shows up twice.
+        // A public channel the user has joined would appear in both. A substring query
+        // exercises the dedupe step: without it, matchByName sees two partial matches
+        // for the same channel id and throws AMBIGUOUS_CHANNEL. An exact-match query
+        // wouldn't catch a regression because matchByName returns on the first .find.
         const joinedPublic = createChannel(70, 'Engineering', { public: true })
         mockChannelLists([joinedPublic], [joinedPublic])
 
-        const result = await resolveChannelRef('Engineering', 1)
+        const result = await resolveChannelRef('eng', 1)
 
         expect(result).toEqual(joinedPublic)
     })

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -230,7 +230,22 @@ export async function resolveChannelRef(ref: string, workspaceId: number): Promi
     }
 
     if (parsed.type === 'name') {
-        const channels = await client.channels.getChannels({ workspaceId })
+        // getChannels is membership-scoped — it returns only channels the current user has
+        // joined (across active + archived). Public channels the user hasn't joined are not
+        // included, so name-resolving e.g. `tw channel archive "Old Public Channel"` would
+        // fail with CHANNEL_NOT_FOUND even though the channel is discoverable. Merge with
+        // getPublicChannels (workspace-scoped, returns all public channels regardless of
+        // membership) and dedupe by id so a joined-and-public channel doesn't match twice.
+        const [joined, publicChannels] = await Promise.all([
+            client.channels.getChannels({ workspaceId }),
+            client.workspaces.getPublicChannels(workspaceId),
+        ])
+        const byId = new Map<number, Channel>()
+        for (const channel of joined) byId.set(channel.id, channel)
+        for (const channel of publicChannels) {
+            if (!byId.has(channel.id)) byId.set(channel.id, channel)
+        }
+        const channels = Array.from(byId.values())
         return matchByName(channels, parsed.name, {
             ambiguousCode: 'AMBIGUOUS_CHANNEL',
             notFoundCode: 'CHANNEL_NOT_FOUND',

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -240,12 +240,11 @@ export async function resolveChannelRef(ref: string, workspaceId: number): Promi
             client.channels.getChannels({ workspaceId }),
             client.workspaces.getPublicChannels(workspaceId),
         ])
-        const byId = new Map<number, Channel>()
-        for (const channel of joined) byId.set(channel.id, channel)
-        for (const channel of publicChannels) {
-            if (!byId.has(channel.id)) byId.set(channel.id, channel)
-        }
-        const channels = Array.from(byId.values())
+        const joinedIds = new Set(joined.map((channel) => channel.id))
+        const channels = [
+            ...joined,
+            ...publicChannels.filter((channel) => !joinedIds.has(channel.id)),
+        ]
         return matchByName(channels, parsed.name, {
             ambiguousCode: 'AMBIGUOUS_CHANNEL',
             notFoundCode: 'CHANNEL_NOT_FOUND',


### PR DESCRIPTION
## Summary

- `resolveChannelRef`'s name branch only called `client.channels.getChannels({ workspaceId })`, which is **membership-scoped** and excludes public channels the current user hasn't joined.
- Effect: `tw channel <action> "Public Channel I Haven't Joined"` fails with `CHANNEL_NOT_FOUND`, while `id:N` and URL refs work because `getChannel(id)` isn't membership-filtered.
- Fix merges `getChannels` with `workspaces.getPublicChannels` and dedupes by id. Same shape as `src/commands/channel/list.ts:177-180` already uses for the `--scope public` path.

## Why this exists

The bug was first suspected to be "active vs archived" — that turned out to be wrong: `getChannels({ workspaceId })` already returns both states (Twist's API is tri-state — see `list.ts:163-169`). The real axis is **joined vs unjoined**, which I confirmed live and which also holds for non-admin users (`getPublicChannels` is not admin-gated). Scale check in Doist workspace 1585: 998 public channels, 829 of which I haven't joined — so the bug bites in production, not just edge cases.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run type-check` — no errors in `refs.ts` / `refs.test.ts` (pre-existing `@doist/cli-core` export errors elsewhere on `main` are unrelated)
- [x] `npx vitest run src/lib/refs.test.ts` — **71/71 pass** (4 new tests: unjoined-public exact match, unjoined-public substring match, dedup of joined-and-public, ambiguity across joined+public)
- [x] **Live smoke** in workspace 1767 (Testing Environment), against a fresh test channel — no existing channels touched:
  1. `tw channel create tw-cli-resolver-smoke-<ts> --workspace 1767` → id 837258
  2. Left the channel via SDK `removeUser`
  3. `tw channel archive "tw-cli-resolver-smoke-<ts>" --workspace 1767` → `{ id: 837258, archived: true }` ✅ (previously: `CHANNEL_NOT_FOUND`)
  4. `tw channel delete id:837258 --workspace 1767 --yes` → cleaned up

Smoke required #246's `channel create/archive/delete` commands to exercise an action on the resolved channel; they were checked out temporarily and reverted after.

## Out of scope

- Help-text cleanup on `tw channel unarchive` in #246's `src/commands/channel/index.ts` — separate trivial follow-up once both this and #246 land.
- `id:` and URL branches — already work for archived and unjoined channels via `getChannel(id)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)