### PR TITLE
feat(attachments): support uploading files on replies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "license": "MIT",
             "dependencies": {
                 "@doist/cli-core": "0.24.0",
-                "@doist/twist-sdk": "2.8.1",
+                "@doist/twist-sdk": "2.9.0",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -182,9 +182,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.8.1.tgz",
-            "integrity": "sha512-FfBEI/9EyxPQGHU3SZ7aXW/l5x6Ric+7lcLye5VuNFzS24ws4iDqmKddWks+LF8bQitTjIC03Kbd8aX1AM2ZOQ==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.9.0.tgz",
+            "integrity": "sha512-pnRCDZKEq14BcYcY2AzMSqqCtawWUFSevnKnhgUHRQ6g23nNKw/In0R8BeFtfI6vb+NL5zKS03W5dEDej9n3Sw==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",
@@ -201,6 +201,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
             "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -212,6 +213,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
             "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -222,6 +224,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
             "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1033,6 +1036,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
             "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -1340,9 +1344,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1360,9 +1361,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1380,9 +1378,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1400,9 +1395,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1420,9 +1412,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1440,9 +1429,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1460,9 +1446,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1480,9 +1463,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1687,9 +1667,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1707,9 +1684,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1727,9 +1701,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1747,9 +1718,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1767,9 +1735,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1787,9 +1752,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1807,9 +1769,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1827,9 +1786,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1974,6 +1930,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1990,6 +1947,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2006,6 +1964,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2022,6 +1981,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2038,6 +1998,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2054,9 +2015,7 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2073,9 +2032,7 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2092,9 +2049,7 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2111,9 +2066,7 @@
             "cpu": [
                 "s390x"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2130,9 +2083,7 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2149,9 +2100,7 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2168,6 +2117,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2184,6 +2134,7 @@
             "cpu": [
                 "wasm32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2202,6 +2153,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2218,6 +2170,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2998,6 +2951,7 @@
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
             "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3039,7 +2993,7 @@
             "version": "25.9.1",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
             "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
@@ -4611,6 +4565,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -5525,6 +5480,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5545,6 +5501,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5565,6 +5522,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5585,6 +5543,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5605,6 +5564,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5625,9 +5585,7 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5648,9 +5606,7 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5671,9 +5627,7 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5694,9 +5648,7 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5717,6 +5669,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5737,6 +5690,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10146,6 +10100,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
             "license": "0BSD",
             "optional": true
         },
@@ -10227,7 +10182,7 @@
             "version": "7.24.6",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
             "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unicode-emoji-modifier-base": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "license": "MIT",
             "dependencies": {
                 "@doist/cli-core": "0.24.0",
-                "@doist/twist-sdk": "2.9.0",
+                "@doist/twist-sdk": "2.9.1",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -182,9 +182,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.9.0.tgz",
-            "integrity": "sha512-pnRCDZKEq14BcYcY2AzMSqqCtawWUFSevnKnhgUHRQ6g23nNKw/In0R8BeFtfI6vb+NL5zKS03W5dEDej9n3Sw==",
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.9.1.tgz",
+            "integrity": "sha512-M5ZobkiqGwZ/EneJjxyIDTiBgENW5KZT7zLoDFrPM+68nqJXUiUqPY8Af35+72FYPhIUvlc38v2vm43UQdQdaw==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ],
     "dependencies": {
         "@doist/cli-core": "0.24.0",
-        "@doist/twist-sdk": "2.9.0",
+        "@doist/twist-sdk": "2.9.1",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ],
     "dependencies": {
         "@doist/cli-core": "0.24.0",
-        "@doist/twist-sdk": "2.8.1",
+        "@doist/twist-sdk": "2.9.0",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -91,6 +91,7 @@ tw thread create <channel-ref> "Title" "content" --notify 123,456  # Notify spec
 tw thread create <channel-ref> "Title" "content" --unarchive  # Land thread in author's Inbox (overrides default Twist auto-archive)
 tw thread create <channel-ref> "Title" "content" --no-unarchive  # Force archive even when userSettings.unarchiveNewThreads=true
 tw thread create <channel-ref> "Title" "content" --dry-run  # Preview without posting
+tw thread create <channel-ref> "Title" --file ./a.png  # Attach a file (repeatable; content optional)
 tw thread reply <ref> "content"  # Post a comment (notifies EVERYONE_IN_THREAD by default)
 tw thread reply <ref> "content" --notify EVERYONE  # Notify all workspace members
 tw thread reply <ref> "content" --notify 123,id:456   # Notify specific user IDs

--- a/skills/twist-cli/SKILL.md
+++ b/skills/twist-cli/SKILL.md
@@ -98,6 +98,7 @@ tw thread reply <ref> "content" --json  # Post and return comment as JSON
 tw thread reply <ref> "content" --json --full  # Include all comment fields
 tw thread reply <ref> "content" --close       # Reply and close the thread
 tw thread reply <ref> "content" --reopen      # Reply and reopen a closed thread
+tw thread reply <ref> "content" --file ./a.png  # Attach a file (repeatable; content optional)
 tw thread done <ref>             # Archive thread (mark done)
 tw thread done <ref> --json      # Archive and return status as JSON
 tw thread mute <ref>             # Mute thread for 60 minutes (default)
@@ -151,6 +152,7 @@ tw conversation with <user-ref> --include-groups # List any conversations with t
 tw conversation reply <ref> "content"     # Send a message
 tw conversation reply <ref> "content" --json  # Send and return message as JSON
 tw conversation reply <ref> "content" --json --full  # Include all message fields
+tw conversation reply <ref> "content" --file ./a.png  # Attach a file (repeatable; content optional)
 tw conversation done <ref>                # Archive conversation
 tw conversation done <ref> --json         # Archive and return status as JSON
 tw conversation mute <ref>               # Mute conversation for 60 minutes (default)

--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -223,6 +223,30 @@ function createClient({
 
 const createProgram = () => createTestProgram(registerConversationCommand)
 
+// Shared setup for the --file suite: a fresh mock client wired into getTwistClient
+// plus a program. Tests asserting on output call captureConsole() themselves.
+function setupFileTest() {
+    const client = createClient({})
+    apiMocks.getTwistClient.mockResolvedValue(client)
+    return { client, program: createProgram() }
+}
+
+// Registers a temp dir with two files for a --file suite, cleaned up afterwards.
+function useFileFixtures(prefix: string, png: string, pdf: string) {
+    const paths = { dir: '', png: '', pdf: '' }
+    beforeAll(async () => {
+        paths.dir = await mkdtemp(join(tmpdir(), prefix))
+        paths.png = join(paths.dir, png)
+        paths.pdf = join(paths.dir, pdf)
+        await writeFile(paths.png, 'png-bytes')
+        await writeFile(paths.pdf, 'pdf-bytes')
+    })
+    afterAll(async () => {
+        await rm(paths.dir, { recursive: true, force: true })
+    })
+    return paths
+}
+
 describe('conversation implicit view', () => {
     beforeEach(() => {
         vi.clearAllMocks()
@@ -795,32 +819,16 @@ describe('conversation done', () => {
 })
 
 describe('conversation reply --file', () => {
-    let tmpDir: string
-    let filePng: string
-    let filePdf: string
-
-    beforeAll(async () => {
-        tmpDir = await mkdtemp(join(tmpdir(), 'tw-convo-reply-'))
-        filePng = join(tmpDir, 'photo.png')
-        filePdf = join(tmpDir, 'doc.pdf')
-        await writeFile(filePng, 'png-bytes')
-        await writeFile(filePdf, 'pdf-bytes')
-    })
-
-    afterAll(async () => {
-        await rm(tmpDir, { recursive: true, force: true })
-    })
+    const files = useFileFixtures('tw-convo-reply-', 'photo.png', 'doc.pdf')
 
     beforeEach(() => {
         vi.clearAllMocks()
     })
 
     it('uploads the file and attaches it to the message', async () => {
-        const client = createClient({})
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
         const consoleSpy = captureConsole()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -829,7 +837,7 @@ describe('conversation reply --file', () => {
             '42',
             'See attached',
             '--file',
-            filePng,
+            files.png,
         ])
 
         expect(client.attachments.upload).toHaveBeenCalledTimes(1)
@@ -847,10 +855,8 @@ describe('conversation reply --file', () => {
     })
 
     it('attaches multiple repeated --file values', async () => {
-        const client = createClient({})
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -859,9 +865,9 @@ describe('conversation reply --file', () => {
             '42',
             'two files',
             '--file',
-            filePng,
+            files.png,
             '--file',
-            filePdf,
+            files.pdf,
         ])
 
         expect(client.attachments.upload).toHaveBeenCalledTimes(2)
@@ -872,11 +878,9 @@ describe('conversation reply --file', () => {
     })
 
     it('allows a file-only message with no text content', async () => {
-        const client = createClient({})
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'conversation', 'reply', '42', '--file', filePng])
+        await program.parseAsync(['node', 'tw', 'conversation', 'reply', '42', '--file', files.png])
 
         expect(client.conversationMessages.createMessage).toHaveBeenCalledWith(
             expect.objectContaining({ content: '', attachments: expect.any(Array) }),
@@ -886,10 +890,8 @@ describe('conversation reply --file', () => {
     })
 
     it('errors with FILE_NOT_FOUND for a missing path and does not send', async () => {
-        const client = createClient({})
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await expect(
             program.parseAsync([
                 'node',
@@ -899,7 +901,7 @@ describe('conversation reply --file', () => {
                 '42',
                 'x',
                 '--file',
-                join(tmpDir, 'missing.png'),
+                join(files.dir, 'missing.png'),
             ]),
         ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
 
@@ -908,11 +910,9 @@ describe('conversation reply --file', () => {
     })
 
     it('does not upload during --dry-run but lists the attachment', async () => {
-        const client = createClient({})
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
         const consoleSpy = captureConsole()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -921,12 +921,12 @@ describe('conversation reply --file', () => {
             '42',
             'preview',
             '--file',
-            filePng,
+            files.png,
             '--dry-run',
         ])
 
         expect(client.attachments.upload).not.toHaveBeenCalled()
         expect(client.conversationMessages.createMessage).not.toHaveBeenCalled()
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(files.png))
     })
 })

--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -1,10 +1,13 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
     captureConsole,
     createTestProgram,
     describeEmptyMachineOutput,
 } from '@doist/cli-core/testing'
 import type { BatchResponse as TwistBatchResponse } from '@doist/twist-sdk'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { CliError } from '../../lib/errors.js'
 
 const apiMocks = vi.hoisted(() => ({
@@ -31,6 +34,11 @@ vi.mock('../../lib/markdown.js', () => ({
 }))
 
 vi.mock('chalk')
+
+vi.mock('../../lib/input.js', () => ({
+    readStdin: vi.fn().mockResolvedValue(''),
+    openEditor: vi.fn().mockResolvedValue(''),
+}))
 
 import { registerConversationCommand } from './index.js'
 
@@ -151,7 +159,25 @@ function createClient({
                     return Promise.resolve(messagesByConversation[conversationId] ?? [])
                 },
             ),
-            createMessage: vi.fn(),
+            createMessage: vi.fn(
+                async (args: {
+                    conversationId: number
+                    content: string
+                    attachments?: Array<{ fileName?: string | null }>
+                }) => ({
+                    id: 999,
+                    conversationId: args.conversationId,
+                    content: args.content,
+                    url: 'https://twist.com/a/1/msg/999',
+                }),
+            ),
+        },
+        attachments: {
+            upload: vi.fn(async (args: { file: Blob; fileName: string }) => ({
+                attachmentId: `att-${args.fileName}`,
+                urlType: 'file',
+                fileName: args.fileName,
+            })),
         },
         workspaceUsers: {
             getUserById: vi.fn(
@@ -764,5 +790,140 @@ describe('conversation done', () => {
             program.parseAsync(['node', 'tw', 'conversation', 'done', '42', '--dry-run']),
         ).rejects.toThrow('conversation not found')
         expect(client.conversations.archiveConversation).not.toHaveBeenCalled()
+    })
+})
+
+describe('conversation reply --file', () => {
+    let tmpDir: string
+    let filePng: string
+    let filePdf: string
+
+    beforeAll(async () => {
+        tmpDir = await mkdtemp(join(tmpdir(), 'tw-convo-reply-'))
+        filePng = join(tmpDir, 'photo.png')
+        filePdf = join(tmpDir, 'doc.pdf')
+        await writeFile(filePng, 'png-bytes')
+        await writeFile(filePdf, 'pdf-bytes')
+    })
+
+    afterAll(async () => {
+        await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('uploads the file and attaches it to the message', async () => {
+        const client = createClient({})
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const consoleSpy = captureConsole()
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'conversation',
+            'reply',
+            '42',
+            'See attached',
+            '--file',
+            filePng,
+        ])
+
+        expect(client.attachments.upload).toHaveBeenCalledTimes(1)
+        expect(client.attachments.upload).toHaveBeenCalledWith(
+            expect.objectContaining({ fileName: 'photo.png' }),
+        )
+        expect(client.conversationMessages.createMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                conversationId: 42,
+                content: 'See attached',
+                attachments: [expect.objectContaining({ fileName: 'photo.png' })],
+            }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Attached: photo.png'))
+    })
+
+    it('attaches multiple repeated --file values', async () => {
+        const client = createClient({})
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'conversation',
+            'reply',
+            '42',
+            'two files',
+            '--file',
+            filePng,
+            '--file',
+            filePdf,
+        ])
+
+        expect(client.attachments.upload).toHaveBeenCalledTimes(2)
+        const args = client.conversationMessages.createMessage.mock.calls[0][0] as {
+            attachments: Array<{ fileName?: string }>
+        }
+        expect(args.attachments.map((a) => a.fileName)).toEqual(['photo.png', 'doc.pdf'])
+    })
+
+    it('allows a file-only message with no text content', async () => {
+        const client = createClient({})
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'conversation', 'reply', '42', '--file', filePng])
+
+        expect(client.conversationMessages.createMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ content: '', attachments: expect.any(Array) }),
+        )
+    })
+
+    it('errors with FILE_NOT_FOUND for a missing path and does not send', async () => {
+        const client = createClient({})
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await expect(
+            program.parseAsync([
+                'node',
+                'tw',
+                'conversation',
+                'reply',
+                '42',
+                'x',
+                '--file',
+                join(tmpDir, 'missing.png'),
+            ]),
+        ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+        expect(client.conversationMessages.createMessage).not.toHaveBeenCalled()
+    })
+
+    it('does not upload during --dry-run but lists the attachment', async () => {
+        const client = createClient({})
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const consoleSpy = captureConsole()
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'conversation',
+            'reply',
+            '42',
+            'preview',
+            '--file',
+            filePng,
+            '--dry-run',
+        ])
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+        expect(client.conversationMessages.createMessage).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
     })
 })

--- a/src/commands/conversation/conversation.test.ts
+++ b/src/commands/conversation/conversation.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../lib/input.js', () => ({
     openEditor: vi.fn().mockResolvedValue(''),
 }))
 
+import { openEditor } from '../../lib/input.js'
 import { registerConversationCommand } from './index.js'
 
 type TestConversation = {
@@ -880,6 +881,8 @@ describe('conversation reply --file', () => {
         expect(client.conversationMessages.createMessage).toHaveBeenCalledWith(
             expect.objectContaining({ content: '', attachments: expect.any(Array) }),
         )
+        // A file-only message must not block on the editor.
+        expect(openEditor).not.toHaveBeenCalled()
     })
 
     it('errors with FILE_NOT_FOUND for a missing path and does not send', async () => {

--- a/src/commands/conversation/helpers.ts
+++ b/src/commands/conversation/helpers.ts
@@ -18,7 +18,7 @@ export type ConversationWithOptions = PaginatedViewOptions & {
     snippet?: boolean
 }
 
-export type ReplyOptions = MutationOptions
+export type ReplyOptions = MutationOptions & { file?: string[] }
 
 export type MuteOptions = MutationOptions & { minutes?: string }
 

--- a/src/commands/conversation/index.ts
+++ b/src/commands/conversation/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { collect } from '../../lib/options.js'
 import { markConversationDone } from './done.js'
 import { muteConversation } from './mute.js'
 import { replyToConversation } from './reply.js'
@@ -77,6 +78,7 @@ Examples:
     conversation
         .command('reply <conversation-ref> [content]')
         .description('Send a message in a conversation')
+        .option('--file <path>', 'Attach a file (repeatable; content optional)', collect, [])
         .option('--dry-run', 'Show what would be sent without sending')
         .option('--json', 'Output sent message as JSON')
         .option('--full', 'Include all fields in JSON output')
@@ -86,7 +88,8 @@ Examples:
 Examples:
   tw conversation reply 12345 "Hello!"
   echo "Message body" | tw conversation reply 12345
-  tw conversation reply 12345 "Update" --json`,
+  tw conversation reply 12345 "Update" --json
+  tw conversation reply 12345 "See attached" --file ./photo.jpg`,
         )
         .action(replyToConversation)
 

--- a/src/commands/conversation/reply.ts
+++ b/src/commands/conversation/reply.ts
@@ -44,9 +44,15 @@ export async function replyToConversation(
         return
     }
 
-    const attachments = hasFiles ? await uploadAttachments(files) : undefined
-
     const client = await getTwistClient()
+
+    // Preflight the target before uploading so an invalid or forbidden
+    // conversation fails fast instead of leaving an orphaned upload behind.
+    if (hasFiles) {
+        await client.conversations.getConversation(conversationId)
+    }
+
+    const attachments = hasFiles ? await uploadAttachments(files) : undefined
     const message = await client.conversationMessages.createMessage({
         conversationId,
         content: messageContent,

--- a/src/commands/conversation/reply.ts
+++ b/src/commands/conversation/reply.ts
@@ -1,4 +1,6 @@
+import chalk from 'chalk'
 import { getTwistClient } from '../../lib/api.js'
+import { uploadAttachments } from '../../lib/attachments.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import { formatJson, printDryRun } from '../../lib/output.js'
@@ -12,34 +14,43 @@ export async function replyToConversation(
 ): Promise<void> {
     const conversationId = resolveConversationId(ref)
 
+    const files = options.file ?? []
+    const hasFiles = files.length > 0
+
     let replyContent = await readStdin()
     if (!replyContent && content) {
         replyContent = content
     }
-    if (!replyContent) {
+    // A file-only message is allowed: skip the editor prompt and the empty-content guard.
+    if (!replyContent && !hasFiles) {
         replyContent = await openEditor()
     }
-    if (!replyContent || replyContent.trim() === '') {
+    if ((!replyContent || replyContent.trim() === '') && !hasFiles) {
         throw new CliError(
             'MISSING_CONTENT',
-            'No content provided. Pass content as an argument or pipe via stdin.',
+            'No content provided. Pass content as an argument, pipe via stdin, or attach a file.',
         )
     }
+    const messageContent = replyContent ?? ''
 
     if (options.dryRun) {
         const preview =
-            replyContent.length > 200 ? `${replyContent.slice(0, 200)}...` : replyContent
+            messageContent.length > 200 ? `${messageContent.slice(0, 200)}...` : messageContent
         printDryRun('send message to conversation', {
             Conversation: String(conversationId),
-            Content: preview,
+            Attach: hasFiles ? files.join(', ') : undefined,
+            Content: preview || undefined,
         })
         return
     }
 
+    const attachments = hasFiles ? await uploadAttachments(files) : undefined
+
     const client = await getTwistClient()
     const message = await client.conversationMessages.createMessage({
         conversationId,
-        content: replyContent,
+        content: messageContent,
+        attachments,
     })
 
     if (options.json) {
@@ -48,4 +59,8 @@ export async function replyToConversation(
     }
 
     console.log(`Message sent: ${message.url}`)
+    if (attachments && attachments.length > 0) {
+        const names = attachments.map((a) => a.fileName ?? 'file').join(', ')
+        console.log(chalk.dim(`Attached: ${names}`))
+    }
 }

--- a/src/commands/thread/create.ts
+++ b/src/commands/thread/create.ts
@@ -1,4 +1,6 @@
+import chalk from 'chalk'
 import { getTwistClient } from '../../lib/api.js'
+import { uploadAttachments } from '../../lib/attachments.js'
 import { getConfig } from '../../lib/config.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
@@ -11,6 +13,7 @@ import { type ResolvedNotify, formatNotifyLabel, resolveNotifyIds } from './help
 type CreateOptions = MutationOptions & {
     notify?: string
     unarchive?: boolean
+    file?: string[]
 }
 
 export async function createThread(
@@ -21,19 +24,24 @@ export async function createThread(
 ): Promise<void> {
     const channelId = resolveChannelId(channelRef)
 
+    const files = options.file ?? []
+    const hasFiles = files.length > 0
+
     let threadContent = await readStdin()
     if (!threadContent && content) {
         threadContent = content
     }
-    if (!threadContent) {
+    // A file-only thread is allowed: skip the editor prompt and the empty-content guard.
+    if (!threadContent && !hasFiles) {
         threadContent = await openEditor()
     }
-    if (!threadContent || threadContent.trim() === '') {
+    if ((!threadContent || threadContent.trim() === '') && !hasFiles) {
         throw new CliError(
             'MISSING_CONTENT',
-            'No content provided. Pass content as an argument or pipe via stdin.',
+            'No content provided. Pass content as an argument, pipe via stdin, or attach a file.',
         )
     }
+    const messageContent = threadContent ?? ''
 
     const allIds = options.notify ? parseUserIdRefs(options.notify) : undefined
 
@@ -51,7 +59,7 @@ export async function createThread(
 
     if (options.dryRun) {
         const preview =
-            threadContent.length > 200 ? `${threadContent.slice(0, 200)}...` : threadContent
+            messageContent.length > 200 ? `${messageContent.slice(0, 200)}...` : messageContent
         printDryRun('create thread', {
             Channel: `${channel.name} (${channelId})`,
             Title: title,
@@ -64,17 +72,21 @@ export async function createThread(
                     ? formatNotifyLabel(resolved.notified.groups)
                     : undefined,
             Unarchive: shouldUnarchive ? 'yes' : undefined,
-            Content: preview,
+            Attach: hasFiles ? files.join(', ') : undefined,
+            Content: preview || undefined,
         })
         return
     }
 
+    const attachments = hasFiles ? await uploadAttachments(files) : undefined
+
     const thread = await client.threads.createThread({
         channelId,
         title,
-        content: threadContent,
+        content: messageContent,
         recipients: resolved?.recipients,
         groups: resolved?.groups,
+        attachments,
     })
 
     if (shouldUnarchive) {
@@ -93,4 +105,8 @@ export async function createThread(
     }
 
     console.log(`Thread created: ${thread.url}`)
+    if (attachments && attachments.length > 0) {
+        const names = attachments.map((a) => a.fileName ?? 'file').join(', ')
+        console.log(chalk.dim(`Attached: ${names}`))
+    }
 }

--- a/src/commands/thread/index.ts
+++ b/src/commands/thread/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from 'commander'
 import { withUnvalidatedChoices } from '../../lib/completion.js'
+import { collect } from '../../lib/options.js'
 import { createThread } from './create.js'
 import { deleteThread } from './delete.js'
 import { markThreadDone } from './mutate.js'
@@ -55,6 +56,7 @@ Examples:
         )
         .option('--close', 'Close the thread after replying')
         .option('--reopen', 'Reopen the thread after replying')
+        .option('--file <path>', 'Attach a file (repeatable; content optional)', collect, [])
         .option('--dry-run', 'Show what would be posted without posting')
         .option('--json', 'Output posted comment as JSON')
         .option('--full', 'Include all fields in JSON output')
@@ -64,7 +66,9 @@ Examples:
 Examples:
   tw thread reply 12345 "Sounds good!"
   echo "Long reply" | tw thread reply 12345
-  tw thread reply 12345 "Done" --close --json`,
+  tw thread reply 12345 "Done" --close --json
+  tw thread reply 12345 "See attached" --file ./diagram.png
+  tw thread reply 12345 --file ./a.png --file ./b.pdf`,
         )
         .action(replyToThread)
 

--- a/src/commands/thread/index.ts
+++ b/src/commands/thread/index.ts
@@ -81,6 +81,7 @@ Examples:
             'Unarchive after creation so the thread appears in your Inbox (overrides userSettings.unarchiveNewThreads when false)',
         )
         .option('--no-unarchive', 'Skip unarchive even if userSettings.unarchiveNewThreads is true')
+        .option('--file <path>', 'Attach a file (repeatable; content optional)', collect, [])
         .option('--dry-run', 'Show what would be posted without posting')
         .option('--json', 'Output created thread as JSON')
         .option('--full', 'Include all fields in JSON output')
@@ -91,7 +92,8 @@ Examples:
   tw thread create 12345 "Weekly update" "Here's what happened..."
   echo "Body from stdin" | tw thread create id:12345 "Title"
   tw thread create 12345 "Title" "Body" --notify 67890,11111 --json
-  tw thread create 12345 "Title" "Body" --unarchive`,
+  tw thread create 12345 "Title" "Body" --unarchive
+  tw thread create 12345 "Title" --file ./report.pdf`,
         )
         .action(createThread)
 

--- a/src/commands/thread/reply.ts
+++ b/src/commands/thread/reply.ts
@@ -1,4 +1,6 @@
+import chalk from 'chalk'
 import { getTwistClient } from '../../lib/api.js'
+import { uploadAttachments } from '../../lib/attachments.js'
 import { CliError } from '../../lib/errors.js'
 import { openEditor, readStdin } from '../../lib/input.js'
 import type { MutationOptions } from '../../lib/options.js'
@@ -11,6 +13,7 @@ type ReplyOptions = MutationOptions & {
     notify?: string
     close?: boolean
     reopen?: boolean
+    file?: string[]
 }
 
 export async function replyToThread(
@@ -24,19 +27,31 @@ export async function replyToThread(
         throw new CliError('CONFLICTING_OPTIONS', 'Cannot use --close and --reopen together.')
     }
 
+    const files = options.file ?? []
+    const hasFiles = files.length > 0
+
+    if (hasFiles && (options.close || options.reopen)) {
+        throw new CliError(
+            'CONFLICTING_OPTIONS',
+            'Cannot attach files with --close or --reopen. Post the attachment separately.',
+        )
+    }
+
     let replyContent = await readStdin()
     if (!replyContent && content) {
         replyContent = content
     }
-    if (!replyContent) {
+    // A file-only reply is allowed: skip the editor prompt and the empty-content guard.
+    if (!replyContent && !hasFiles) {
         replyContent = await openEditor()
     }
-    if (!replyContent || replyContent.trim() === '') {
+    if ((!replyContent || replyContent.trim() === '') && !hasFiles) {
         throw new CliError(
             'MISSING_CONTENT',
-            'No content provided. Pass content as an argument or pipe via stdin.',
+            'No content provided. Pass content as an argument, pipe via stdin, or attach a file.',
         )
     }
+    const messageContent = replyContent ?? ''
 
     const notifyValue = options.notify ?? 'EVERYONE_IN_THREAD'
     const isSpecialRecipient = notifyValue === 'EVERYONE' || notifyValue === 'EVERYONE_IN_THREAD'
@@ -61,7 +76,7 @@ export async function replyToThread(
     if (options.dryRun) {
         const actionSuffix = actionLabel ? ` and ${actionLabel} it` : ''
         const preview =
-            replyContent.length > 200 ? `${replyContent.slice(0, 200)}...` : replyContent
+            messageContent.length > 200 ? `${messageContent.slice(0, 200)}...` : messageContent
         printDryRun(`post comment to thread${actionSuffix}`, {
             Thread: `${thread.title} (${threadId})`,
             Notify: isSpecialRecipient ? notifyValue : undefined,
@@ -73,33 +88,37 @@ export async function replyToThread(
                 !isSpecialRecipient && resolved && resolved.notified.groups.length > 0
                     ? formatNotifyLabel(resolved.notified.groups)
                     : undefined,
-            Content: preview,
+            Attach: hasFiles ? files.join(', ') : undefined,
+            Content: preview || undefined,
         })
         return
     }
 
+    const attachments = hasFiles ? await uploadAttachments(files) : undefined
+    const attachmentsPayload = attachments ? { attachments } : {}
     const groupsPayload = resolved?.groups ? { groups: resolved.groups } : {}
 
     const comment =
         action === 'close'
             ? await client.threads.closeThread({
                   id: threadId,
-                  content: replyContent,
+                  content: messageContent,
                   recipients,
                   ...groupsPayload,
               } as Parameters<typeof client.threads.closeThread>[0])
             : action === 'reopen'
               ? await client.threads.reopenThread({
                     id: threadId,
-                    content: replyContent,
+                    content: messageContent,
                     recipients,
                     ...groupsPayload,
                 } as Parameters<typeof client.threads.reopenThread>[0])
               : await client.comments.createComment({
                     threadId,
-                    content: replyContent,
+                    content: messageContent,
                     recipients,
                     ...groupsPayload,
+                    ...attachmentsPayload,
                 } as Parameters<typeof client.comments.createComment>[0])
 
     if (options.json) {
@@ -110,4 +129,8 @@ export async function replyToThread(
 
     const suffix = actionLabel ? ` (thread ${actionLabel === 'close' ? 'closed' : 'reopened'})` : ''
     console.log(`Comment posted${suffix}: ${comment.url}`)
+    if (attachments && attachments.length > 0) {
+        const names = attachments.map((a) => a.fileName ?? 'file').join(', ')
+        console.log(chalk.dim(`Attached: ${names}`))
+    }
 }

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -1,6 +1,9 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { captureConsole, createTestProgram } from '@doist/cli-core/testing'
 import type { BatchResponse as TwistBatchResponse } from '@doist/twist-sdk'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const apiMocks = vi.hoisted(() => ({
     getTwistClient: vi.fn(),
@@ -138,9 +141,20 @@ function createClient({
                 if (options?.batch) return { kind: 'comment', id: _id }
                 return Promise.resolve(undefined)
             }),
-            createComment: vi.fn(async (_args: { threadId: number; content: string }) =>
-                createComment(12, 12),
+            createComment: vi.fn(
+                async (_args: {
+                    threadId: number
+                    content: string
+                    attachments?: Array<{ fileName?: string | null }>
+                }) => createComment(12, 12),
             ),
+        },
+        attachments: {
+            upload: vi.fn(async (args: { file: Blob; fileName: string }) => ({
+                attachmentId: `att-${args.fileName}`,
+                urlType: 'file',
+                fileName: args.fileName,
+            })),
         },
         channels: {
             getChannel: vi.fn((_id: number, options?: { batch?: boolean }) => {
@@ -1317,5 +1331,162 @@ describe('thread done', () => {
             program.parseAsync(['node', 'tw', 'thread', 'done', '500', '--dry-run']),
         ).rejects.toThrow('thread not found')
         expect(client.inbox.archiveThread).not.toHaveBeenCalled()
+    })
+})
+
+describe('thread reply --file', () => {
+    let tmpDir: string
+    let filePng: string
+    let filePdf: string
+
+    beforeAll(async () => {
+        tmpDir = await mkdtemp(join(tmpdir(), 'tw-reply-'))
+        filePng = join(tmpDir, 'diagram.png')
+        filePdf = join(tmpDir, 'report.pdf')
+        await writeFile(filePng, 'png-bytes')
+        await writeFile(filePdf, 'pdf-bytes')
+    })
+
+    afterAll(async () => {
+        await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('uploads the file and attaches it to the comment', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const consoleSpy = captureConsole()
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'reply',
+            '500',
+            'See attached',
+            '--file',
+            filePng,
+        ])
+
+        expect(client.attachments.upload).toHaveBeenCalledTimes(1)
+        expect(client.attachments.upload).toHaveBeenCalledWith(
+            expect.objectContaining({ fileName: 'diagram.png' }),
+        )
+        expect(client.comments.createComment).toHaveBeenCalledWith(
+            expect.objectContaining({
+                threadId: 500,
+                content: 'See attached',
+                attachments: [expect.objectContaining({ fileName: 'diagram.png' })],
+            }),
+        )
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Attached: diagram.png'))
+    })
+
+    it('attaches multiple repeated --file values', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'reply',
+            '500',
+            'two files',
+            '--file',
+            filePng,
+            '--file',
+            filePdf,
+        ])
+
+        expect(client.attachments.upload).toHaveBeenCalledTimes(2)
+        const args = client.comments.createComment.mock.calls[0][0] as {
+            attachments: Array<{ fileName?: string }>
+        }
+        expect(args.attachments.map((a) => a.fileName)).toEqual(['diagram.png', 'report.pdf'])
+    })
+
+    it('allows a file-only reply with no text content', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'tw', 'thread', 'reply', '500', '--file', filePng])
+
+        expect(client.comments.createComment).toHaveBeenCalledWith(
+            expect.objectContaining({ content: '', attachments: expect.any(Array) }),
+        )
+    })
+
+    it('errors with FILE_NOT_FOUND for a missing path and does not post', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await expect(
+            program.parseAsync([
+                'node',
+                'tw',
+                'thread',
+                'reply',
+                '500',
+                'x',
+                '--file',
+                join(tmpDir, 'missing.png'),
+            ]),
+        ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+        expect(client.comments.createComment).not.toHaveBeenCalled()
+    })
+
+    it('rejects --file combined with --close', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await expect(
+            program.parseAsync([
+                'node',
+                'tw',
+                'thread',
+                'reply',
+                '500',
+                'x',
+                '--close',
+                '--file',
+                filePng,
+            ]),
+        ).rejects.toMatchObject({ code: 'CONFLICTING_OPTIONS' })
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+    })
+
+    it('does not upload during --dry-run but lists the attachment', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const consoleSpy = captureConsole()
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'reply',
+            '500',
+            'preview',
+            '--file',
+            filePng,
+            '--dry-run',
+        ])
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+        expect(client.comments.createComment).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
     })
 })

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -100,8 +100,12 @@ function createClient({
             }),
             getUnread: vi.fn(async () => unreadThreads),
             createThread: vi.fn(
-                async (_args: { channelId: number; content: string; title?: string | null }) =>
-                    createThreadFixture(999),
+                async (_args: {
+                    channelId: number
+                    content: string
+                    title?: string | null
+                    attachments?: Array<{ fileName?: string | null }>
+                }) => createThreadFixture(999),
             ),
             closeThread: vi.fn(async (_args: { id: number; content: string }) =>
                 createComment(10, 10),
@@ -1489,6 +1493,134 @@ describe('thread reply --file', () => {
 
         expect(client.attachments.upload).not.toHaveBeenCalled()
         expect(client.comments.createComment).not.toHaveBeenCalled()
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
+    })
+})
+
+describe('thread create --file', () => {
+    let tmpDir: string
+    let filePng: string
+    let filePdf: string
+
+    beforeAll(async () => {
+        tmpDir = await mkdtemp(join(tmpdir(), 'tw-create-'))
+        filePng = join(tmpDir, 'cover.png')
+        filePdf = join(tmpDir, 'spec.pdf')
+        await writeFile(filePng, 'png-bytes')
+        await writeFile(filePdf, 'pdf-bytes')
+    })
+
+    afterAll(async () => {
+        await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('uploads files and attaches them to the new thread', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const consoleSpy = captureConsole()
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'create',
+            '100',
+            'Release notes',
+            'See attached',
+            '--file',
+            filePng,
+            '--file',
+            filePdf,
+        ])
+
+        expect(client.attachments.upload).toHaveBeenCalledTimes(2)
+        const args = client.threads.createThread.mock.calls[0][0] as {
+            title: string
+            content: string
+            attachments: Array<{ fileName?: string }>
+        }
+        expect(args.title).toBe('Release notes')
+        expect(args.content).toBe('See attached')
+        expect(args.attachments.map((a) => a.fileName)).toEqual(['cover.png', 'spec.pdf'])
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Attached: cover.png, spec.pdf'),
+        )
+    })
+
+    it('allows a file-only thread (title only, no body) without opening the editor', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'create',
+            '100',
+            'Title',
+            '--file',
+            filePng,
+        ])
+
+        const args = client.threads.createThread.mock.calls[0][0] as {
+            content: string
+            attachments: unknown[]
+        }
+        expect(args.content).toBe('')
+        expect(args.attachments).toHaveLength(1)
+        expect(openEditor).not.toHaveBeenCalled()
+    })
+
+    it('errors with FILE_NOT_FOUND for a missing path and does not create the thread', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const program = createProgram()
+        await expect(
+            program.parseAsync([
+                'node',
+                'tw',
+                'thread',
+                'create',
+                '100',
+                'Title',
+                'body',
+                '--file',
+                join(tmpDir, 'missing.png'),
+            ]),
+        ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+        expect(client.threads.createThread).not.toHaveBeenCalled()
+    })
+
+    it('does not upload during --dry-run but lists the attachment', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+        const consoleSpy = captureConsole()
+
+        const program = createProgram()
+        await program.parseAsync([
+            'node',
+            'tw',
+            'thread',
+            'create',
+            '100',
+            'Title',
+            'body',
+            '--file',
+            filePng,
+            '--dry-run',
+        ])
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+        expect(client.threads.createThread).not.toHaveBeenCalled()
         expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
     })
 })

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -215,6 +215,31 @@ function createClient({
 
 const createProgram = () => createTestProgram(registerThreadCommand)
 
+// Shared setup for the --file suites: a fresh mock client wired into getTwistClient
+// plus a program. Tests asserting on output call captureConsole() themselves.
+function setupFileTest() {
+    const client = createClient()
+    apiMocks.getTwistClient.mockResolvedValue(client)
+    return { client, program: createProgram() }
+}
+
+// Registers a temp dir with two files for a --file suite, cleaned up afterwards.
+// Returns getters so the paths are read lazily inside each test (after beforeAll).
+function useFileFixtures(prefix: string, png: string, pdf: string) {
+    const paths = { dir: '', png: '', pdf: '' }
+    beforeAll(async () => {
+        paths.dir = await mkdtemp(join(tmpdir(), prefix))
+        paths.png = join(paths.dir, png)
+        paths.pdf = join(paths.dir, pdf)
+        await writeFile(paths.png, 'png-bytes')
+        await writeFile(paths.pdf, 'pdf-bytes')
+    })
+    afterAll(async () => {
+        await rm(paths.dir, { recursive: true, force: true })
+    })
+    return paths
+}
+
 describe('thread implicit view', () => {
     beforeEach(() => {
         vi.clearAllMocks()
@@ -1339,32 +1364,16 @@ describe('thread done', () => {
 })
 
 describe('thread reply --file', () => {
-    let tmpDir: string
-    let filePng: string
-    let filePdf: string
-
-    beforeAll(async () => {
-        tmpDir = await mkdtemp(join(tmpdir(), 'tw-reply-'))
-        filePng = join(tmpDir, 'diagram.png')
-        filePdf = join(tmpDir, 'report.pdf')
-        await writeFile(filePng, 'png-bytes')
-        await writeFile(filePdf, 'pdf-bytes')
-    })
-
-    afterAll(async () => {
-        await rm(tmpDir, { recursive: true, force: true })
-    })
+    const files = useFileFixtures('tw-reply-', 'diagram.png', 'report.pdf')
 
     beforeEach(() => {
         vi.clearAllMocks()
     })
 
     it('uploads the file and attaches it to the comment', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
         const consoleSpy = captureConsole()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -1373,7 +1382,7 @@ describe('thread reply --file', () => {
             '500',
             'See attached',
             '--file',
-            filePng,
+            files.png,
         ])
 
         expect(client.attachments.upload).toHaveBeenCalledTimes(1)
@@ -1391,10 +1400,8 @@ describe('thread reply --file', () => {
     })
 
     it('attaches multiple repeated --file values', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -1403,9 +1410,9 @@ describe('thread reply --file', () => {
             '500',
             'two files',
             '--file',
-            filePng,
+            files.png,
             '--file',
-            filePdf,
+            files.pdf,
         ])
 
         expect(client.attachments.upload).toHaveBeenCalledTimes(2)
@@ -1416,11 +1423,9 @@ describe('thread reply --file', () => {
     })
 
     it('allows a file-only reply with no text content', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
-        await program.parseAsync(['node', 'tw', 'thread', 'reply', '500', '--file', filePng])
+        await program.parseAsync(['node', 'tw', 'thread', 'reply', '500', '--file', files.png])
 
         expect(client.comments.createComment).toHaveBeenCalledWith(
             expect.objectContaining({ content: '', attachments: expect.any(Array) }),
@@ -1430,10 +1435,8 @@ describe('thread reply --file', () => {
     })
 
     it('errors with FILE_NOT_FOUND for a missing path and does not post', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await expect(
             program.parseAsync([
                 'node',
@@ -1443,7 +1446,7 @@ describe('thread reply --file', () => {
                 '500',
                 'x',
                 '--file',
-                join(tmpDir, 'missing.png'),
+                join(files.dir, 'missing.png'),
             ]),
         ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
 
@@ -1452,10 +1455,8 @@ describe('thread reply --file', () => {
     })
 
     it('rejects --file combined with --close', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await expect(
             program.parseAsync([
                 'node',
@@ -1466,7 +1467,7 @@ describe('thread reply --file', () => {
                 'x',
                 '--close',
                 '--file',
-                filePng,
+                files.png,
             ]),
         ).rejects.toMatchObject({ code: 'CONFLICTING_OPTIONS' })
 
@@ -1474,11 +1475,9 @@ describe('thread reply --file', () => {
     })
 
     it('does not upload during --dry-run but lists the attachment', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
         const consoleSpy = captureConsole()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -1487,43 +1486,27 @@ describe('thread reply --file', () => {
             '500',
             'preview',
             '--file',
-            filePng,
+            files.png,
             '--dry-run',
         ])
 
         expect(client.attachments.upload).not.toHaveBeenCalled()
         expect(client.comments.createComment).not.toHaveBeenCalled()
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(files.png))
     })
 })
 
 describe('thread create --file', () => {
-    let tmpDir: string
-    let filePng: string
-    let filePdf: string
-
-    beforeAll(async () => {
-        tmpDir = await mkdtemp(join(tmpdir(), 'tw-create-'))
-        filePng = join(tmpDir, 'cover.png')
-        filePdf = join(tmpDir, 'spec.pdf')
-        await writeFile(filePng, 'png-bytes')
-        await writeFile(filePdf, 'pdf-bytes')
-    })
-
-    afterAll(async () => {
-        await rm(tmpDir, { recursive: true, force: true })
-    })
+    const files = useFileFixtures('tw-create-', 'cover.png', 'spec.pdf')
 
     beforeEach(() => {
         vi.clearAllMocks()
     })
 
     it('uploads files and attaches them to the new thread', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
         const consoleSpy = captureConsole()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -1533,9 +1516,9 @@ describe('thread create --file', () => {
             'Release notes',
             'See attached',
             '--file',
-            filePng,
+            files.png,
             '--file',
-            filePdf,
+            files.pdf,
         ])
 
         expect(client.attachments.upload).toHaveBeenCalledTimes(2)
@@ -1553,10 +1536,8 @@ describe('thread create --file', () => {
     })
 
     it('allows a file-only thread (title only, no body) without opening the editor', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -1565,7 +1546,7 @@ describe('thread create --file', () => {
             '100',
             'Title',
             '--file',
-            filePng,
+            files.png,
         ])
 
         const args = client.threads.createThread.mock.calls[0][0] as {
@@ -1578,10 +1559,8 @@ describe('thread create --file', () => {
     })
 
     it('errors with FILE_NOT_FOUND for a missing path and does not create the thread', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
 
-        const program = createProgram()
         await expect(
             program.parseAsync([
                 'node',
@@ -1592,7 +1571,7 @@ describe('thread create --file', () => {
                 'Title',
                 'body',
                 '--file',
-                join(tmpDir, 'missing.png'),
+                join(files.dir, 'missing.png'),
             ]),
         ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
 
@@ -1601,11 +1580,9 @@ describe('thread create --file', () => {
     })
 
     it('does not upload during --dry-run but lists the attachment', async () => {
-        const client = createClient()
-        apiMocks.getTwistClient.mockResolvedValue(client)
+        const { client, program } = setupFileTest()
         const consoleSpy = captureConsole()
 
-        const program = createProgram()
         await program.parseAsync([
             'node',
             'tw',
@@ -1615,12 +1592,12 @@ describe('thread create --file', () => {
             'Title',
             'body',
             '--file',
-            filePng,
+            files.png,
             '--dry-run',
         ])
 
         expect(client.attachments.upload).not.toHaveBeenCalled()
         expect(client.threads.createThread).not.toHaveBeenCalled()
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(filePng))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining(files.png))
     })
 })

--- a/src/commands/thread/thread.test.ts
+++ b/src/commands/thread/thread.test.ts
@@ -45,7 +45,7 @@ vi.mock('../../lib/input.js', () => ({
 
 vi.mock('chalk')
 
-import { readStdin } from '../../lib/input.js'
+import { openEditor, readStdin } from '../../lib/input.js'
 import { registerThreadCommand } from './index.js'
 
 function createThreadFixture(id: number) {
@@ -1421,6 +1421,8 @@ describe('thread reply --file', () => {
         expect(client.comments.createComment).toHaveBeenCalledWith(
             expect.objectContaining({ content: '', attachments: expect.any(Array) }),
         )
+        // A file-only reply must not block on the editor.
+        expect(openEditor).not.toHaveBeenCalled()
     })
 
     it('errors with FILE_NOT_FOUND for a missing path and does not post', async () => {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -5,11 +5,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const getWorkspaceUsersMock = vi.hoisted(() => vi.fn().mockResolvedValue([]))
 const sdkMocks = vi.hoisted(() => ({
     deleteChannel: vi.fn(),
+    uploadAttachment: vi.fn(),
 }))
 
 vi.mock('@doist/twist-sdk', () => {
     class TwistApi {
         channels = { deleteChannel: sdkMocks.deleteChannel }
+        attachments = { upload: sdkMocks.uploadAttachment }
         workspaceUsers = { getWorkspaceUsers: getWorkspaceUsersMock }
         constructor(_token?: string) {}
     }
@@ -110,6 +112,25 @@ describe('wrapResult — central 403 translation', () => {
         const client = createWrappedTwistClient('test-token')
 
         await expect(client.channels.deleteChannel(500)).rejects.toMatchObject({
+            code: 'INSUFFICIENT_SCOPE',
+            message: 'This action requires permissions your current token does not have.',
+            hints: ['Run `tw auth login` to re-authenticate with the required scopes'],
+        })
+    })
+
+    it('translates an attachments.upload scope 403 into INSUFFICIENT_SCOPE (re-login prompt)', async () => {
+        sdkMocks.uploadAttachment.mockRejectedValueOnce(
+            new TwistRequestError('Request failed with status 403', 403, {
+                error_string: 'Insufficient scope provided: attachments:write',
+            }),
+        )
+
+        const { createWrappedTwistClient } = await import('./api.js')
+        const client = createWrappedTwistClient('test-token')
+
+        await expect(
+            client.attachments.upload({ file: new Blob(['x']), fileName: 'x.png' }),
+        ).rejects.toMatchObject({
             code: 'INSUFFICIENT_SCOPE',
             message: 'This action requires permissions your current token does not have.',
             hints: ['Run `tw auth login` to re-authenticate with the required scopes'],

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -96,6 +96,9 @@ const API_SPINNER_MESSAGES: Record<string, { text: string; color?: 'blue' | 'gre
         'inbox.archiveThread': { text: 'Archiving thread...', color: 'yellow' },
         'inbox.unarchiveThread': { text: 'Unarchiving thread...', color: 'yellow' },
 
+        // Attachment operations
+        'attachments.upload': { text: 'Uploading file...', color: 'blue' },
+
         // Batch operations
         batch: { text: 'Processing batch operations...', color: 'blue' },
     }

--- a/src/lib/attachments.test.ts
+++ b/src/lib/attachments.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+    getTwistClient: vi.fn(),
+}))
+
+vi.mock('./api.js', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('./api.js')>()),
+    getTwistClient: apiMocks.getTwistClient,
+}))
+
+import { uploadAttachments } from './attachments.js'
+
+function createClient() {
+    return {
+        attachments: {
+            upload: vi.fn(async (args: { file: Blob; fileName: string }) => ({
+                attachmentId: `att-${args.fileName}`,
+                urlType: 'file',
+                fileName: args.fileName,
+            })),
+        },
+    }
+}
+
+describe('uploadAttachments', () => {
+    let tmpDir: string
+    let fileA: string
+    let fileB: string
+
+    beforeAll(async () => {
+        tmpDir = await mkdtemp(join(tmpdir(), 'tw-upload-'))
+        fileA = join(tmpDir, 'a.png')
+        fileB = join(tmpDir, 'b.pdf')
+        await writeFile(fileA, 'a-bytes')
+        await writeFile(fileB, 'b-bytes')
+    })
+
+    afterAll(async () => {
+        await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('uploads every file and preserves input order', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        const result = await uploadAttachments([fileA, fileB])
+
+        expect(client.attachments.upload).toHaveBeenCalledTimes(2)
+        expect(result.map((a) => a.fileName)).toEqual(['a.png', 'b.pdf'])
+    })
+
+    it('never uploads when any path is invalid (no partial uploads)', async () => {
+        const client = createClient()
+        apiMocks.getTwistClient.mockResolvedValue(client)
+
+        await expect(
+            uploadAttachments([fileA, join(tmpDir, 'missing.png'), fileB]),
+        ).rejects.toMatchObject({ code: 'FILE_NOT_FOUND' })
+
+        expect(client.attachments.upload).not.toHaveBeenCalled()
+    })
+})

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -4,8 +4,8 @@ import { openLocalFileAsBlob } from './local-file.js'
 
 /**
  * Upload one or more local files and return the created {@link Attachment}s,
- * ready to splice into the `attachments` array of `comments.createComment` or
- * `conversationMessages.createMessage`.
+ * ready to splice into the `attachments` array of `comments.createComment`,
+ * `conversationMessages.createMessage`, or `threads.createThread`.
  *
  * All paths are validated (existence + readability) up front, before any
  * upload starts, so a bad path fails fast without leaving a partial set of

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -4,23 +4,22 @@ import { openLocalFileAsBlob } from './local-file.js'
 
 /**
  * Upload one or more local files and return the created {@link Attachment}s,
- * ready to splice into the `attachments` array of `comments.createComment`,
- * `threads.createThread`, or `conversationMessages.createMessage`.
+ * ready to splice into the `attachments` array of `comments.createComment` or
+ * `conversationMessages.createMessage`.
  *
  * All paths are validated (existence + readability) up front, before any
  * upload starts, so a bad path fails fast without leaving a partial set of
- * uploaded-but-unreferenced attachments behind.
+ * uploaded-but-unreferenced attachments behind. Uploads then run concurrently
+ * while the returned array preserves the input order.
  */
 export async function uploadAttachments(files: string[]): Promise<Attachment[]> {
     // Validate every path first so a bad one fails before we upload anything.
     const opened = await Promise.all(files.map((file) => openLocalFileAsBlob({ file })))
 
     const client = await getTwistClient()
-    const attachments: Attachment[] = []
-    for (const { blob, fileName } of opened) {
-        attachments.push(await client.attachments.upload({ file: blob, fileName }))
-    }
-    return attachments
+    return Promise.all(
+        opened.map(({ blob, fileName }) => client.attachments.upload({ file: blob, fileName })),
+    )
 }
 
 export type { Attachment }

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,0 +1,26 @@
+import type { Attachment } from '@doist/twist-sdk'
+import { getTwistClient } from './api.js'
+import { openLocalFileAsBlob } from './local-file.js'
+
+/**
+ * Upload one or more local files and return the created {@link Attachment}s,
+ * ready to splice into the `attachments` array of `comments.createComment`,
+ * `threads.createThread`, or `conversationMessages.createMessage`.
+ *
+ * All paths are validated (existence + readability) up front, before any
+ * upload starts, so a bad path fails fast without leaving a partial set of
+ * uploaded-but-unreferenced attachments behind.
+ */
+export async function uploadAttachments(files: string[]): Promise<Attachment[]> {
+    // Validate every path first so a bad one fails before we upload anything.
+    const opened = await Promise.all(files.map((file) => openLocalFileAsBlob({ file })))
+
+    const client = await getTwistClient()
+    const attachments: Attachment[] = []
+    for (const { blob, fileName } of opened) {
+        attachments.push(await client.attachments.upload({ file: blob, fileName }))
+    }
+    return attachments
+}
+
+export type { Attachment }

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -44,7 +44,8 @@ export const READ_WRITE_SCOPES = [
     'groups:remove',
     'search:read',
     'notifications:read',
-    `attachments:write`,
+    'attachments:read',
+    'attachments:write',
 ]
 
 export const READ_ONLY_SCOPES = [
@@ -58,7 +59,7 @@ export const READ_ONLY_SCOPES = [
     'groups:read',
     'search:read',
     'notifications:read',
-    `attachments:read`,
+    'attachments:read',
 ]
 
 const AUTH_HINTS = ['Try again: tw auth login', 'Or set TWIST_API_TOKEN environment variable']

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -44,6 +44,7 @@ export const READ_WRITE_SCOPES = [
     'groups:remove',
     'search:read',
     'notifications:read',
+    `attachments:write`,
 ]
 
 export const READ_ONLY_SCOPES = [
@@ -57,6 +58,7 @@ export const READ_ONLY_SCOPES = [
     'groups:read',
     'search:read',
     'notifications:read',
+    `attachments:read`,
 ]
 
 const AUTH_HINTS = ['Try again: tw auth login', 'Or set TWIST_API_TOKEN environment variable']

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -49,6 +49,7 @@ export type ErrorCode =
     // State errors
     | 'ALREADY_INSTALLED'
     | 'BATCH_FAILED'
+    | 'FILE_NOT_FOUND'
     | 'FILE_READ_ERROR'
     | 'NOT_CREATOR'
     | 'NOT_INSTALLED'

--- a/src/lib/local-file.test.ts
+++ b/src/lib/local-file.test.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { openLocalFileAsBlob } from './local-file.js'
+
+describe('openLocalFileAsBlob', () => {
+    let tmpDir: string
+    let filePath: string
+
+    beforeAll(async () => {
+        tmpDir = await mkdtemp(join(tmpdir(), 'tw-localfile-'))
+        filePath = join(tmpDir, 'diagram.png')
+        await writeFile(filePath, 'hello-bytes')
+    })
+
+    afterAll(async () => {
+        await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    it('returns a file-backed Blob and the basename as fileName', async () => {
+        const { blob, fileName, filePath: resolved } = await openLocalFileAsBlob({ file: filePath })
+        expect(blob).toBeInstanceOf(Blob)
+        expect(await blob.text()).toBe('hello-bytes')
+        expect(fileName).toBe('diagram.png')
+        expect(resolved).toBe(filePath)
+    })
+
+    it('honours an explicit fileName override', async () => {
+        const { fileName } = await openLocalFileAsBlob({ file: filePath, fileName: 'renamed.png' })
+        expect(fileName).toBe('renamed.png')
+    })
+
+    it('throws FILE_NOT_FOUND for a missing path', async () => {
+        await expect(openLocalFileAsBlob({ file: join(tmpDir, 'nope.png') })).rejects.toMatchObject(
+            { code: 'FILE_NOT_FOUND' },
+        )
+    })
+})

--- a/src/lib/local-file.ts
+++ b/src/lib/local-file.ts
@@ -1,0 +1,51 @@
+import { openAsBlob } from 'node:fs'
+import { open } from 'node:fs/promises'
+import { basename, resolve } from 'node:path'
+import { CliError } from './errors.js'
+
+export interface LocalFileOptions {
+    /** Path to the file on disk (relative paths resolve against cwd). */
+    file: string
+    /** Optional override for the upload's user-facing filename. Defaults to `basename(file)`. */
+    fileName?: string
+}
+
+/**
+ * Open a local file as a streaming `Blob` for upload, with CLI-grade
+ * error reporting. The returned Blob is file-backed — undici reads it
+ * lazily when serializing the multipart request body, so the payload
+ * never has to fit in memory all at once.
+ *
+ * Returns the resolved absolute path and the effective `fileName`
+ * (caller's override, falling back to `basename(filePath)`) so call
+ * sites don't have to recompute either.
+ *
+ * Why `open` + `close` rather than `stat`: `stat` only proves the path
+ * exists; an unreadable file (chmod 000) would slip past and then
+ * fail later inside undici, where the error surfaces as a generic
+ * transport failure and renders as `INTERNAL_ERROR`. Opening for read
+ * and immediately closing verifies actual readability and keeps any
+ * fs failure (ENOENT / EACCES / EPERM / EISDIR / …) on the structured
+ * `CliError` path. Also disambiguates the opaque
+ * `ERR_INVALID_ARG_VALUE` TypeError that `openAsBlob` rewraps fs
+ * errors as.
+ */
+export async function openLocalFileAsBlob(
+    options: LocalFileOptions,
+): Promise<{ blob: Blob; filePath: string; fileName: string }> {
+    const filePath = resolve(options.file)
+    try {
+        const handle = await open(filePath, 'r')
+        await handle.close()
+        const blob = await openAsBlob(filePath)
+        return { blob, filePath, fileName: options.fileName || basename(filePath) }
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            throw new CliError('FILE_NOT_FOUND', `File not found: ${filePath}`, [
+                'Check the file path and try again.',
+            ])
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        throw new CliError('FILE_READ_ERROR', `Cannot read file: ${filePath}`, [message])
+    }
+}

--- a/src/lib/local-file.ts
+++ b/src/lib/local-file.ts
@@ -3,7 +3,7 @@ import { open } from 'node:fs/promises'
 import { basename, resolve } from 'node:path'
 import { CliError } from './errors.js'
 
-export interface LocalFileOptions {
+export type LocalFileOptions = {
     /** Path to the file on disk (relative paths resolve against cwd). */
     file: string
     /** Optional override for the upload's user-facing filename. Defaults to `basename(file)`. */

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -16,3 +16,11 @@ export type MutationOptions = {
     json?: boolean
     full?: boolean
 }
+
+/**
+ * Commander collector for repeatable options (e.g. `--file a --file b`).
+ * Use with a `[]` default: `.option('--file <path>', '…', collect, [])`.
+ */
+export function collect(value: string, previous: string[]): string[] {
+    return [...previous, value]
+}

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -95,6 +95,7 @@ tw thread create <channel-ref> "Title" "content" --notify 123,456  # Notify spec
 tw thread create <channel-ref> "Title" "content" --unarchive  # Land thread in author's Inbox (overrides default Twist auto-archive)
 tw thread create <channel-ref> "Title" "content" --no-unarchive  # Force archive even when userSettings.unarchiveNewThreads=true
 tw thread create <channel-ref> "Title" "content" --dry-run  # Preview without posting
+tw thread create <channel-ref> "Title" --file ./a.png  # Attach a file (repeatable; content optional)
 tw thread reply <ref> "content"  # Post a comment (notifies EVERYONE_IN_THREAD by default)
 tw thread reply <ref> "content" --notify EVERYONE  # Notify all workspace members
 tw thread reply <ref> "content" --notify 123,id:456   # Notify specific user IDs

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -102,6 +102,7 @@ tw thread reply <ref> "content" --json  # Post and return comment as JSON
 tw thread reply <ref> "content" --json --full  # Include all comment fields
 tw thread reply <ref> "content" --close       # Reply and close the thread
 tw thread reply <ref> "content" --reopen      # Reply and reopen a closed thread
+tw thread reply <ref> "content" --file ./a.png  # Attach a file (repeatable; content optional)
 tw thread done <ref>             # Archive thread (mark done)
 tw thread done <ref> --json      # Archive and return status as JSON
 tw thread mute <ref>             # Mute thread for 60 minutes (default)
@@ -155,6 +156,7 @@ tw conversation with <user-ref> --include-groups # List any conversations with t
 tw conversation reply <ref> "content"     # Send a message
 tw conversation reply <ref> "content" --json  # Send and return message as JSON
 tw conversation reply <ref> "content" --json --full  # Include all message fields
+tw conversation reply <ref> "content" --file ./a.png  # Attach a file (repeatable; content optional)
 tw conversation done <ref>                # Archive conversation
 tw conversation done <ref> --json         # Archive and return status as JSON
 tw conversation mute <ref>               # Mute conversation for 60 minutes (default)


### PR DESCRIPTION
## What

Adds file-attachment upload to `tw thread reply` and `tw conversation reply`, using the new `attachments` client added in `@doist/twist-sdk` [2.9.0](https://github.com/Doist/twist-sdk-typescript/pull/141).

```bash
tw thread reply 12345 "See attached" --file ./diagram.png
tw conversation reply 12345 "Photos" --file ./a.jpg --file ./b.jpg
tw thread reply 12345 --file ./report.pdf            # file-only, no text
```

## How

- **SDK bump** `@doist/twist-sdk` 2.8.1 → 2.9.0.
- **`src/lib/local-file.ts`** — `openLocalFileAsBlob` resolves a path, verifies readability, and returns a file-backed `Blob` (streamed, never fully buffered), with structured `FILE_NOT_FOUND` / `FILE_READ_ERROR`. Mirrors the helper in `todoist-cli`.
- **`src/lib/attachments.ts`** — `uploadAttachments(files)` validates **every** path before uploading any (a bad path fails fast, no orphaned uploads), then uploads each and returns the `Attachment[]` to splice into the create call.
- `--file` is **repeatable**; a **file-only** post with no text content is allowed.
- `--file` + `--close`/`--reopen` → `CONFLICTING_OPTIONS` (those arg shapes don't accept attachments).

## Auth / scopes (403 handling)

Uploading needs the new `attachments:write` scope. A token from before the scope change gets a 403. Because `attachments.upload` isn't in `KNOWN_SAFE_API_METHODS`, it's treated as mutating and routes through `wrapResult`, so the existing centralized translation kicks in: an "Insufficient scope" 403 becomes `INSUFFICIENT_SCOPE` with the `tw auth login` re-login prompt. Added an `attachments.upload` spinner entry to guarantee the wrap. Scope lists in `auth-provider.ts` now include `attachments:read` / `attachments:write`.

## Not included: `thread create`

Intentionally left out — the SDK's `CreateThreadArgs` has no `attachments` field and the schema is zod `$strip`, so unknown keys are dropped before the request. Supporting it needs an SDK change first.

## Verification

- `type-check`, full suite (**729 tests**, incl. new `local-file` unit tests, `--file` suites for both reply surfaces, and an `attachments.upload` 403 → `INSUFFICIENT_SCOPE` test), oxlint + oxfmt all pass.
- Verified end-to-end against the live API: uploaded a ~780KB JPEG via `tw conversation reply` — message posted with the attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)