### PR TITLE
chore(deps): bump @doist/twist-sdk to 2.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "license": "MIT",
             "dependencies": {
                 "@doist/cli-core": "0.24.0",
-                "@doist/twist-sdk": "2.9.1",
+                "@doist/twist-sdk": "2.9.2",
                 "@pnpm/tabtab": "0.5.4",
                 "chalk": "5.6.2",
                 "commander": "14.0.3",
@@ -182,14 +182,14 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.9.1.tgz",
-            "integrity": "sha512-M5ZobkiqGwZ/EneJjxyIDTiBgENW5KZT7zLoDFrPM+68nqJXUiUqPY8Af35+72FYPhIUvlc38v2vm43UQdQdaw==",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.9.2.tgz",
+            "integrity": "sha512-O+ikOSUvpLXRO5QPQO9U5EepxDe1JEL172wV0RmdAnHZ55O7Ku0NncqwFKouZ5QJ4puI7d4tsEmStqz1ji4gdA==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",
                 "ts-custom-error": "^3.2.0",
-                "undici": "^7.16.0",
+                "undici": "7.24.8",
                 "uuid": "^11.1.0",
                 "zod": "4.1.12"
             },
@@ -10178,9 +10178,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-            "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ],
     "dependencies": {
         "@doist/cli-core": "0.24.0",
-        "@doist/twist-sdk": "2.9.1",
+        "@doist/twist-sdk": "2.9.2",
         "@pnpm/tabtab": "0.5.4",
         "chalk": "5.6.2",
         "commander": "14.0.3",


### PR DESCRIPTION
## Summary
- Bump `@doist/twist-sdk` from 2.9.1 to 2.9.2, which pins `undici` to 7.24.8.

This pulls the pinned undici transitively into the CLI, avoiding the Node 26 regression seen with undici 7.27.1 in the decompression dispatcher path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)