### PR TITLE
fix(channels): Include unjoined public channels in public-channel allowlist

### DIFF
--- a/src/lib/public-channels.test.ts
+++ b/src/lib/public-channels.test.ts
@@ -14,16 +14,10 @@ import {
 
 const mockGetTwistClient = vi.mocked(getTwistClient)
 
-function makeMockChannels(
-    channels: Array<{ id: number; public: boolean }>,
-    publicChannels: Array<{ id: number }> = [],
-): ReturnType<typeof getTwistClient> {
+function makeMockPublicChannels(ids: number[]): ReturnType<typeof getTwistClient> {
     return Promise.resolve({
-        channels: {
-            getChannels: vi.fn().mockResolvedValue(channels),
-        },
         workspaces: {
-            getPublicChannels: vi.fn().mockResolvedValue(publicChannels),
+            getPublicChannels: vi.fn().mockResolvedValue(ids.map((id) => ({ id }))),
         },
     }) as unknown as ReturnType<typeof getTwistClient>
 }
@@ -85,57 +79,36 @@ describe('getPublicChannelIds', () => {
         clearPublicChannelCache()
     })
 
-    it('returns only public channel IDs', async () => {
-        mockGetTwistClient.mockImplementation(() =>
-            makeMockChannels([
-                { id: 1, public: true },
-                { id: 2, public: false },
-                { id: 3, public: true },
-            ]),
-        )
+    it('returns the public channel IDs from getPublicChannels', async () => {
+        // getPublicChannels is workspace-scoped and returns all public channels (active and
+        // archived, joined and unjoined), so every id it returns is part of the allowlist.
+        mockGetTwistClient.mockImplementation(() => makeMockPublicChannels([1, 3, 7, 8]))
 
         const ids = await getPublicChannelIds(100)
-        expect(ids).toEqual(new Set([1, 3]))
-    })
-
-    it('includes public channels the user has not joined', async () => {
-        // getChannels (membership-scoped) returns only id 1; getPublicChannels returns the full
-        // public set including unjoined channels 7 and 8.
-        mockGetTwistClient.mockImplementation(() =>
-            makeMockChannels([{ id: 1, public: true }], [{ id: 1 }, { id: 7 }, { id: 8 }]),
-        )
-
-        const ids = await getPublicChannelIds(100)
-        expect(ids).toEqual(new Set([1, 7, 8]))
+        expect(ids).toEqual(new Set([1, 3, 7, 8]))
     })
 
     it('caches results per workspace', async () => {
-        const getChannels = vi.fn().mockResolvedValue([{ id: 1, public: true }])
         const getPublicChannels = vi.fn().mockResolvedValue([])
         mockGetTwistClient.mockResolvedValue({
-            channels: { getChannels },
             workspaces: { getPublicChannels },
         } as unknown as Awaited<ReturnType<typeof getTwistClient>>)
 
         await getPublicChannelIds(100)
         await getPublicChannelIds(100)
 
-        expect(getChannels).toHaveBeenCalledTimes(1)
         expect(getPublicChannels).toHaveBeenCalledTimes(1)
     })
 
     it('fetches separately for different workspaces', async () => {
-        const getChannels = vi.fn().mockResolvedValue([{ id: 1, public: true }])
         const getPublicChannels = vi.fn().mockResolvedValue([])
         mockGetTwistClient.mockResolvedValue({
-            channels: { getChannels },
             workspaces: { getPublicChannels },
         } as unknown as Awaited<ReturnType<typeof getTwistClient>>)
 
         await getPublicChannelIds(100)
         await getPublicChannelIds(200)
 
-        expect(getChannels).toHaveBeenCalledTimes(2)
         expect(getPublicChannels).toHaveBeenCalledTimes(2)
     })
 })
@@ -161,26 +134,22 @@ describe('assertChannelIsPublic', () => {
         resetGlobalArgs()
     })
 
-    it('throws for private channels by default', async () => {
-        mockGetTwistClient.mockImplementation(() =>
-            makeMockChannels([
-                { id: 5, public: true },
-                { id: 6, public: false },
-            ]),
-        )
+    it('throws for channels absent from the public list by default', async () => {
+        // Channel 6 isn't in getPublicChannels, so it's treated as private.
+        mockGetTwistClient.mockImplementation(() => makeMockPublicChannels([5]))
 
         await expect(assertChannelIsPublic(6, 100)).rejects.toThrow('private channel')
     })
 
     it('allows public channels by default', async () => {
-        mockGetTwistClient.mockImplementation(() => makeMockChannels([{ id: 5, public: true }]))
+        mockGetTwistClient.mockImplementation(() => makeMockPublicChannels([5]))
 
         await expect(assertChannelIsPublic(5, 100)).resolves.toBeUndefined()
     })
 
     it('allows public channels the user has not joined', async () => {
-        // Channel 7 is public but not in the membership-scoped getChannels result.
-        mockGetTwistClient.mockImplementation(() => makeMockChannels([], [{ id: 7 }]))
+        // getPublicChannels returns unjoined-but-public channels, so channel 7 is allowed.
+        mockGetTwistClient.mockImplementation(() => makeMockPublicChannels([7]))
 
         await expect(assertChannelIsPublic(7, 100)).resolves.toBeUndefined()
     })

--- a/src/lib/public-channels.test.ts
+++ b/src/lib/public-channels.test.ts
@@ -16,10 +16,14 @@ const mockGetTwistClient = vi.mocked(getTwistClient)
 
 function makeMockChannels(
     channels: Array<{ id: number; public: boolean }>,
+    publicChannels: Array<{ id: number }> = [],
 ): ReturnType<typeof getTwistClient> {
     return Promise.resolve({
         channels: {
             getChannels: vi.fn().mockResolvedValue(channels),
+        },
+        workspaces: {
+            getPublicChannels: vi.fn().mockResolvedValue(publicChannels),
         },
     }) as unknown as ReturnType<typeof getTwistClient>
 }
@@ -94,28 +98,45 @@ describe('getPublicChannelIds', () => {
         expect(ids).toEqual(new Set([1, 3]))
     })
 
+    it('includes public channels the user has not joined', async () => {
+        // getChannels (membership-scoped) returns only id 1; getPublicChannels returns the full
+        // public set including unjoined channels 7 and 8.
+        mockGetTwistClient.mockImplementation(() =>
+            makeMockChannels([{ id: 1, public: true }], [{ id: 1 }, { id: 7 }, { id: 8 }]),
+        )
+
+        const ids = await getPublicChannelIds(100)
+        expect(ids).toEqual(new Set([1, 7, 8]))
+    })
+
     it('caches results per workspace', async () => {
         const getChannels = vi.fn().mockResolvedValue([{ id: 1, public: true }])
+        const getPublicChannels = vi.fn().mockResolvedValue([])
         mockGetTwistClient.mockResolvedValue({
             channels: { getChannels },
+            workspaces: { getPublicChannels },
         } as unknown as Awaited<ReturnType<typeof getTwistClient>>)
 
         await getPublicChannelIds(100)
         await getPublicChannelIds(100)
 
         expect(getChannels).toHaveBeenCalledTimes(1)
+        expect(getPublicChannels).toHaveBeenCalledTimes(1)
     })
 
     it('fetches separately for different workspaces', async () => {
         const getChannels = vi.fn().mockResolvedValue([{ id: 1, public: true }])
+        const getPublicChannels = vi.fn().mockResolvedValue([])
         mockGetTwistClient.mockResolvedValue({
             channels: { getChannels },
+            workspaces: { getPublicChannels },
         } as unknown as Awaited<ReturnType<typeof getTwistClient>>)
 
         await getPublicChannelIds(100)
         await getPublicChannelIds(200)
 
         expect(getChannels).toHaveBeenCalledTimes(2)
+        expect(getPublicChannels).toHaveBeenCalledTimes(2)
     })
 })
 
@@ -155,6 +176,13 @@ describe('assertChannelIsPublic', () => {
         mockGetTwistClient.mockImplementation(() => makeMockChannels([{ id: 5, public: true }]))
 
         await expect(assertChannelIsPublic(5, 100)).resolves.toBeUndefined()
+    })
+
+    it('allows public channels the user has not joined', async () => {
+        // Channel 7 is public but not in the membership-scoped getChannels result.
+        mockGetTwistClient.mockImplementation(() => makeMockChannels([], [{ id: 7 }]))
+
+        await expect(assertChannelIsPublic(7, 100)).resolves.toBeUndefined()
     })
 
     it('allows private channels when --include-private-channels is set', async () => {

--- a/src/lib/public-channels.ts
+++ b/src/lib/public-channels.ts
@@ -9,11 +9,6 @@ export async function getPublicChannelIds(workspaceId: number): Promise<Set<numb
     if (cached) return cached
 
     const client = await getTwistClient()
-    // getPublicChannels is workspace-scoped: it returns every public channel (active and
-    // archived, joined and unjoined). getChannels is membership-scoped, so building the
-    // allowlist from it alone wrongly excluded public channels the user hasn't joined — a
-    // thread in such a channel was rejected as private (#263). getPublicChannels is a complete
-    // superset of the public channels getChannels would surface, so it's the only call needed.
     const publicChannels = await client.workspaces.getPublicChannels(workspaceId)
     const publicIds = new Set(publicChannels.map((ch) => ch.id))
     publicChannelCache.set(workspaceId, publicIds)

--- a/src/lib/public-channels.ts
+++ b/src/lib/public-channels.ts
@@ -9,10 +9,21 @@ export async function getPublicChannelIds(workspaceId: number): Promise<Set<numb
     if (cached) return cached
 
     const client = await getTwistClient()
-    const channels = await client.channels.getChannels({ workspaceId })
+    // getChannels is membership-scoped — it returns only channels the current user has joined,
+    // so public channels the user hasn't joined are excluded. Merge with getPublicChannels
+    // (workspace-scoped, returns all public channels regardless of membership) so a thread in
+    // an unjoined-but-public channel isn't wrongly rejected as private. Mirrors resolveChannelRef
+    // in refs.ts.
+    const [joined, publicChannels] = await Promise.all([
+        client.channels.getChannels({ workspaceId }),
+        client.workspaces.getPublicChannels(workspaceId),
+    ])
     const publicIds = new Set<number>()
-    for (const ch of channels) {
+    for (const ch of joined) {
         if (ch.public) publicIds.add(ch.id)
+    }
+    for (const ch of publicChannels) {
+        publicIds.add(ch.id)
     }
     publicChannelCache.set(workspaceId, publicIds)
     return publicIds

--- a/src/lib/public-channels.ts
+++ b/src/lib/public-channels.ts
@@ -9,22 +9,13 @@ export async function getPublicChannelIds(workspaceId: number): Promise<Set<numb
     if (cached) return cached
 
     const client = await getTwistClient()
-    // getChannels is membership-scoped — it returns only channels the current user has joined,
-    // so public channels the user hasn't joined are excluded. Merge with getPublicChannels
-    // (workspace-scoped, returns all public channels regardless of membership) so a thread in
-    // an unjoined-but-public channel isn't wrongly rejected as private. Mirrors resolveChannelRef
-    // in refs.ts.
-    const [joined, publicChannels] = await Promise.all([
-        client.channels.getChannels({ workspaceId }),
-        client.workspaces.getPublicChannels(workspaceId),
-    ])
-    const publicIds = new Set<number>()
-    for (const ch of joined) {
-        if (ch.public) publicIds.add(ch.id)
-    }
-    for (const ch of publicChannels) {
-        publicIds.add(ch.id)
-    }
+    // getPublicChannels is workspace-scoped: it returns every public channel (active and
+    // archived, joined and unjoined). getChannels is membership-scoped, so building the
+    // allowlist from it alone wrongly excluded public channels the user hasn't joined — a
+    // thread in such a channel was rejected as private (#263). getPublicChannels is a complete
+    // superset of the public channels getChannels would surface, so it's the only call needed.
+    const publicChannels = await client.workspaces.getPublicChannels(workspaceId)
+    const publicIds = new Set(publicChannels.map((ch) => ch.id))
     publicChannelCache.set(workspaceId, publicIds)
     return publicIds
 }


### PR DESCRIPTION
## Overview

`getPublicChannelIds` built its allowlist from `getChannels` alone, which is membership-scoped and excludes public channels the user hasn't joined. This wrongly rejected threads in unjoined-but-public channels as private via assertChannelIsPublic, and left a latent masking bug in filterVisibleSearchResults.

Merge `getChannels` with `workspaces.getPublicChannels` and dedupe by id, mirroring the #249 fix in resolveChannelRef.

## Reference

- Fixes #263
- Similar to https://github.com/Doist/twist-cli/pull/249

## Test Plan

- `npm run build`
- Via the UI, visit an unjoined channel (i.e. I picked "z.Cooking" but you do you)
- Copy the link of any thread inside that unjoined channel
- Extract the threadId from the URL (it's the last id in the URL)
- `node dist/index.js thread view id:<threadId>`
- [ ] Verify that the thread renders normally (instead of `NOT_FOUND: This thread belongs to a private channel`)