### PR TITLE
chore: group oxlint and oxfmt renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>doist/renovate-config:frontend-base"]
+    "extends": ["github>doist/renovate-config:frontend-base"],
+    "packageRules": [
+        {
+            "matchPackageNames": ["oxlint", "oxfmt"],
+            "groupName": "ox toolchain",
+            "description": "Group oxlint and oxfmt updates into a single PR"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- Add a renovate `packageRule` grouping `oxlint` and `oxfmt` updates into a single PR, so the ox toolchain bumps together.

Mirrors Doist/automations#3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)